### PR TITLE
chore(release): prepare v1.4.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+## [1.4.6] - 2026-04-14
+
+### Added
+
+- **feat(explanation): deterministic explanation normalization.** Added canonical normalization for deterministic policy explanation tokens so equivalent outcomes converge to stable, reusable phrasing across runs and audit surfaces. This helps operators compare evidence reliably and reduces explanation drift in dashboards and tests. Verify quickly with `go test ./internal/explanation/...`.
+
+### Fixed
+
+- **fix(explanation): stage taxonomy and token collapse consistency.** Aligned explanation stage taxonomy (including MCP PII semantics) and fixed edge cases where fully-collapsed tokens were not returned as a single deduplicated canonical token. This improves consistency between policy decisions and rendered explanations.
+
+- **fix(gateway): canonical explanation stage propagation.** Gateway explanation output now uses the canonical explanation stage instead of pipeline-stage values, preventing mismatched stage labels in downstream evidence and UI surfaces.
+
+- **fix(graphadapter): preserve graph evidence identity fields.** Graph adapter run evidence now retains session and model fields on graph execution paths, improving traceability for stateful graph runs and downstream audit analysis.
+
+### Docs
+
+- **docs(quickstart): add verification snippet.** Quickstart now includes an explicit verification snippet so operators can validate a governed setup immediately after onboarding with less ambiguity.
+
 ## [1.4.5] - 2026-04-12
 
 ### Added
@@ -427,7 +445,8 @@ For user-facing entries, include:
 - EU AI Act: risk management, transparency, human oversight (Art. 9, 13, 14).
 - Data residency: tier-based EU model routing.
 
-[Unreleased]: https://github.com/dativo-io/talon/compare/v1.4.5...HEAD
+[Unreleased]: https://github.com/dativo-io/talon/compare/v1.4.6...HEAD
+[1.4.6]: https://github.com/dativo-io/talon/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/dativo-io/talon/compare/v1.4.0...v1.4.5
 [1.4.0]: https://github.com/dativo-io/talon/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/dativo-io/talon/compare/v1.2.0...v1.3.0


### PR DESCRIPTION
## Summary
- add the v1.4.6 release section to CHANGELOG with commits since v1.4.5
- update compare links so Unreleased now starts after v1.4.6
- keep release prep isolated to changelog-only changes

## Test plan
- [x] Verify CHANGELOG includes `## [1.4.6] - 2026-04-14`
- [x] Verify links include `[1.4.6]: .../compare/v1.4.5...v1.4.6`
- [x] Confirm diff from `origin/main` only touches `CHANGELOG.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only update; no production code or configuration changes, so regression risk is minimal beyond documentation accuracy.
> 
> **Overview**
> Adds a new `## [1.4.6] - 2026-04-14` release section to `CHANGELOG.md`, documenting explanation determinism/normalization improvements, fixes around explanation stage propagation and graph evidence identity fields, and a quickstart verification snippet.
> 
> Updates the compare links so `[Unreleased]` now starts from `v1.4.6` and adds the new `[1.4.6]` tag comparison link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdd9f14b3a26f2775c0d64b8bdb717a8703ee0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->