### PR TITLE
fix(readme): render badges as images and remove Trust Signals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,12 @@ Talon is a single Go binary in front of OpenAI, Anthropic, and Bedrock. Point yo
 
 
 
-[CI](https://github.com/dativo-io/talon/actions/workflows/ci.yml)
-[CodeQL](https://github.com/dativo-io/talon/actions/workflows/codeql.yml)
-[Release](https://github.com/dativo-io/talon/actions/workflows/release.yml)
-[Latest Release](https://github.com/dativo-io/talon/releases/latest)
-[Go Report Card](https://goreportcard.com/report/github.com/dativo-io/talon)
-[License](LICENSE)
-
-### Trust Signals
-
-- Release cadence: [23 tagged releases](https://github.com/dativo-io/talon/releases) (latest: `v1.3.0`, 2026-03-18)
-- Supply-chain: [CodeQL](https://github.com/dativo-io/talon/actions/workflows/codeql.yml) + [security workflow](https://github.com/dativo-io/talon/actions/workflows/security.yml) + [GoReleaser](.goreleaser.yml)
-- Verifiable evidence: `talon audit verify <evidence-id>`
-- Social preview asset: [`web/social-preview.svg`](web/social-preview.svg) (set in repo settings as Open Graph image)
+[![CI](https://github.com/dativo-io/talon/actions/workflows/ci.yml/badge.svg)](https://github.com/dativo-io/talon/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/dativo-io/talon/actions/workflows/codeql.yml/badge.svg)](https://github.com/dativo-io/talon/actions/workflows/codeql.yml)
+[![Release](https://github.com/dativo-io/talon/actions/workflows/release.yml/badge.svg)](https://github.com/dativo-io/talon/actions/workflows/release.yml)
+[![Latest Release](https://img.shields.io/github/v/release/dativo-io/talon)](https://github.com/dativo-io/talon/releases/latest)
+[![Go Report Card](https://goreportcard.com/badge/github.com/dativo-io/talon)](https://goreportcard.com/report/github.com/dativo-io/talon)
+[![License](https://img.shields.io/github/license/dativo-io/talon)](LICENSE)
 
 ### Install Options (pick one)
 


### PR DESCRIPTION
## Summary
- Fixed badges rendering as plain-text links instead of shield images (used GitHub Actions `/badge.svg` URLs + shields.io for version/license)
- Removed the "Trust Signals" section which duplicated badge information

## Test plan
- [ ] Verify badges render correctly on the GitHub repo page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates README badges/links; no runtime, security, or data-handling logic is affected.
> 
> **Overview**
> Updates `README.md` to replace plain-text workflow/release/license links with rendered badge images (GitHub Actions `badge.svg` + shields.io for release/license).
> 
> Removes the **Trust Signals** section that duplicated this information, leaving the badges as the primary quick-glance indicators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80640205dd0dd84088eabc8d70c1bf76f1ae8a36. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->