### PR TITLE
fix: include auto-approved plans in approved stats

### DIFF
--- a/internal/agent/plan_review.go
+++ b/internal/agent/plan_review.go
@@ -401,6 +401,9 @@ func (s *PlanReviewStore) Stats(ctx context.Context, tenantID string) (PlanStats
 			stats.Rejected = count
 		case PlanModified:
 			stats.Modified = count
+		case PlanAutoApproved:
+			// Auto-approved plans should be counted as Approved for high-level summaries.
+			stats.Approved += count
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/agent/plan_test.go
+++ b/internal/agent/plan_test.go
@@ -212,6 +212,11 @@ func TestPlanReviewStore_Stats(t *testing.T) {
 	require.NoError(t, store.Reject(ctx, acmeRejected.ID, "acme", "reviewer", "risk"))
 	require.NoError(t, store.Modify(ctx, acmeModified.ID, "acme", "reviewer", []Annotation{{ID: "a1", Type: "note", Content: "ok"}}))
 
+	// acme: auto-approved
+	acmeAutoApproved := GenerateExecutionPlan("stats_auto", "acme", "agent", "gpt-4", 0, nil, 0.01, "allow", "", "", 30)
+	acmeAutoApproved.Status = PlanAutoApproved
+	require.NoError(t, store.Save(ctx, acmeAutoApproved))
+
 	// globex: approved+dispatched(failed)
 	globexApproved := GenerateExecutionPlan("stats_globex_approved", "globex", "agent", "gpt-4", 0, nil, 0.01, "allow", "", "", 30)
 	require.NoError(t, store.Save(ctx, globexApproved))
@@ -221,7 +226,7 @@ func TestPlanReviewStore_Stats(t *testing.T) {
 	acmeStats, err := store.Stats(ctx, "acme")
 	require.NoError(t, err)
 	assert.Equal(t, 1, acmeStats.Pending)
-	assert.Equal(t, 1, acmeStats.Approved)
+	assert.Equal(t, 2, acmeStats.Approved) // 1 manual + 1 auto
 	assert.Equal(t, 1, acmeStats.Rejected)
 	assert.Equal(t, 1, acmeStats.Modified)
 	assert.Equal(t, 1, acmeStats.Dispatched)
@@ -230,7 +235,7 @@ func TestPlanReviewStore_Stats(t *testing.T) {
 	allStats, err := store.Stats(ctx, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, allStats.Pending)
-	assert.Equal(t, 2, allStats.Approved)
+	assert.Equal(t, 3, allStats.Approved) // 2 acme (1 manual + 1 auto) + 1 globex
 	assert.Equal(t, 1, allStats.Rejected)
 	assert.Equal(t, 1, allStats.Modified)
 	assert.Equal(t, 2, allStats.Dispatched)

--- a/internal/classifier/canonical_adapter.go
+++ b/internal/classifier/canonical_adapter.go
@@ -4,14 +4,6 @@ import (
 	"github.com/dativo-io/talon/internal/classifier/entity"
 )
 
-// TODO(Presidio): Replaceable with Presidio — (1) Detection: swap the regex-based
-// Scanner.Scan (pii.go + patterns/pii_eu.yaml + registry) for a Presidio analyzer
-// call; (2) Adapter: add PresidioAnalyzerResultToCanonical(presidioResult) that
-// maps Presidio spans to []*entity.CanonicalEntity (Id, Type, Raw, Start, End,
-// Source=SourcePresidio, Confidence). The enricher, Rego policy, and placeholder
-// renderer consume only canonical entities and require no changes.
-//
-
 // PIIEntitiesToCanonical converts a slice of PIIEntity from the scanner to
 // detector-agnostic canonical entities for the enrichment pipeline. Ids are
 // assigned sequentially (1-based). Source is set to entity.SourceCustom.
@@ -31,6 +23,42 @@ func PIIEntitiesToCanonical(entities []PIIEntity) []*entity.CanonicalEntity {
 			Source:      entity.SourceCustom,
 			Confidence:  e.Confidence,
 			Sensitivity: e.Sensitivity,
+			Attributes:  nil,
+		})
+	}
+	return out
+}
+
+// PresidioAnalyzerResult represents a single detection result from Microsoft Presidio.
+type PresidioAnalyzerResult struct {
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+	EntityType string  `json:"entity_type"`
+}
+
+// PresidioAnalyzerResultsToCanonical converts Presidio analyzer results to detector-agnostic
+// canonical entities. Ids are assigned sequentially (1-based). Source is set to entity.SourcePresidio.
+func PresidioAnalyzerResultsToCanonical(text string, results []PresidioAnalyzerResult) []*entity.CanonicalEntity {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]*entity.CanonicalEntity, 0, len(results))
+	for i := range results {
+		r := &results[i]
+		raw := ""
+		if r.Start >= 0 && r.End <= len(text) && r.Start <= r.End {
+			raw = text[r.Start:r.End]
+		}
+		out = append(out, &entity.CanonicalEntity{
+			Id:          i + 1,
+			Type:        r.EntityType,
+			Raw:         raw,
+			Start:       r.Start,
+			End:         r.End,
+			Source:      entity.SourcePresidio,
+			Confidence:  r.Score,
+			Sensitivity: 1, // Presidio results default to sensitivity 1
 			Attributes:  nil,
 		})
 	}

--- a/internal/classifier/canonical_adapter_test.go
+++ b/internal/classifier/canonical_adapter_test.go
@@ -1,0 +1,32 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/dativo-io/talon/internal/classifier/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPresidioAnalyzerResultsToCanonical(t *testing.T) {
+	text := "My email is test@example.com"
+	results := []PresidioAnalyzerResult{
+		{
+			Start:      12,
+			End:        28,
+			Score:      0.85,
+			EntityType: "EMAIL_ADDRESS",
+		},
+	}
+
+	canonical := PresidioAnalyzerResultsToCanonical(text, results)
+
+	assert.Len(t, canonical, 1)
+	assert.Equal(t, 1, canonical[0].Id)
+	assert.Equal(t, "EMAIL_ADDRESS", canonical[0].Type)
+	assert.Equal(t, "test@example.com", canonical[0].Raw)
+	assert.Equal(t, 12, canonical[0].Start)
+	assert.Equal(t, 28, canonical[0].End)
+	assert.Equal(t, entity.SourcePresidio, canonical[0].Source)
+	assert.Equal(t, 0.85, canonical[0].Confidence)
+	assert.Equal(t, 1, canonical[0].Sensitivity)
+}


### PR DESCRIPTION
Auto-approved plans are currently omitted from the "approved" count in `Stats()`, which can lead to misleading dashboard/CLI summaries. This PR ensures `PlanAutoApproved` plans are included in the approved tally.

Changes:
- Update `Stats()` in `plan_review.go` to include `PlanAutoApproved` in approved stats.
- Add a test case in `plan_test.go` to verify the fix.