### PR TITLE
fix(release): handle duplicate GitHub release assets on rerun

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,3 +95,7 @@ release:
     name: talon
   draft: false
   prerelease: auto
+  # Re-run safe: if assets already exist on this tag's release, delete and retry upload.
+  replace_existing_artifacts: true
+  # Keep release notes aligned with the latest run output.
+  mode: replace


### PR DESCRIPTION
## Summary
- configure GoReleaser to replace existing release assets when an upload hits 422 duplicate-name errors
- set release notes mode to replace so reruns keep release body aligned with latest output

## Why
- rerunning a tag release currently fails when assets like `checksums.txt` already exist on the same GitHub release

## Test plan
- [x] Verify `.goreleaser.yml` contains `release.replace_existing_artifacts: true`
- [x] Verify `.goreleaser.yml` contains `release.mode: replace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change limited to release publishing behavior; primary risk is unintentionally overwriting existing release assets/notes on reruns.
> 
> **Overview**
> Makes GoReleaser tag-release reruns idempotent by enabling `release.replace_existing_artifacts`, so duplicate-name GitHub assets are deleted and re-uploaded.
> 
> Sets `release.mode: replace` to overwrite the release body on reruns, keeping release notes aligned with the latest generated output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1595f08dd0f6d6daf2aed931757aca0606b443b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->