### PR TITLE
feat(gateway): add OpenAI proxy quickstart mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **change(server): dev-mode route relocation under quickstart.** When `--proxy-quickstart` is enabled, host-root OpenAI-compatible paths are handled by the quickstart facade and tenant agent chat remains available at `POST /v1/agents/chat/completions`.
+- **change(serve): quickstart no longer registers a synthetic tenant key.** Quickstart mode is strictly a host-root OpenAI-compatibility facade; it will not silently unlock tenant APIs. Relocated tenant endpoints require a real tenant key configured by the operator and otherwise return `401 Unauthorized`.
+- **change(serve): `--gateway-config` exclusivity check uses explicit flag set.** `--proxy-quickstart` is rejected alongside `--gateway` or any explicitly passed `--gateway-config`, detected via `cobra.Flags().Changed` rather than the default string value.
+- **change(gateway): quickstart `unsafe-listen` signal threaded via config.** The `quickstart_unsafe_listen` evidence annotation is driven by `GatewayConfig.QuickstartUnsafeListen`, populated from `--unsafe-listen` through `QuickstartOptions`, instead of a process environment variable.
 
 ### Release Note Quality Bar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **change(server): dev-mode route relocation under quickstart.** When `--proxy-quickstart` is enabled, host-root OpenAI-compatible paths are handled by the quickstart facade and tenant agent chat remains available at `POST /v1/agents/chat/completions`.
-- **change(serve): quickstart no longer registers a synthetic tenant key.** Quickstart mode is strictly a host-root OpenAI-compatibility facade; it will not silently unlock tenant APIs. Relocated tenant endpoints require a real tenant key configured by the operator and otherwise return `401 Unauthorized`.
+- **change(server): dev-mode route relocation under quickstart.** When `--proxy-quickstart` is enabled, host-root OpenAI-compatible paths are handled by the quickstart facade. Tenant agent chat is available at `POST /v1/agents/chat/completions` only when the operator has configured real tenant keys; in default quickstart (no tenant keys), that route is not mounted and returns `404 Not Found` to preserve a strict facade-only boundary.
+- **change(serve): quickstart no longer registers a synthetic tenant key.** Quickstart mode is strictly a host-root OpenAI-compatibility facade; it will not silently unlock tenant APIs. When tenant keys are configured, the relocated tenant endpoint sits behind standard tenant-auth middleware and returns `401 Unauthorized` without a valid key.
 - **change(serve): `--gateway-config` exclusivity check uses explicit flag set.** `--proxy-quickstart` is rejected alongside `--gateway` or any explicitly passed `--gateway-config`, detected via `cobra.Flags().Changed` rather than the default string value.
 - **change(gateway): quickstart `unsafe-listen` signal threaded via config.** The `quickstart_unsafe_listen` evidence annotation is driven by `GatewayConfig.QuickstartUnsafeListen`, populated from `--unsafe-listen` through `QuickstartOptions`, instead of a process environment variable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **feat(serve): OpenAI-compatible quickstart proxy mode.** Added `talon serve --proxy-quickstart` for dev/local host-root compatibility (`POST /v1/chat/completions`, `POST /v1/responses`) without gateway YAML, while keeping policy, PII redaction, and evidence active.
+- **feat(gateway): upstream auth mode support for quickstart.** Added provider `upstream_auth_mode` (`secret` default, `client_bearer` quickstart path) with client bearer forwarding, `OPENAI_API_KEY` fallback, and explicit 401 when no upstream key is available.
+- **feat(evidence): quickstart upstream auth metadata.** Evidence records now include additive fields `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and `gateway_annotations` (backward compatible with existing records).
+
+### Changed
+
+- **change(server): dev-mode route relocation under quickstart.** When `--proxy-quickstart` is enabled, host-root OpenAI-compatible paths are handled by the quickstart facade and tenant agent chat remains available at `POST /v1/agents/chat/completions`.
+
 ### Release Note Quality Bar
 
 For user-facing entries, include:

--- a/README.md
+++ b/README.md
@@ -301,7 +301,22 @@ talon serve --port 8080 --proxy-config examples/vendor-proxy/zendesk-proxy.talon
 
 # With LLM API gateway (proxy mode: route OpenAI/Anthropic/Ollama traffic through Talon)
 talon serve --port 8080 --gateway --gateway-config examples/gateway/talon.config.gateway.yaml
+
+# Dev/local OpenAI-compatible quickstart (no gateway YAML)
+talon serve --proxy-quickstart --port 8080
+# Then point your SDK to OPENAI_BASE_URL=http://127.0.0.1:8080/v1
 ```
+
+### Quickstart for existing OpenAI apps
+
+`--proxy-quickstart` is a dev-mode compatibility surface for existing OpenAI SDK apps:
+
+- Supported host-root endpoints: `POST /v1/chat/completions`, `POST /v1/responses`.
+- Upstream auth precedence: client bearer token, then `OPENAI_API_KEY`, then `401`.
+- Governance remains active (policy, PII scan/redaction, evidence) with `enforce` default.
+
+Use loopback by default; non-loopback binds require `--unsafe-listen`.
+For production gateway behavior, keep using `--gateway` + `talon.config.yaml`.
 
 Endpoints include: `GET /v1/health`, `GET /v1/status`, `POST /v1/agents/run`, `POST /v1/chat/completions` (OpenAI-compatible), `GET /v1/evidence`, `GET /v1/costs`, `GET /v1/plans/pending` (plan review), `POST /mcp` (native MCP), `POST /mcp/proxy` (when proxy is configured), `**POST /v1/proxy/{provider}/v1/chat/completions**` (LLM API gateway when `--gateway` is set; caller auth via `Authorization: Bearer <tenant-key>`), and operational control plane endpoints: `GET /v1/runs`, `POST /v1/runs/{id}/kill`, `POST /v1/runs/{id}/pause`, `POST /v1/runs/{id}/resume`, `GET /v1/overrides`, `POST /v1/overrides/{tenant_id}/lockdown`, `GET /v1/tool-approvals`, `POST /v1/tool-approvals/{id}/decide`. Tenant-scoped API routes use `Authorization: Bearer <tenant-key>`. Admin-only routes (including all `/v1/runs`, `/v1/overrides`, and `/v1/tool-approvals` endpoints) use `X-Talon-Admin-Key: <key>` (or bearer fallback).
 

--- a/docs/ADOPTION_SCENARIOS.md
+++ b/docs/ADOPTION_SCENARIOS.md
@@ -13,6 +13,8 @@ Companies adopt Talon in three ways:
 
 **Existing app (Slack bot, desktop app, script) that already calls OpenAI/Anthropic/Ollama?** Route traffic through Talon's **LLM API Gateway** (proxy mode) with no code change beyond base URL and a caller API key. See [Slack bot integration](guides/slack-bot-integration.md), [Desktop app governance](guides/desktop-app-governance.md), and [OpenClaw integration](guides/openclaw-integration.md).
 
+For local developer loops, use `talon serve --proxy-quickstart` to get host-root OpenAI-compatible endpoints first, then graduate to full gateway config.
+
 This guide shows realistic timelines, effort, and ROI for each path.
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,6 +9,9 @@ This page points you to the right doc for what you want to do.
 **1.** I have an existing app that calls OpenAI or Anthropic.  
 → [Add Talon to your existing app](guides/add-talon-to-existing-app.md)
 
+**1a.** I want the fastest OpenAI-compatible local drop-in (no gateway YAML).  
+→ [OpenAI proxy quickstart](tutorials/proxy-quickstart.md)
+
 **2.** I'm building something new and want controls from day one.  
 → [Your first agent with Talon](tutorials/first-governed-agent.md)
 

--- a/docs/adr/0001-openai-proxy-quickstart.md
+++ b/docs/adr/0001-openai-proxy-quickstart.md
@@ -15,10 +15,11 @@ Add `talon serve --proxy-quickstart` as a dev/local mode with these constraints:
 - Host-root compatibility for `POST /v1/chat/completions` and `POST /v1/responses` only.
 - Reuse the existing gateway pipeline (PII, policy, cost controls, evidence).
 - Use a synthetic caller (`quickstart-local`) and tenant (`quickstart`) injected by an in-process facade.
+- Do **not** register any synthetic tenant key; quickstart is strictly a host-root facade and must not unlock Talon's tenant-auth surface by side effect. Tenant endpoints (including the relocated `/v1/agents/chat/completions`) still require a real tenant key configured by the operator.
 - Default to `enforce` mode and `redact` PII action.
 - Use upstream BYOK (`client_bearer`) with env fallback (`OPENAI_API_KEY`) and fail with 401 when absent.
-- Require loopback binds by default; non-loopback requires `--unsafe-listen`.
-- Keep mode mutually exclusive with `--gateway` / `--gateway-config`.
+- Require loopback binds by default; non-loopback requires `--unsafe-listen`. The `--unsafe-listen` signal is threaded explicitly into the quickstart `GatewayConfig` (field `QuickstartUnsafeListen`) rather than set as a process env var, so evidence annotations remain deterministic and do not depend on ambient environment state.
+- Keep mode mutually exclusive with `--gateway` / `--gateway-config`. The exclusivity check uses `cobra.Flags().Changed("gateway-config")` so it depends on whether the operator explicitly passed the flag, not on the default string value.
 
 ## Consequences
 

--- a/docs/adr/0001-openai-proxy-quickstart.md
+++ b/docs/adr/0001-openai-proxy-quickstart.md
@@ -15,7 +15,7 @@ Add `talon serve --proxy-quickstart` as a dev/local mode with these constraints:
 - Host-root compatibility for `POST /v1/chat/completions` and `POST /v1/responses` only.
 - Reuse the existing gateway pipeline (PII, policy, cost controls, evidence).
 - Use a synthetic caller (`quickstart-local`) and tenant (`quickstart`) injected by an in-process facade.
-- Do **not** register any synthetic tenant key; quickstart is strictly a host-root facade and must not unlock Talon's tenant-auth surface by side effect. Tenant endpoints (including the relocated `/v1/agents/chat/completions`) still require a real tenant key configured by the operator.
+- Do **not** register any synthetic tenant key; quickstart is strictly a host-root facade and must not unlock Talon's tenant-auth surface by side effect. The relocated `POST /v1/agents/chat/completions` route is conditionally mounted: it is registered only when the operator has configured real tenant keys, and sits behind standard tenant-auth middleware. In default quickstart (no tenant keys), the route is not mounted at all and returns `404 Not Found`.
 - Default to `enforce` mode and `redact` PII action.
 - Use upstream BYOK (`client_bearer`) with env fallback (`OPENAI_API_KEY`) and fail with 401 when absent.
 - Require loopback binds by default; non-loopback requires `--unsafe-listen`. The `--unsafe-listen` signal is threaded explicitly into the quickstart `GatewayConfig` (field `QuickstartUnsafeListen`) rather than set as a process env var, so evidence annotations remain deterministic and do not depend on ambient environment state.

--- a/docs/adr/0001-openai-proxy-quickstart.md
+++ b/docs/adr/0001-openai-proxy-quickstart.md
@@ -1,0 +1,35 @@
+# ADR 0001: OpenAI-compatible proxy quickstart
+
+## Status
+
+Accepted.
+
+## Context
+
+Many teams already have OpenAI SDK integrations and want to evaluate Talon governance quickly without writing gateway config first.
+
+## Decision
+
+Add `talon serve --proxy-quickstart` as a dev/local mode with these constraints:
+
+- Host-root compatibility for `POST /v1/chat/completions` and `POST /v1/responses` only.
+- Reuse the existing gateway pipeline (PII, policy, cost controls, evidence).
+- Use a synthetic caller (`quickstart-local`) and tenant (`quickstart`) injected by an in-process facade.
+- Default to `enforce` mode and `redact` PII action.
+- Use upstream BYOK (`client_bearer`) with env fallback (`OPENAI_API_KEY`) and fail with 401 when absent.
+- Require loopback binds by default; non-loopback requires `--unsafe-listen`.
+- Keep mode mutually exclusive with `--gateway` / `--gateway-config`.
+
+## Consequences
+
+Positive:
+
+- Existing SDK apps can adopt Talon with only a base URL swap.
+- Governance and evidence stay active even in quickstart mode.
+- Quickstart traffic is auditable and separable by tenant/caller.
+
+Trade-offs:
+
+- Partial OpenAI compatibility (no embeddings, no responses retrieval/delete paths).
+- Dev-mode-only route relocation for tenant chat endpoint (`/v1/agents/chat/completions` while quickstart is enabled).
+- BYOK path is intentionally scoped to quickstart and should not replace vaulted provider auth in production.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,3 +4,4 @@ ADRs have been moved to **contributor documentation**.
 
 - **Agent planning (ADR-001):** [ADR-001 (agent planning)](../contributor/adr/ADR-001-agent-planning-paradigm.md)  
 - **User-facing doc:** [Agent Planning in Talon](../AGENT_PLANNING.md)
+- **OpenAI proxy quickstart (ADR-0001):** [ADR-0001](0001-openai-proxy-quickstart.md)

--- a/docs/guides/add-talon-to-existing-app.md
+++ b/docs/guides/add-talon-to-existing-app.md
@@ -10,6 +10,14 @@ Get Talon intercepting your real traffic in a few minutes. You have an app (Pyth
 
 ## Steps
 
+### 0. Fastest path (dev/local quickstart)
+
+If you want the quickest OpenAI-compatible local wiring first, start with:
+
+- [Tutorial: OpenAI proxy quickstart](../tutorials/proxy-quickstart.md)
+
+Then return here to move from quickstart into full gateway config for production.
+
 ### 1. Create a project directory and gateway config
 
 ```bash

--- a/docs/reference/authentication-and-key-scopes.md
+++ b/docs/reference/authentication-and-key-scopes.md
@@ -37,6 +37,19 @@ Notes:
 - Use **`TALON_ADMIN_KEY`** for admin/reviewer/operator actions and all dashboard/metrics endpoints.
 - Prefer `X-Talon-Admin-Key` for admin calls; bearer fallback is accepted.
 
+### BYOK in quickstart mode (dev-only)
+
+`talon serve --proxy-quickstart` adds a scoped exception for upstream authentication:
+
+- Host-root requests (`/v1/chat/completions`, `/v1/responses`) forward the caller bearer token to the upstream provider.
+- If the caller bearer is missing, Talon falls back to `OPENAI_API_KEY`.
+- This does not replace tenant-key/admin-key authentication for Talon control-plane and tenant APIs.
+
+Evidence distinction:
+
+- `upstream_key_fingerprint` identifies forwarded upstream key material safely.
+- `secrets_accessed` remains reserved for Talon vault reads.
+
 ---
 
 ## Common confusion

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -142,6 +142,17 @@ When `talon serve --gateway` is used, the `gateway:` block in `talon.config.yaml
 | `gateway.rate_limits` | Global and per-caller request rate limits |
 | `gateway.timeouts` | Connect, request, and stream idle timeouts |
 
+Provider auth mode:
+
+- `gateway.providers.<provider>.upstream_auth_mode`:
+  - `secret` (default): read provider credential from Talon vault (`secret_name` required).
+  - `client_bearer`: forward caller bearer upstream (quickstart profile only).
+
+Quickstart note:
+
+- `talon serve --proxy-quickstart` builds gateway config in memory (no YAML required).
+- Use [proxy quickstart reference](proxy-quickstart.md) for quickstart flags/env and compatibility limits.
+
 ### Gateway dashboard
 
 When the gateway is enabled, Talon serves a real-time metrics dashboard. Access is controlled by `TALON_ADMIN_KEY` (`X-Talon-Admin-Key` header).

--- a/docs/reference/gateway-dashboard.md
+++ b/docs/reference/gateway-dashboard.md
@@ -183,6 +183,17 @@ The HTML dashboard connects to this endpoint automatically for live updates. If 
 
 ## Snapshot fields reference
 
+### Quickstart evidence attributes (optional)
+
+When traffic comes from `--proxy-quickstart`, evidence records may include:
+
+- `upstream_auth_mode`
+- `upstream_key_source`
+- `upstream_key_fingerprint`
+- `gateway_annotations`
+
+These are additive attributes and do not change existing dashboard snapshot keys.
+
 ### `summary` (top-level KPIs)
 
 | Field | Type | Description |

--- a/docs/reference/proxy-quickstart.md
+++ b/docs/reference/proxy-quickstart.md
@@ -1,0 +1,65 @@
+# Reference: proxy quickstart
+
+`talon serve --proxy-quickstart` enables a dev/local OpenAI-compatible host-root proxy.
+
+## Scope
+
+Supported host-root endpoints:
+
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+
+Unsupported in quickstart host-root mode:
+
+- `POST /v1/embeddings`
+- `GET /v1/responses/{id}`
+- `DELETE /v1/responses/{id}`
+
+Unsupported paths return `404` with a partial-compatibility message.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--proxy-quickstart` | Enable quickstart mode. |
+| `--unsafe-listen` | Allow non-loopback bind with quickstart mode. |
+| `--host` | Host/IP for bind. Loopback only unless `--unsafe-listen`. |
+| `--port` | Listen port. |
+
+## Environment variables
+
+| Variable | Meaning |
+|---|---|
+| `OPENAI_API_KEY` | Upstream fallback when caller bearer is absent. |
+| `TALON_QUICKSTART_OPENAI_BASE_URL` | Upstream OpenAI-compatible base URL. |
+| `TALON_QUICKSTART_MODE` | `shadow` to opt into shadow mode (default `enforce`). |
+| `TALON_QUICKSTART_ALLOW_ALL_MODELS` | `1/true` clears quickstart model allowlist. |
+
+## Auth model
+
+Quickstart uses upstream BYOK as a scoped exception:
+
+- Caller `Authorization: Bearer <key>` is forwarded to upstream.
+- If missing, Talon tries `OPENAI_API_KEY`.
+- If neither exists, request fails with `401`.
+
+## Governance defaults
+
+- Enforcement mode: `enforce`.
+- PII default action: `redact`.
+- Evidence includes `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and optional `gateway_annotations`.
+
+## Bind safety
+
+- `--host` omitted: binds to `127.0.0.1:<port>`.
+- Loopback hosts (`127.0.0.1`, `::1`, `localhost`): allowed.
+- Non-loopback host without `--unsafe-listen`: startup error.
+
+## Mutual exclusivity
+
+`--proxy-quickstart` cannot be used with:
+
+- `--gateway`
+- `--gateway-config`
+
+Use `--gateway` for production-style caller mapping and vaulted provider auth.

--- a/docs/reference/proxy-quickstart.md
+++ b/docs/reference/proxy-quickstart.md
@@ -51,7 +51,9 @@ Quickstart uses upstream BYOK as a scoped exception:
 
 ## Tenant auth boundary
 
-Quickstart is strictly a host-root OpenAI-compatibility facade backed by a synthetic in-process caller. It does **not** register a synthetic tenant key and does **not** unlock Talon's tenant-auth surface. Tenant endpoints such as the relocated `POST /v1/agents/chat/completions` still require a real tenant key configured by the operator; without it, those routes return `401 Unauthorized` as expected from Talon's normal auth middleware.
+Quickstart is strictly a host-root OpenAI-compatibility facade backed by a synthetic in-process caller. It does **not** register a synthetic tenant key and does **not** unlock Talon's tenant-auth surface.
+
+The relocated tenant agent chat route `POST /v1/agents/chat/completions` is only mounted when the operator has configured real tenant keys (for example through a full gateway config). In default quickstart (no tenant keys), this route is not mounted at all and returns `404 Not Found`, preserving a clean facade-only boundary and avoiding any dev-mode-open backdoor to tenant APIs. When tenant keys are configured, the relocated route sits behind standard tenant-auth middleware and returns `401 Unauthorized` without a valid key.
 
 ## Bind safety
 

--- a/docs/reference/proxy-quickstart.md
+++ b/docs/reference/proxy-quickstart.md
@@ -47,7 +47,11 @@ Quickstart uses upstream BYOK as a scoped exception:
 
 - Enforcement mode: `enforce`.
 - PII default action: `redact`.
-- Evidence includes `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and optional `gateway_annotations`.
+- Evidence includes `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and optional `gateway_annotations` (e.g. `quickstart_mode`, `quickstart_shadow_mode`, `quickstart_model_allowlist_disabled`, `quickstart_unsafe_listen`).
+
+## Tenant auth boundary
+
+Quickstart is strictly a host-root OpenAI-compatibility facade backed by a synthetic in-process caller. It does **not** register a synthetic tenant key and does **not** unlock Talon's tenant-auth surface. Tenant endpoints such as the relocated `POST /v1/agents/chat/completions` still require a real tenant key configured by the operator; without it, those routes return `401 Unauthorized` as expected from Talon's normal auth middleware.
 
 ## Bind safety
 

--- a/docs/tutorials/proxy-quickstart.md
+++ b/docs/tutorials/proxy-quickstart.md
@@ -1,0 +1,62 @@
+# Tutorial: OpenAI proxy quickstart
+
+Use this path when you already have an app using an OpenAI-compatible SDK and want Talon governance without writing gateway YAML.
+
+## 1) Start Talon quickstart mode
+
+```bash
+talon serve --proxy-quickstart --port 8080
+```
+
+By default Talon binds `127.0.0.1` and enables:
+
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+
+## 2) Point your app to Talon
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_API_KEY=sk-your-key
+```
+
+Your app keeps using the OpenAI SDK. Talon is now in the request path.
+
+## 3) Test with curl
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/chat/completions \
+  -H "Authorization: Bearer sk-test" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}'
+```
+
+Responses API:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/responses \
+  -H "Authorization: Bearer sk-test" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","input":"hello"}'
+```
+
+## 4) Verify governance evidence
+
+```bash
+talon audit list --tenant quickstart --limit 5
+```
+
+Look for:
+
+- `tenant_id=quickstart`
+- `agent_id=quickstart-local`
+- `upstream_auth_mode=client_bearer`
+
+## Behavior notes
+
+- Enforcement mode defaults to `enforce` (shadow optional via `TALON_QUICKSTART_MODE=shadow`).
+- PII default action is `redact`.
+- Key source precedence: client bearer > `OPENAI_API_KEY` > 401.
+- Partial OpenAI compatibility: only chat completions and responses create endpoints are supported at host root.
+
+For production gateway rollout, use `--gateway` and [gateway guides](../guides/add-talon-to-existing-app.md).

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -278,6 +278,7 @@ func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 		"input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash",
 		"observation_mode_override", "shadow_violation_types",
 		"cache_hit", "cache_entry_id", "cost_saved",
+		"upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations",
 		"primary_explanation_code", "primary_explanation_reason", "primary_version_identity",
 	}
 	if err := writer.Write(header); err != nil {
@@ -310,6 +311,10 @@ func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 			strconv.FormatBool(r.CacheHit),
 			r.CacheEntryID,
 			formatCostNumeric(r.CostSaved),
+			r.UpstreamAuthMode,
+			r.UpstreamKeySource,
+			r.UpstreamKeyFingerprint,
+			r.GatewayAnnotationsCSV(),
 			r.PrimaryExplanationCode,
 			r.PrimaryExplanationReason,
 			r.PrimaryVersionIdentity,
@@ -585,6 +590,15 @@ func renderAuditShow(w io.Writer, ev *evidence.Evidence, valid bool) {
 		fmt.Fprintf(w, "  Requested:  %s\n", req)
 		fmt.Fprintf(w, "  Filtered:   %s\n", filt)
 		fmt.Fprintf(w, "  Forwarded:  %s\n", fwd)
+	}
+	if ev.UpstreamAuthMode != "" || ev.UpstreamKeySource != "" || ev.UpstreamKeyFingerprint != "" {
+		fmt.Fprintln(w, "Upstream Auth")
+		fmt.Fprintf(w, "  Mode:        %s\n", ev.UpstreamAuthMode)
+		fmt.Fprintf(w, "  Key Source:  %s\n", ev.UpstreamKeySource)
+		fmt.Fprintf(w, "  Key FP:      %s\n", ev.UpstreamKeyFingerprint)
+	}
+	if len(ev.GatewayAnnotations) > 0 {
+		fmt.Fprintf(w, "Gateway Annotations: %s\n", strings.Join(ev.GatewayAnnotations, ", "))
 	}
 	if ev.CacheHit {
 		fmt.Fprintln(w, "Cache")

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -72,7 +72,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := validateServeModeFlags(serveProxyQuickstart, serveGateway, serveGatewayConfig); err != nil {
+	gatewayConfigExplicit := cmd.Flags().Changed("gateway-config")
+	if err := validateServeModeFlags(serveProxyQuickstart, serveGateway, gatewayConfigExplicit); err != nil {
 		return err
 	}
 
@@ -361,7 +362,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 			opts = append(opts, server.WithGateway(gatewayHandler))
 		}
 	} else if serveProxyQuickstart {
-		quickstartCfg, err := gateway.QuickstartConfig(gateway.QuickstartOptions{})
+		quickstartCfg, err := gateway.QuickstartConfig(gateway.QuickstartOptions{
+			UnsafeListen: serveUnsafeListen,
+		})
 		if err != nil {
 			return fmt.Errorf("building quickstart gateway config: %w", err)
 		}
@@ -384,8 +387,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 			server.WithQuickstartEnabled(true),
 			server.WithProxyQuickstart(server.NewQuickstartFacade(gw, quickstartCfg.ListenPrefix, &quickstartCfg.Callers[0])),
 		)
-		// Keep tenant endpoints available under quickstart mode via a dedicated local key.
-		tenantKeys["quickstart"] = "quickstart"
+		// Intentionally do NOT register a synthetic tenant key here. Quickstart is
+		// a host-root OpenAI-compatibility facade backed by a synthetic in-process
+		// caller; it must not silently unlock the tenant-auth surface. Tenant
+		// endpoints (e.g. relocated /v1/agents/chat/completions) still require a
+		// real tenant key from configuration if the operator wants to use them.
 	}
 
 	// Gateway dashboard metrics collector
@@ -463,9 +469,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if serveProxyQuickstart {
 		if serveUnsafeListen {
 			log.Warn().Msg("proxy quickstart exposed on non-loopback address; local/dev use only")
-			_ = os.Setenv("TALON_QUICKSTART_UNSAFE_LISTEN", "1")
-		} else {
-			_ = os.Unsetenv("TALON_QUICKSTART_UNSAFE_LISTEN")
 		}
 		log.Info().
 			Str("openai_base_url", "http://"+addr).
@@ -647,11 +650,15 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func validateServeModeFlags(proxyQuickstart, gatewayEnabled bool, gatewayConfig string) error {
+// validateServeModeFlags enforces mutual exclusivity between the quickstart
+// facade and the full gateway. gatewayConfigExplicit should be true only when
+// the user passed --gateway-config explicitly (detected via cobra's
+// Flags().Changed), so the check does not depend on the default string value.
+func validateServeModeFlags(proxyQuickstart, gatewayEnabled, gatewayConfigExplicit bool) error {
 	if !proxyQuickstart {
 		return nil
 	}
-	if gatewayEnabled || gatewayConfig != "talon.config.yaml" {
+	if gatewayEnabled || gatewayConfigExplicit {
 		return fmt.Errorf("--proxy-quickstart cannot be combined with --gateway or --gateway-config")
 	}
 	return nil

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,11 +39,14 @@ import (
 )
 
 var (
-	servePort          int
-	serveProxyConfig   string
-	serveDashboard     bool
-	serveGateway       bool
-	serveGatewayConfig string
+	servePort            int
+	serveHost            string
+	serveProxyConfig     string
+	serveDashboard       bool
+	serveGateway         bool
+	serveGatewayConfig   string
+	serveProxyQuickstart bool
+	serveUnsafeListen    bool
 )
 
 var serveCmd = &cobra.Command{
@@ -52,10 +57,13 @@ var serveCmd = &cobra.Command{
 
 func init() {
 	serveCmd.Flags().IntVar(&servePort, "port", 8080, "HTTP server port")
+	serveCmd.Flags().StringVar(&serveHost, "host", "", "HTTP server host (empty means default bind behavior)")
 	serveCmd.Flags().StringVar(&serveProxyConfig, "proxy-config", "", "Path to MCP proxy config YAML (optional)")
 	serveCmd.Flags().BoolVar(&serveDashboard, "dashboard", true, "Serve embedded dashboard at / and /dashboard")
 	serveCmd.Flags().BoolVar(&serveGateway, "gateway", false, "Enable LLM API gateway at /v1/proxy/*")
 	serveCmd.Flags().StringVar(&serveGatewayConfig, "gateway-config", "talon.config.yaml", "Path to config file with gateway block (used when --gateway is set)")
+	serveCmd.Flags().BoolVar(&serveProxyQuickstart, "proxy-quickstart", false, "Enable local/dev OpenAI-compatible quickstart proxy at host-root /v1/*")
+	serveCmd.Flags().BoolVar(&serveUnsafeListen, "unsafe-listen", false, "Allow --proxy-quickstart to bind non-loopback addresses")
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -63,6 +71,10 @@ func init() {
 func runServe(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	if err := validateServeModeFlags(serveProxyQuickstart, serveGateway, serveGatewayConfig); err != nil {
+		return err
+	}
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -317,6 +329,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	var gatewayHandler http.Handler
+	var gatewayCfgForMode *gateway.GatewayConfig
 	tenantKeys := map[string]string{}
 	if serveGateway {
 		gatewayCfg, err := gateway.LoadGatewayConfig(serveGatewayConfig)
@@ -344,18 +357,43 @@ func runServe(cmd *cobra.Command, args []string) error {
 					cfg.Cache.Enabled, cfg.Cache.DefaultTTL, cfg.Cache.SimilarityThreshold, cfg.Cache.MaxEntriesPerTenant)
 			}
 			gatewayHandler = gw
+			gatewayCfgForMode = gatewayCfg
 			opts = append(opts, server.WithGateway(gatewayHandler))
 		}
+	} else if serveProxyQuickstart {
+		quickstartCfg, err := gateway.QuickstartConfig(gateway.QuickstartOptions{})
+		if err != nil {
+			return fmt.Errorf("building quickstart gateway config: %w", err)
+		}
+		gatewayPolicy, err := policy.NewGatewayEngine(ctx)
+		if err != nil {
+			return fmt.Errorf("gateway policy engine: %w", err)
+		}
+		gw, err := gateway.NewGateway(quickstartCfg, cls, evidenceStore, secretsStore, gatewayPolicy, nil)
+		if err != nil {
+			return fmt.Errorf("initializing quickstart gateway: %w", err)
+		}
+		if serveCacheStore != nil && serveCachePolicy != nil && cfg.Cache != nil {
+			gw.SetCache(serveCacheStore, serveCacheEmbedder, serveCacheScrubber, serveCachePolicy,
+				cfg.Cache.Enabled, cfg.Cache.DefaultTTL, cfg.Cache.SimilarityThreshold, cfg.Cache.MaxEntriesPerTenant)
+		}
+		gatewayHandler = gw
+		gatewayCfgForMode = quickstartCfg
+		opts = append(opts,
+			server.WithGateway(gatewayHandler),
+			server.WithQuickstartEnabled(true),
+			server.WithProxyQuickstart(server.NewQuickstartFacade(gw, quickstartCfg.ListenPrefix, &quickstartCfg.Callers[0])),
+		)
+		// Keep tenant endpoints available under quickstart mode via a dedicated local key.
+		tenantKeys["quickstart"] = "quickstart"
 	}
 
 	// Gateway dashboard metrics collector
 	var metricsCollector *metrics.Collector
 	if gatewayHandler != nil {
 		enforcementMode := "enforce"
-		if serveGateway {
-			if gwCfg, err := gateway.LoadGatewayConfig(serveGatewayConfig); err == nil {
-				enforcementMode = string(gwCfg.Mode)
-			}
+		if gatewayCfgForMode != nil {
+			enforcementMode = string(gatewayCfgForMode.Mode)
 		}
 
 		collectorOpts := []metrics.CollectorOption{
@@ -418,7 +456,25 @@ func runServe(cmd *cobra.Command, args []string) error {
 		opts...,
 	)
 
-	addr := fmt.Sprintf(":%d", servePort)
+	addr, err := resolveServeAddress(serveHost, servePort, serveProxyQuickstart, serveUnsafeListen)
+	if err != nil {
+		return err
+	}
+	if serveProxyQuickstart {
+		if serveUnsafeListen {
+			log.Warn().Msg("proxy quickstart exposed on non-loopback address; local/dev use only")
+			_ = os.Setenv("TALON_QUICKSTART_UNSAFE_LISTEN", "1")
+		} else {
+			_ = os.Unsetenv("TALON_QUICKSTART_UNSAFE_LISTEN")
+		}
+		log.Info().
+			Str("openai_base_url", "http://"+addr).
+			Str("agent_chat_path", "/v1/agents/chat/completions").
+			Str("mode", string(gatewayCfgForMode.Mode)).
+			Str("pii_default", "redact").
+			Str("auth_precedence", "client bearer > OPENAI_API_KEY > 401").
+			Msg("proxy_quickstart_enabled")
+	}
 	httpServer := &http.Server{
 		Addr:         addr,
 		Handler:      srv.Routes(),
@@ -559,4 +615,44 @@ func mapBoolFields(m map[string]interface{}, e *metrics.GatewayEvent) {
 	if v, ok := m["cache_hit"].(bool); ok {
 		e.CacheHit = v
 	}
+}
+
+func resolveServeAddress(host string, port int, quickstartEnabled, unsafeListen bool) (string, error) {
+	cleanHost := strings.TrimSpace(host)
+	if !quickstartEnabled {
+		if cleanHost == "" {
+			return fmt.Sprintf(":%d", port), nil
+		}
+		return net.JoinHostPort(cleanHost, fmt.Sprintf("%d", port)), nil
+	}
+
+	if cleanHost == "" {
+		return net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", port)), nil
+	}
+	normalizedHost := strings.Trim(cleanHost, "[]")
+	if isLoopbackHost(normalizedHost) {
+		return net.JoinHostPort(normalizedHost, fmt.Sprintf("%d", port)), nil
+	}
+	if !unsafeListen {
+		return "", fmt.Errorf("quickstart cannot bind to %s:%d: use --unsafe-listen to override", normalizedHost, port)
+	}
+	return net.JoinHostPort(normalizedHost, fmt.Sprintf("%d", port)), nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func validateServeModeFlags(proxyQuickstart, gatewayEnabled bool, gatewayConfig string) error {
+	if !proxyQuickstart {
+		return nil
+	}
+	if gatewayEnabled || gatewayConfig != "talon.config.yaml" {
+		return fmt.Errorf("--proxy-quickstart cannot be combined with --gateway or --gateway-config")
+	}
+	return nil
 }

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -61,4 +62,33 @@ func TestMapToGatewayEvent_DefaultTimestampWhenMissing(t *testing.T) {
 
 	assert.False(t, got.Timestamp.IsZero(), "timestamp should be populated when absent")
 	assert.Equal(t, "test", got.CallerID)
+}
+
+func TestValidateServeModeFlags(t *testing.T) {
+	assert.NoError(t, validateServeModeFlags(false, false, "talon.config.yaml"))
+	assert.NoError(t, validateServeModeFlags(true, false, "talon.config.yaml"))
+	assert.Error(t, validateServeModeFlags(true, true, "talon.config.yaml"))
+	assert.Error(t, validateServeModeFlags(true, false, "custom.yaml"))
+}
+
+func TestResolveServeAddress_QuickstartAndLoopbackRules(t *testing.T) {
+	addr, err := resolveServeAddress("", 8080, true, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:8080", addr)
+
+	addr, err = resolveServeAddress("localhost", 8081, true, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost:8081", addr)
+
+	_, err = resolveServeAddress("0.0.0.0", 8082, true, false)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "--unsafe-listen"))
+
+	addr, err = resolveServeAddress("0.0.0.0", 8083, true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.0.0.0:8083", addr)
+
+	addr, err = resolveServeAddress("", 9090, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, ":9090", addr)
 }

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -65,10 +65,19 @@ func TestMapToGatewayEvent_DefaultTimestampWhenMissing(t *testing.T) {
 }
 
 func TestValidateServeModeFlags(t *testing.T) {
-	assert.NoError(t, validateServeModeFlags(false, false, "talon.config.yaml"))
-	assert.NoError(t, validateServeModeFlags(true, false, "talon.config.yaml"))
-	assert.Error(t, validateServeModeFlags(true, true, "talon.config.yaml"))
-	assert.Error(t, validateServeModeFlags(true, false, "custom.yaml"))
+	// Not in quickstart mode: any combination is fine.
+	assert.NoError(t, validateServeModeFlags(false, false, false))
+	assert.NoError(t, validateServeModeFlags(false, true, true))
+
+	// Quickstart alone (no other flags) is allowed, even though --gateway-config
+	// has a default value, because the user did not explicitly set it.
+	assert.NoError(t, validateServeModeFlags(true, false, false))
+
+	// Quickstart + --gateway is rejected.
+	assert.Error(t, validateServeModeFlags(true, true, false))
+
+	// Quickstart + explicit --gateway-config is rejected regardless of value.
+	assert.Error(t, validateServeModeFlags(true, false, true))
 }
 
 func TestResolveServeAddress_QuickstartAndLoopbackRules(t *testing.T) {

--- a/internal/evidence/export.go
+++ b/internal/evidence/export.go
@@ -38,13 +38,17 @@ type ExportRecord struct {
 	ObservationModeOverride bool     `json:"observation_mode_override"`
 	ShadowViolationTypes    []string `json:"shadow_violation_types,omitempty"`
 	// Semantic cache (audit export)
-	CacheHit                 bool    `json:"cache_hit,omitempty"`
-	CacheEntryID             string  `json:"cache_entry_id,omitempty"`
-	CacheSimilarity          float64 `json:"cache_similarity,omitempty"`
-	CostSaved                float64 `json:"cost_saved,omitempty"`
-	PrimaryExplanationCode   string  `json:"primary_explanation_code,omitempty"`
-	PrimaryExplanationReason string  `json:"primary_explanation_reason,omitempty"`
-	PrimaryVersionIdentity   string  `json:"primary_version_identity,omitempty"`
+	CacheHit                 bool     `json:"cache_hit,omitempty"`
+	CacheEntryID             string   `json:"cache_entry_id,omitempty"`
+	CacheSimilarity          float64  `json:"cache_similarity,omitempty"`
+	CostSaved                float64  `json:"cost_saved,omitempty"`
+	UpstreamAuthMode         string   `json:"upstream_auth_mode,omitempty"`
+	UpstreamKeySource        string   `json:"upstream_key_source,omitempty"`
+	UpstreamKeyFingerprint   string   `json:"upstream_key_fingerprint,omitempty"`
+	GatewayAnnotations       []string `json:"gateway_annotations,omitempty"`
+	PrimaryExplanationCode   string   `json:"primary_explanation_code,omitempty"`
+	PrimaryExplanationReason string   `json:"primary_explanation_reason,omitempty"`
+	PrimaryVersionIdentity   string   `json:"primary_version_identity,omitempty"`
 }
 
 // ExportMetadata wraps JSON export with context about the export run.
@@ -97,6 +101,10 @@ func ToExportRecord(e *Evidence) ExportRecord {
 		CacheEntryID:            e.CacheEntryID,
 		CacheSimilarity:         e.CacheSimilarity,
 		CostSaved:               e.CostSaved,
+		UpstreamAuthMode:        e.UpstreamAuthMode,
+		UpstreamKeySource:       e.UpstreamKeySource,
+		UpstreamKeyFingerprint:  e.UpstreamKeyFingerprint,
+		GatewayAnnotations:      append([]string(nil), e.GatewayAnnotations...),
 	}
 	if len(e.PolicyDecision.Reasons) > 0 {
 		rec.PolicyReasons = append([]string(nil), e.PolicyDecision.Reasons...)
@@ -133,4 +141,9 @@ func (r *ExportRecord) ToolsCalledCSV() string {
 // ShadowViolationTypesCSV returns comma-separated shadow violation types for CSV export.
 func (r *ExportRecord) ShadowViolationTypesCSV() string {
 	return strings.Join(r.ShadowViolationTypes, ",")
+}
+
+// GatewayAnnotationsCSV returns comma-separated gateway annotations for CSV export.
+func (r *ExportRecord) GatewayAnnotationsCSV() string {
+	return strings.Join(r.GatewayAnnotations, ",")
 }

--- a/internal/evidence/export_test.go
+++ b/internal/evidence/export_test.go
@@ -92,6 +92,10 @@ func TestExportRecord_JSONRoundTrip(t *testing.T) {
 		InvocationType: "gateway", Allowed: true, Cost: 0.02, ModelUsed: "gpt-4o",
 		ObservationModeOverride: true,
 		ShadowViolationTypes:    []string{"pii_block"},
+		UpstreamAuthMode:        "client_bearer",
+		UpstreamKeySource:       "client",
+		UpstreamKeyFingerprint:  "abc123def456",
+		GatewayAnnotations:      []string{"quickstart_mode"},
 	}
 
 	data, err := json.Marshal(rec)
@@ -102,6 +106,13 @@ func TestExportRecord_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, rec.ID, decoded.ID)
 	assert.True(t, decoded.ObservationModeOverride)
 	assert.Equal(t, []string{"pii_block"}, decoded.ShadowViolationTypes)
+	assert.Equal(t, "client_bearer", decoded.UpstreamAuthMode)
+	assert.Equal(t, "quickstart_mode", decoded.GatewayAnnotations[0])
+}
+
+func TestExportRecord_GatewayAnnotationsCSV(t *testing.T) {
+	rec := ExportRecord{GatewayAnnotations: []string{"quickstart_mode", "quickstart_shadow_mode"}}
+	assert.Equal(t, "quickstart_mode,quickstart_shadow_mode", rec.GatewayAnnotationsCSV())
 }
 
 func TestExportEnvelope_JSONRoundTrip(t *testing.T) {

--- a/internal/evidence/schema_compat_test.go
+++ b/internal/evidence/schema_compat_test.go
@@ -1,0 +1,32 @@
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEvidenceSchemaBackwardCompatible(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "pre_quickstart_record.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var ev Evidence
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	if ev.UpstreamAuthMode != "" {
+		t.Fatalf("expected empty upstream_auth_mode for legacy record, got %q", ev.UpstreamAuthMode)
+	}
+	if ev.UpstreamKeySource != "" {
+		t.Fatalf("expected empty upstream_key_source for legacy record, got %q", ev.UpstreamKeySource)
+	}
+	if ev.UpstreamKeyFingerprint != "" {
+		t.Fatalf("expected empty upstream_key_fingerprint for legacy record, got %q", ev.UpstreamKeyFingerprint)
+	}
+	if len(ev.GatewayAnnotations) != 0 {
+		t.Fatalf("expected no gateway_annotations for legacy record, got %v", ev.GatewayAnnotations)
+	}
+}

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -52,6 +52,10 @@ type Evidence struct {
 	Execution               Execution         `json:"execution"`
 	ModelRoutingRationale   string            `json:"model_routing_rationale,omitempty"` // Why this model was chosen: "primary", "degraded to fallback", etc.
 	SecretsAccessed         []string          `json:"secrets_accessed,omitempty"`
+	UpstreamAuthMode        string            `json:"upstream_auth_mode,omitempty"`       // gateway upstream auth mode: secret | client_bearer
+	UpstreamKeySource       string            `json:"upstream_key_source,omitempty"`      // gateway key source: client | env
+	UpstreamKeyFingerprint  string            `json:"upstream_key_fingerprint,omitempty"` // SHA-256 fingerprint prefix; never the key
+	GatewayAnnotations      []string          `json:"gateway_annotations,omitempty"`      // constrained gateway runtime annotations
 	MemoryWrites            []MemoryWrite     `json:"memory_writes,omitempty"`
 	MemoryReads             []MemoryRead      `json:"memory_reads,omitempty"`
 	AuditTrail              AuditTrail        `json:"audit_trail"`

--- a/internal/evidence/testdata/pre_quickstart_record.json
+++ b/internal/evidence/testdata/pre_quickstart_record.json
@@ -1,0 +1,38 @@
+{
+  "id": "ev_pre_quickstart_1",
+  "correlation_id": "corr_pre_quickstart_1",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "tenant_id": "default",
+  "agent_id": "agent-pre",
+  "invocation_type": "gateway",
+  "policy_decision": {
+    "allowed": true,
+    "action": "allow",
+    "policy_version": "v1"
+  },
+  "classification": {
+    "input_tier": 0,
+    "output_tier": 0,
+    "pii_redacted": false
+  },
+  "execution": {
+    "model_used": "gpt-4o-mini",
+    "cost": 0.01,
+    "tokens": {
+      "input": 10,
+      "output": 5
+    },
+    "duration_ms": 100
+  },
+  "audit_trail": {
+    "input_hash": "in-hash",
+    "output_hash": "out-hash"
+  },
+  "compliance": {
+    "frameworks": [
+      "gdpr"
+    ],
+    "data_location": "eu"
+  },
+  "signature": "sig"
+}

--- a/internal/gateway/byok_test.go
+++ b/internal/gateway/byok_test.go
@@ -1,0 +1,177 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+func TestGateway_BYOKClientBearerForwarded(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	gw, evStore, caller := newBYOKGateway(t, upstream.URL)
+	req := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	req.Header.Set("Authorization", "Bearer sk-client-key")
+	req = req.WithContext(WithQuickstartCaller(req.Context(), caller))
+	rec := httptest.NewRecorder()
+	gw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer sk-client-key" {
+		t.Fatalf("upstream auth = %q", gotAuth)
+	}
+	list, err := evStore.List(context.Background(), caller.TenantID, caller.Name, time.Time{}, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("list evidence: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("expected evidence record for byok request")
+	}
+	if list[0].UpstreamAuthMode != "client_bearer" {
+		t.Fatalf("upstream_auth_mode = %q", list[0].UpstreamAuthMode)
+	}
+	if list[0].UpstreamKeySource != "client" {
+		t.Fatalf("upstream_key_source = %q", list[0].UpstreamKeySource)
+	}
+	if len(list[0].UpstreamKeyFingerprint) != 12 {
+		t.Fatalf("unexpected upstream key fingerprint: %q", list[0].UpstreamKeyFingerprint)
+	}
+	if list[0].UpstreamKeyFingerprint == "sk-client-key" {
+		t.Fatalf("fingerprint must not store raw key")
+	}
+}
+
+func TestGateway_BYOKEnvFallback(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env-fallback")
+
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	gw, _, caller := newBYOKGateway(t, upstream.URL)
+	req := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	req = req.WithContext(WithQuickstartCaller(req.Context(), caller))
+	rec := httptest.NewRecorder()
+	gw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer sk-env-fallback" {
+		t.Fatalf("upstream auth = %q", gotAuth)
+	}
+	evs, err := newEvidenceList(t, gw, caller)
+	if err != nil {
+		t.Fatalf("list evidence: %v", err)
+	}
+	if len(evs) == 0 {
+		t.Fatalf("expected evidence record")
+	}
+	if evs[0].UpstreamKeySource != "env" {
+		t.Fatalf("upstream_key_source = %q", evs[0].UpstreamKeySource)
+	}
+}
+
+func TestGateway_BYOKMissingKeyReturns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("upstream should not be called")
+	}))
+	defer upstream.Close()
+
+	gw, _, caller := newBYOKGateway(t, upstream.URL)
+	req := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	req = req.WithContext(WithQuickstartCaller(req.Context(), caller))
+	rec := httptest.NewRecorder()
+	gw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func newBYOKGateway(t *testing.T, upstreamURL string) (*Gateway, *evidence.Store, *CallerConfig) {
+	t.Helper()
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true, BaseURL: upstreamURL, UpstreamAuthMode: "client_bearer"},
+		},
+		Callers: []CallerConfig{
+			{Name: quickstartCallerName, TenantID: quickstartTenantID, AllowedProviders: []string{"openai"}},
+		},
+		ServerDefaults: ServerDefaults{
+			DefaultPIIAction: "redact",
+			RequireCallerID:  boolPtr(false),
+		},
+		RateLimits: RateLimitsConfig{
+			GlobalRequestsPerMin:    1000,
+			PerCallerRequestsPerMin: 1000,
+		},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate cfg: %v", err)
+	}
+	dir := t.TempDir()
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	if err != nil {
+		t.Fatalf("new evidence store: %v", err)
+	}
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	if err != nil {
+		t.Fatalf("new secrets store: %v", err)
+	}
+	t.Cleanup(func() { _ = secStore.Close() })
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+	return gw, evStore, &cfg.Callers[0]
+}
+
+func gatewayRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://talon.local/v1/proxy/openai/v1/chat/completions", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func newEvidenceList(t *testing.T, gw *Gateway, caller *CallerConfig) ([]evidence.Evidence, error) {
+	t.Helper()
+	if gw == nil || gw.evidenceStore == nil {
+		return nil, nil
+	}
+	return gw.evidenceStore.List(context.Background(), caller.TenantID, caller.Name, time.Time{}, time.Time{}, 10)
+}

--- a/internal/gateway/caller_injection_test.go
+++ b/internal/gateway/caller_injection_test.go
@@ -1,0 +1,159 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+func TestGateway_QuickstartCallerFromContextOnly(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	gw, evStore, quickstartCaller := newBYOKGateway(t, upstream.URL)
+
+	// No context caller and no bearer key: caller resolves via existing fallback.
+	req := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+	gw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with missing upstream key, got %d", rec.Code)
+	}
+	records, err := evStore.List(context.Background(), "", "", time.Time{}, time.Time{}, 20)
+	if err != nil {
+		t.Fatalf("listing evidence: %v", err)
+	}
+	for i := range records {
+		if records[i].AgentID == quickstartCaller.Name {
+			t.Fatalf("unexpected quickstart caller from fallback path")
+		}
+	}
+
+	// Context caller must be honored.
+	req2 := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	req2.Header.Set("Authorization", "Bearer sk-context")
+	req2 = req2.WithContext(WithQuickstartCaller(req2.Context(), quickstartCaller))
+	rec2 := httptest.NewRecorder()
+	gw.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec2.Code, rec2.Body.String())
+	}
+	got, err := evStore.List(context.Background(), quickstartCaller.TenantID, quickstartCaller.Name, time.Time{}, time.Time{}, 20)
+	if err != nil {
+		t.Fatalf("listing evidence by caller: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected quickstart evidence record")
+	}
+
+	// Header-only "claim" must not impersonate quickstart-local identity.
+	req3 := gatewayRequest(t, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	req3.Header.Set("X-Talon-Caller", quickstartCaller.Name)
+	req3.Header.Set("Authorization", "Bearer sk-no-context")
+	rec3 := httptest.NewRecorder()
+	gw.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusUnauthorized && rec3.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", rec3.Code)
+	}
+	all, err := evStore.List(context.Background(), "", "", time.Time{}, time.Time{}, 50)
+	if err != nil {
+		t.Fatalf("listing all evidence: %v", err)
+	}
+	// Decode full records to ensure there is at least one non-quickstart caller.
+	foundNonQuickstart := false
+	for i := range all {
+		if all[i].AgentID != quickstartCaller.Name {
+			foundNonQuickstart = true
+			break
+		}
+	}
+	if !foundNonQuickstart {
+		t.Fatalf("expected at least one non-quickstart caller from non-context request")
+	}
+}
+
+func TestQuickstartCallerContextHelpers(t *testing.T) {
+	caller := &CallerConfig{Name: "quickstart-local", TenantID: "quickstart"}
+	ctx := context.Background()
+	if QuickstartCallerFromContext(ctx) != nil {
+		t.Fatalf("unexpected caller in empty context")
+	}
+	ctx = WithQuickstartCaller(ctx, caller)
+	got := QuickstartCallerFromContext(ctx)
+	if got == nil || got.Name != caller.Name || got.TenantID != caller.TenantID {
+		raw, _ := json.Marshal(got)
+		t.Fatalf("unexpected caller: %s", string(raw))
+	}
+}
+
+func TestGateway_AnonymousFallbackWhenCallerIDNotRequired(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true, BaseURL: upstream.URL, UpstreamAuthMode: "client_bearer"},
+		},
+		ServerDefaults: ServerDefaults{
+			DefaultPIIAction: "redact",
+			RequireCallerID:  boolPtr(false),
+		},
+		RateLimits: RateLimitsConfig{
+			GlobalRequestsPerMin:    1000,
+			PerCallerRequestsPerMin: 1000,
+		},
+		Timeouts: TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+	dir := t.TempDir()
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	if err != nil {
+		t.Fatalf("evidence store: %v", err)
+	}
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	if err != nil {
+		t.Fatalf("secrets store: %v", err)
+	}
+	t.Cleanup(func() { _ = secStore.Close() })
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://talon.local/v1/proxy/openai/v1/chat/completions",
+		bytes.NewBufferString(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Authorization", "Bearer sk-anon")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	gw.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	records, err := evStore.List(context.Background(), "default", "anonymous", time.Time{}, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("listing evidence: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatalf("expected anonymous fallback evidence")
+	}
+}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -46,8 +46,13 @@ type GatewayConfig struct {
 
 // ProviderConfig holds per-provider gateway settings.
 type ProviderConfig struct {
-	Enabled          bool     `yaml:"enabled" json:"enabled"`
-	SecretName       string   `yaml:"secret_name,omitempty" json:"secret_name,omitempty"`
+	Enabled    bool   `yaml:"enabled" json:"enabled"`
+	SecretName string `yaml:"secret_name,omitempty" json:"secret_name,omitempty"`
+	// UpstreamAuthMode controls how Talon authenticates to the upstream provider.
+	// "secret" (default) reads provider credentials from Talon's secret store.
+	// "client_bearer" forwards the caller bearer token upstream and is intended
+	// for proxy quickstart mode only.
+	UpstreamAuthMode string   `yaml:"upstream_auth_mode,omitempty" json:"upstream_auth_mode,omitempty"` // secret | client_bearer
 	BaseURL          string   `yaml:"base_url" json:"base_url"`
 	AllowedModels    []string `yaml:"allowed_models,omitempty" json:"allowed_models,omitempty"`
 	BlockedModels    []string `yaml:"blocked_models,omitempty" json:"blocked_models,omitempty"`
@@ -179,6 +184,7 @@ const (
 	DefaultAttachmentInjAction     = "warn"
 	DefaultAttachmentMaxFileSizeMB = 10
 	DefaultToolPolicyAction        = "filter" // "filter" removes disallowed tools; "block" rejects the request
+	DefaultUpstreamAuthMode        = "secret"
 )
 
 // LoadGatewayConfig loads gateway configuration from a YAML file (typically talon.config.yaml).
@@ -291,12 +297,21 @@ func (c *GatewayConfig) Validate() error {
 		if !p.Enabled {
 			continue
 		}
+		if p.UpstreamAuthMode == "" {
+			p.UpstreamAuthMode = DefaultUpstreamAuthMode
+		}
+		switch p.UpstreamAuthMode {
+		case "secret", "client_bearer":
+		default:
+			return fmt.Errorf("gateway provider %q: upstream_auth_mode must be secret or client_bearer", name)
+		}
 		if p.BaseURL == "" && (name == "openai" || name == "anthropic" || name == "ollama") {
 			return fmt.Errorf("gateway provider %q: base_url is required", name)
 		}
-		if name != "ollama" && p.SecretName == "" {
+		if name != "ollama" && p.UpstreamAuthMode == "secret" && p.SecretName == "" {
 			return fmt.Errorf("gateway provider %q: secret_name is required", name)
 		}
+		c.Providers[name] = p
 	}
 	if p := c.ServerDefaults.AttachmentPolicy; p != nil {
 		switch p.Action {
@@ -322,7 +337,7 @@ func (c *GatewayConfig) Validate() error {
 			if len(caller.SourceIPRanges) == 0 {
 				return fmt.Errorf("gateway caller %q: source_ip_ranges required when identify_by is source_ip", caller.Name)
 			}
-		} else if caller.TenantKey == "" {
+		} else if caller.TenantKey == "" && c.ServerDefaults.CallerIDRequired() {
 			return fmt.Errorf("gateway caller %q: tenant_key or identify_by=source_ip with source_ip_ranges is required", caller.Name)
 		}
 	}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -42,6 +42,12 @@ type GatewayConfig struct {
 	// dashboard (e.g. "127.0.0.1:9091"). When empty, routes are served on the
 	// main API server. Binding to localhost prevents accidental exposure.
 	DashboardListen string `yaml:"dashboard_listen,omitempty" json:"dashboard_listen,omitempty"`
+	// QuickstartUnsafeListen marks that the serving process bound the
+	// OpenAI-compatible quickstart facade to a non-loopback address with
+	// --unsafe-listen. Set by QuickstartConfig only; never populated from YAML.
+	// The gateway uses this at evidence time to annotate requests with
+	// quickstart_unsafe_listen without relying on process-wide environment state.
+	QuickstartUnsafeListen bool `yaml:"-" json:"-"`
 }
 
 // ProviderConfig holds per-provider gateway settings.

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/explanation"
@@ -42,15 +43,19 @@ type RecordGatewayEvidenceParams struct {
 	ToolsFiltered           []string
 	ToolsForwarded          []string
 	// Semantic cache (set when response was served from cache)
-	CacheHit         bool
-	CacheEntryID     string
-	CacheSimilarity  float64
-	CostSaved        float64
-	AgentReasoning   string
-	RetryAttempt     string // X-Talon-Retry-Attempt header value; empty when not a retry
-	Stage            string // "generation", "judge", or "commit"
-	CandidateIndex   int
-	ExplanationFacts []explanation.Fact
+	CacheHit               bool
+	CacheEntryID           string
+	CacheSimilarity        float64
+	CostSaved              float64
+	UpstreamAuthMode       string
+	UpstreamKeySource      string
+	UpstreamKeyFingerprint string
+	GatewayAnnotations     []string
+	AgentReasoning         string
+	RetryAttempt           string // X-Talon-Retry-Attempt header value; empty when not a retry
+	Stage                  string // "generation", "judge", or "commit"
+	CandidateIndex         int
+	ExplanationFacts       []explanation.Fact
 }
 
 // RecordGatewayEvidence creates and stores a signed evidence record for a gateway request.
@@ -112,6 +117,10 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		CacheEntryID:            params.CacheEntryID,
 		CacheSimilarity:         params.CacheSimilarity,
 		CostSaved:               params.CostSaved,
+		UpstreamAuthMode:        params.UpstreamAuthMode,
+		UpstreamKeySource:       params.UpstreamKeySource,
+		UpstreamKeyFingerprint:  params.UpstreamKeyFingerprint,
+		GatewayAnnotations:      sanitizeGatewayAnnotations(params.GatewayAnnotations),
 		RetryAttempt:            params.RetryAttempt,
 	}
 	if !params.PolicyAllowed {
@@ -140,4 +149,25 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 	}
 	ev.Explanations = explanation.BuildFromFacts(facts)
 	return store.Store(ctx, ev)
+}
+
+func sanitizeGatewayAnnotations(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"quickstart_mode":                     {},
+		"quickstart_model_allowlist_disabled": {},
+		"quickstart_unsafe_listen":            {},
+		"quickstart_shadow_mode":              {},
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, ok := allowed[v]; ok {
+			out = append(out, v)
+			continue
+		}
+		log.Warn().Str("annotation", v).Msg("dropping_unsupported_gateway_annotation")
+	}
+	return out
 }

--- a/internal/gateway/evidence_test.go
+++ b/internal/gateway/evidence_test.go
@@ -21,19 +21,23 @@ func TestRecordGatewayEvidence(t *testing.T) {
 
 	ctx := context.Background()
 	err = RecordGatewayEvidence(ctx, store, RecordGatewayEvidenceParams{
-		CorrelationID:   "corr-1",
-		TenantID:        "default",
-		CallerName:      "test-caller",
-		Team:            "eng",
-		Provider:        "openai",
-		Model:           "gpt-4o",
-		PolicyAllowed:   true,
-		InputTier:       1,
-		Cost:            0.01,
-		InputTokens:     100,
-		OutputTokens:    50,
-		DurationMS:      200,
-		SecretsAccessed: []string{"openai-api-key"},
+		CorrelationID:          "corr-1",
+		TenantID:               "default",
+		CallerName:             "test-caller",
+		Team:                   "eng",
+		Provider:               "openai",
+		Model:                  "gpt-4o",
+		PolicyAllowed:          true,
+		InputTier:              1,
+		Cost:                   0.01,
+		InputTokens:            100,
+		OutputTokens:           50,
+		DurationMS:             200,
+		SecretsAccessed:        []string{"openai-api-key"},
+		UpstreamAuthMode:       "client_bearer",
+		UpstreamKeySource:      "client",
+		UpstreamKeyFingerprint: "abc123def456",
+		GatewayAnnotations:     []string{"quickstart_mode", "unsupported_annotation"},
 	})
 	require.NoError(t, err)
 
@@ -42,6 +46,14 @@ func TestRecordGatewayEvidence(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, byAgent["test-caller"])
 	require.Equal(t, 0.01, byAgent["test-caller"])
+
+	records, err := store.List(ctx, "default", "test-caller", time.Time{}, time.Time{}, 1)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "client_bearer", records[0].UpstreamAuthMode)
+	assert.Equal(t, "client", records[0].UpstreamKeySource)
+	assert.Equal(t, "abc123def456", records[0].UpstreamKeyFingerprint)
+	assert.Equal(t, []string{"quickstart_mode"}, records[0].GatewayAnnotations, "unsupported annotations must be dropped")
 }
 
 // TestRecordGatewayEvidence_ToolGovernanceRoundTrip ensures tool governance is persisted

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -2,10 +2,13 @@ package gateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -51,6 +54,9 @@ const (
 	gatewayRetryAttemptKey   gatewayContextKey = "retry_attempt"
 	gatewayStageKey          gatewayContextKey = "stage"
 	gatewayCandidateIndexKey gatewayContextKey = "candidate_index"
+	gatewayUpstreamAuthMode  gatewayContextKey = "upstream_auth_mode"
+	gatewayUpstreamKeySource gatewayContextKey = "upstream_key_source"
+	gatewayUpstreamKeyFP     gatewayContextKey = "upstream_key_fingerprint"
 )
 
 // hasCallerTag returns true when the caller has the given tag (e.g. "copaw" for CoPaw).
@@ -230,18 +236,24 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 2: Identify
-	caller, err := g.config.ResolveCaller(r)
-	if err != nil {
-		if err == ErrCallerIDRequired || err == ErrCallerNotFound {
+	var caller *CallerConfig
+	qc := QuickstartCallerFromContext(ctx)
+	if qc != nil {
+		caller = qc
+	} else {
+		caller, err = g.config.ResolveCaller(r)
+		if err != nil {
+			if err == ErrCallerIDRequired || err == ErrCallerNotFound {
+				RecordGatewayError(ctx, "auth")
+				RecordGatewayRequest(ctx, "unknown", "", route.Provider, "error")
+				WriteProviderError(w, route.Provider, http.StatusUnauthorized, "Invalid or missing tenant key")
+				return
+			}
 			RecordGatewayError(ctx, "auth")
 			RecordGatewayRequest(ctx, "unknown", "", route.Provider, "error")
-			WriteProviderError(w, route.Provider, http.StatusUnauthorized, "Invalid or missing tenant key")
+			WriteProviderError(w, route.Provider, http.StatusInternalServerError, err.Error())
 			return
 		}
-		RecordGatewayError(ctx, "auth")
-		RecordGatewayRequest(ctx, "unknown", "", route.Provider, "error")
-		WriteProviderError(w, route.Provider, http.StatusInternalServerError, err.Error())
-		return
 	}
 	if span := trace.SpanFromContext(ctx); span.IsRecording() && hasCallerTag(caller, "copaw") {
 		span.SetAttributes(
@@ -558,6 +570,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 9: Forward — get provider key and proxy
+	originalAuthorization := r.Header.Get("Authorization")
 	headers := make(map[string]string)
 	for k, v := range r.Header {
 		switch k {
@@ -586,21 +599,50 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			headers["anthropic-version"] = "2023-06-01"
 		}
 	}
-	if prov.SecretName != "" {
-		secret, err := g.secretsStore.Get(ctx, prov.SecretName, caller.TenantID, caller.Name)
-		if err != nil {
-			durationMS := time.Since(start).Milliseconds()
-			log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
-			WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-			_ = g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
-			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0)
+	upstreamAuthMode := strings.TrimSpace(prov.UpstreamAuthMode)
+	if upstreamAuthMode == "" {
+		upstreamAuthMode = DefaultUpstreamAuthMode
+	}
+	switch upstreamAuthMode {
+	case "client_bearer":
+		clientKey := ""
+		if strings.HasPrefix(originalAuthorization, "Bearer ") {
+			clientKey = strings.TrimSpace(strings.TrimPrefix(originalAuthorization, "Bearer "))
+		}
+		source := "client"
+		if clientKey == "" {
+			clientKey = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+			source = "env"
+		}
+		if clientKey == "" {
+			RecordGatewayError(ctx, "missing_upstream_key")
+			RecordGatewayRequest(ctx, caller.Name, extracted.Model, route.Provider, "error")
+			WriteProviderError(w, route.Provider, http.StatusUnauthorized,
+				"no upstream credential: set OPENAI_API_KEY or send Authorization: Bearer ...")
 			return
 		}
-		if route.Provider == "anthropic" {
-			headers["x-api-key"] = string(secret.Value)
-		} else {
-			headers["Authorization"] = "Bearer " + string(secret.Value)
+		headers["Authorization"] = "Bearer " + clientKey
+		ctx = context.WithValue(ctx, gatewayUpstreamAuthMode, upstreamAuthMode)
+		ctx = context.WithValue(ctx, gatewayUpstreamKeySource, source)
+		ctx = context.WithValue(ctx, gatewayUpstreamKeyFP, fingerprintKey(clientKey))
+	default:
+		if prov.SecretName != "" {
+			secret, err := g.secretsStore.Get(ctx, prov.SecretName, caller.TenantID, caller.Name)
+			if err != nil {
+				durationMS := time.Since(start).Milliseconds()
+				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
+				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
+				_ = g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
+				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0)
+				return
+			}
+			if route.Provider == "anthropic" {
+				headers["x-api-key"] = string(secret.Value)
+			} else {
+				headers["Authorization"] = "Bearer " + string(secret.Value)
+			}
 		}
+		ctx = context.WithValue(ctx, gatewayUpstreamAuthMode, upstreamAuthMode)
 	}
 
 	// Resolve response PII action
@@ -784,6 +826,10 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	params.CacheEntryID = cacheEntryID
 	params.CacheSimilarity = cacheSimilarity
 	params.CostSaved = costSaved
+	params.UpstreamAuthMode = upstreamAuthModeFromContext(ctx)
+	params.UpstreamKeySource = upstreamKeySourceFromContext(ctx)
+	params.UpstreamKeyFingerprint = upstreamKeyFingerprintFromContext(ctx)
+	params.GatewayAnnotations = gatewayAnnotationsForEvidence(g, caller)
 	params.TTFTMS = ttftMS
 	params.TPOTMS = tpotMS
 	return RecordGatewayEvidence(ctx, g.evidenceStore, params)
@@ -851,6 +897,61 @@ func candidateIndexFromContext(ctx context.Context) int {
 		return i
 	}
 	return 0
+}
+
+func upstreamAuthModeFromContext(ctx context.Context) string {
+	v := ctx.Value(gatewayUpstreamAuthMode)
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func upstreamKeySourceFromContext(ctx context.Context) string {
+	v := ctx.Value(gatewayUpstreamKeySource)
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func upstreamKeyFingerprintFromContext(ctx context.Context) string {
+	v := ctx.Value(gatewayUpstreamKeyFP)
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func fingerprintKey(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(raw))
+	hexSum := hex.EncodeToString(sum[:])
+	if len(hexSum) < 12 {
+		return hexSum
+	}
+	return hexSum[:12]
+}
+
+func gatewayAnnotationsForEvidence(g *Gateway, caller *CallerConfig) []string {
+	if caller == nil || !hasCallerTag(caller, "quickstart") {
+		return nil
+	}
+	out := []string{"quickstart_mode"}
+	if g != nil && g.config != nil && g.config.Mode == ModeShadow {
+		out = append(out, "quickstart_shadow_mode")
+	}
+	if g != nil && g.config != nil {
+		if openai, ok := g.config.Provider("openai"); ok && len(openai.AllowedModels) == 0 {
+			out = append(out, "quickstart_model_allowlist_disabled")
+		}
+	}
+	if parseQuickstartBoolEnv("TALON_QUICKSTART_UNSAFE_LISTEN") {
+		out = append(out, "quickstart_unsafe_listen")
+	}
+	return out
 }
 
 // trackSessionUsage updates session cost/token counters when a session store is configured.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -947,9 +947,9 @@ func gatewayAnnotationsForEvidence(g *Gateway, caller *CallerConfig) []string {
 		if openai, ok := g.config.Provider("openai"); ok && len(openai.AllowedModels) == 0 {
 			out = append(out, "quickstart_model_allowlist_disabled")
 		}
-	}
-	if parseQuickstartBoolEnv("TALON_QUICKSTART_UNSAFE_LISTEN") {
-		out = append(out, "quickstart_unsafe_listen")
+		if g.config.QuickstartUnsafeListen {
+			out = append(out, "quickstart_unsafe_listen")
+		}
 	}
 	return out
 }

--- a/internal/gateway/quickstart.go
+++ b/internal/gateway/quickstart.go
@@ -15,6 +15,11 @@ const (
 // QuickstartOptions configures the in-memory proxy quickstart profile.
 type QuickstartOptions struct {
 	OpenAIBaseURL string
+	// UnsafeListen signals that serve was invoked with --unsafe-listen and is
+	// binding a non-loopback address. It is surfaced on evidence records via
+	// gateway_annotations so operators can see the degradation without needing
+	// process-wide environment flags.
+	UnsafeListen bool
 }
 
 // QuickstartConfig builds a minimal in-memory gateway config for local
@@ -80,6 +85,7 @@ func QuickstartConfig(opts QuickstartOptions) (*GatewayConfig, error) {
 			RequestTimeout:    DefaultRequestTimeout,
 			StreamIdleTimeout: DefaultStreamIdleTimeout,
 		},
+		QuickstartUnsafeListen: opts.UnsafeListen,
 	}
 	_ = annotations // annotations are recorded per-request by gateway evidence path.
 

--- a/internal/gateway/quickstart.go
+++ b/internal/gateway/quickstart.go
@@ -1,0 +1,105 @@
+package gateway
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	quickstartCallerName = "quickstart-local"
+	quickstartTenantID   = "quickstart"
+)
+
+// QuickstartOptions configures the in-memory proxy quickstart profile.
+type QuickstartOptions struct {
+	OpenAIBaseURL string
+}
+
+// QuickstartConfig builds a minimal in-memory gateway config for local
+// OpenAI-compatible proxy quickstart mode. It is intentionally narrow and
+// should not become a general configuration system.
+func QuickstartConfig(opts QuickstartOptions) (*GatewayConfig, error) {
+	mode := ModeEnforce
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("TALON_QUICKSTART_MODE")), "shadow") {
+		mode = ModeShadow
+	}
+
+	baseURL := strings.TrimSpace(opts.OpenAIBaseURL)
+	if baseURL == "" {
+		baseURL = strings.TrimSpace(os.Getenv("TALON_QUICKSTART_OPENAI_BASE_URL"))
+	}
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+
+	provider := ProviderConfig{
+		Enabled:          true,
+		BaseURL:          baseURL,
+		UpstreamAuthMode: "client_bearer",
+		AllowedModels:    []string{"gpt-4o-mini", "gpt-4o"},
+	}
+
+	annotations := []string{"quickstart_mode"}
+	if parseQuickstartBoolEnv("TALON_QUICKSTART_ALLOW_ALL_MODELS") {
+		provider.AllowedModels = nil
+		annotations = append(annotations, "quickstart_model_allowlist_disabled")
+	}
+
+	requireCallerID := false
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: DefaultListenPrefix,
+		Mode:         mode,
+		Providers: map[string]ProviderConfig{
+			"openai": provider,
+		},
+		Callers: []CallerConfig{
+			{
+				Name:             quickstartCallerName,
+				TenantID:         quickstartTenantID,
+				Tags:             []string{"quickstart"},
+				AllowedProviders: []string{"openai"},
+			},
+		},
+		ServerDefaults: ServerDefaults{
+			DefaultPIIAction: "redact",
+			MaxDailyCost:     50,
+			MaxMonthlyCost:   500,
+			RequireCallerID:  &requireCallerID,
+			LogPrompts:       false,
+			LogResponses:     false,
+		},
+		RateLimits: RateLimitsConfig{
+			GlobalRequestsPerMin:    600,
+			PerCallerRequestsPerMin: 300,
+		},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    DefaultConnectTimeout,
+			RequestTimeout:    DefaultRequestTimeout,
+			StreamIdleTimeout: DefaultStreamIdleTimeout,
+		},
+	}
+	_ = annotations // annotations are recorded per-request by gateway evidence path.
+
+	if err := cfg.ApplyDefaults(); err != nil {
+		return nil, fmt.Errorf("applying quickstart defaults: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating quickstart config: %w", err)
+	}
+	return cfg, nil
+}
+
+func parseQuickstartBoolEnv(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/internal/gateway/quickstart_context.go
+++ b/internal/gateway/quickstart_context.go
@@ -1,0 +1,17 @@
+package gateway
+
+import "context"
+
+type quickstartCallerCtxKey struct{}
+
+// WithQuickstartCaller attaches a trusted synthetic quickstart caller to the request context.
+func WithQuickstartCaller(ctx context.Context, caller *CallerConfig) context.Context {
+	return context.WithValue(ctx, quickstartCallerCtxKey{}, caller)
+}
+
+// QuickstartCallerFromContext returns the synthetic quickstart caller when present.
+func QuickstartCallerFromContext(ctx context.Context) *CallerConfig {
+	v := ctx.Value(quickstartCallerCtxKey{})
+	caller, _ := v.(*CallerConfig)
+	return caller
+}

--- a/internal/gateway/quickstart_test.go
+++ b/internal/gateway/quickstart_test.go
@@ -65,6 +65,65 @@ func TestQuickstartConfig_EnvOverrides(t *testing.T) {
 	}
 }
 
+func TestQuickstartConfig_UnsafeListenOption(t *testing.T) {
+	cfg, err := QuickstartConfig(QuickstartOptions{UnsafeListen: true})
+	if err != nil {
+		t.Fatalf("QuickstartConfig() error = %v", err)
+	}
+	if !cfg.QuickstartUnsafeListen {
+		t.Fatal("expected QuickstartUnsafeListen=true to be propagated from options")
+	}
+
+	cfgOff, err := QuickstartConfig(QuickstartOptions{})
+	if err != nil {
+		t.Fatalf("QuickstartConfig() error = %v", err)
+	}
+	if cfgOff.QuickstartUnsafeListen {
+		t.Fatal("expected QuickstartUnsafeListen=false by default")
+	}
+
+	// The field must be ignored by YAML marshaling so it cannot be persisted or
+	// loaded via talon.config.yaml — this is a quickstart-only runtime signal.
+	if err := cfgOff.Validate(); err != nil {
+		t.Fatalf("validate default quickstart config: %v", err)
+	}
+}
+
+func TestGatewayAnnotations_UnsafeListenFromConfigNotEnv(t *testing.T) {
+	// Ensure the annotation comes from GatewayConfig.QuickstartUnsafeListen and
+	// not from any process environment variable, so quickstart does not need
+	// env mutation to surface the degraded bind.
+	t.Setenv("TALON_QUICKSTART_UNSAFE_LISTEN", "1")
+	cfg, err := QuickstartConfig(QuickstartOptions{})
+	if err != nil {
+		t.Fatalf("QuickstartConfig() error = %v", err)
+	}
+	gw := &Gateway{config: cfg}
+	ann := gatewayAnnotationsForEvidence(gw, &cfg.Callers[0])
+	for _, a := range ann {
+		if a == "quickstart_unsafe_listen" {
+			t.Fatalf("annotation should not be set from env var, got %v", ann)
+		}
+	}
+
+	cfg2, err := QuickstartConfig(QuickstartOptions{UnsafeListen: true})
+	if err != nil {
+		t.Fatalf("QuickstartConfig(UnsafeListen) error = %v", err)
+	}
+	gw2 := &Gateway{config: cfg2}
+	ann2 := gatewayAnnotationsForEvidence(gw2, &cfg2.Callers[0])
+	found := false
+	for _, a := range ann2 {
+		if a == "quickstart_unsafe_listen" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected quickstart_unsafe_listen annotation when config field is set, got %v", ann2)
+	}
+}
+
 func TestGatewayConfigValidate_UpstreamAuthMode(t *testing.T) {
 	cfg := &GatewayConfig{
 		ListenPrefix: "/v1/proxy",

--- a/internal/gateway/quickstart_test.go
+++ b/internal/gateway/quickstart_test.go
@@ -1,0 +1,93 @@
+package gateway
+
+import "testing"
+
+func TestQuickstartConfig_Defaults(t *testing.T) {
+	cfg, err := QuickstartConfig(QuickstartOptions{})
+	if err != nil {
+		t.Fatalf("QuickstartConfig() error = %v", err)
+	}
+
+	if !cfg.Enabled {
+		t.Fatal("expected enabled quickstart config")
+	}
+	if cfg.Mode != ModeEnforce {
+		t.Fatalf("mode = %q, want %q", cfg.Mode, ModeEnforce)
+	}
+	if cfg.ListenPrefix != "/v1/proxy" {
+		t.Fatalf("listen prefix = %q", cfg.ListenPrefix)
+	}
+	if cfg.ServerDefaults.DefaultPIIAction != "redact" {
+		t.Fatalf("default pii action = %q", cfg.ServerDefaults.DefaultPIIAction)
+	}
+	if cfg.ServerDefaults.CallerIDRequired() {
+		t.Fatal("quickstart should not require caller id")
+	}
+	if len(cfg.Callers) != 1 {
+		t.Fatalf("callers len = %d", len(cfg.Callers))
+	}
+	if cfg.Callers[0].Name != quickstartCallerName || cfg.Callers[0].TenantID != quickstartTenantID {
+		t.Fatalf("caller = %+v", cfg.Callers[0])
+	}
+	prov, ok := cfg.Provider("openai")
+	if !ok {
+		t.Fatal("openai provider missing")
+	}
+	if prov.UpstreamAuthMode != "client_bearer" {
+		t.Fatalf("upstream auth mode = %q", prov.UpstreamAuthMode)
+	}
+	if prov.BaseURL != "https://api.openai.com" {
+		t.Fatalf("base url = %q", prov.BaseURL)
+	}
+	if len(prov.AllowedModels) == 0 {
+		t.Fatal("expected non-empty default model allowlist")
+	}
+}
+
+func TestQuickstartConfig_EnvOverrides(t *testing.T) {
+	t.Setenv("TALON_QUICKSTART_MODE", "shadow")
+	t.Setenv("TALON_QUICKSTART_OPENAI_BASE_URL", "http://localhost:4000")
+	t.Setenv("TALON_QUICKSTART_ALLOW_ALL_MODELS", "true")
+
+	cfg, err := QuickstartConfig(QuickstartOptions{})
+	if err != nil {
+		t.Fatalf("QuickstartConfig() error = %v", err)
+	}
+	if cfg.Mode != ModeShadow {
+		t.Fatalf("mode = %q, want %q", cfg.Mode, ModeShadow)
+	}
+	prov, _ := cfg.Provider("openai")
+	if prov.BaseURL != "http://localhost:4000" {
+		t.Fatalf("base url = %q", prov.BaseURL)
+	}
+	if len(prov.AllowedModels) != 0 {
+		t.Fatalf("allowed models = %v, want empty when allow-all is set", prov.AllowedModels)
+	}
+}
+
+func TestGatewayConfigValidate_UpstreamAuthMode(t *testing.T) {
+	cfg := &GatewayConfig{
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", UpstreamAuthMode: "client_bearer"},
+		},
+		Callers: []CallerConfig{
+			{Name: "quickstart-local", TenantID: "quickstart"},
+		},
+		ServerDefaults: ServerDefaults{RequireCallerID: boolPtr(false)},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg.Providers["openai"] = ProviderConfig{Enabled: true, BaseURL: "https://api.openai.com", UpstreamAuthMode: "invalid"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for invalid upstream_auth_mode")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -575,7 +575,7 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		cw := csv.NewWriter(w)
-		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "cost", "model_used", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity"})
+		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "cost", "model_used", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity"})
 		for i := range records {
 			rec := &records[i]
 			pii := rec.PIIDetectedCSV()
@@ -586,7 +586,7 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 				strconv.FormatBool(rec.Allowed), strconv.FormatFloat(rec.Cost, 'f', -1, 64), rec.ModelUsed,
 				strconv.FormatInt(rec.DurationMS, 10), strconv.FormatBool(rec.HasError),
 				strconv.Itoa(rec.InputTier), strconv.Itoa(rec.OutputTier), pii, strconv.FormatBool(rec.PIIRedacted),
-				reasons, tools, rec.InputHash, rec.OutputHash, rec.PrimaryExplanationCode, rec.PrimaryExplanationReason, rec.PrimaryVersionIdentity,
+				reasons, tools, rec.InputHash, rec.OutputHash, rec.UpstreamAuthMode, rec.UpstreamKeySource, rec.UpstreamKeyFingerprint, rec.GatewayAnnotationsCSV(), rec.PrimaryExplanationCode, rec.PrimaryExplanationReason, rec.PrimaryVersionIdentity,
 			})
 		}
 		cw.Flush()

--- a/internal/server/quickstart_facade.go
+++ b/internal/server/quickstart_facade.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/dativo-io/talon/internal/gateway"
+)
+
+const quickstartPartialCompatibilityMsg = "partial OpenAI compatibility in quickstart mode; see docs"
+
+// NewQuickstartFacade builds a host-root OpenAI-compatible facade that forwards
+// supported routes to the gateway with a trusted synthetic quickstart caller.
+func NewQuickstartFacade(gw *gateway.Gateway, listenPrefix string, caller *gateway.CallerConfig) http.Handler {
+	return newQuickstartFacade(gw, listenPrefix, caller)
+}
+
+func newQuickstartFacade(gw *gateway.Gateway, listenPrefix string, caller *gateway.CallerConfig) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusNotFound, "not_found", quickstartPartialCompatibilityMsg)
+			return
+		}
+		switch r.URL.Path {
+		case "/v1/chat/completions":
+			proxyToGateway(gw, caller, listenPrefix, "/openai/v1/chat/completions", w, r)
+		case "/v1/responses":
+			proxyToGateway(gw, caller, listenPrefix, "/openai/v1/responses", w, r)
+		default:
+			if strings.HasPrefix(r.URL.Path, "/v1/") {
+				writeError(w, http.StatusNotFound, "not_found", quickstartPartialCompatibilityMsg)
+				return
+			}
+			writeError(w, http.StatusNotFound, "not_found", "not found")
+		}
+	})
+}
+
+func proxyToGateway(gw *gateway.Gateway, caller *gateway.CallerConfig, listenPrefix, pathSuffix string, w http.ResponseWriter, r *http.Request) {
+	clone := r.Clone(gateway.WithQuickstartCaller(r.Context(), caller))
+	prefix := strings.TrimSuffix(listenPrefix, "/")
+	clone.URL.Path = prefix + pathSuffix
+	if clone.URL.RawPath != "" {
+		clone.URL.RawPath = clone.URL.Path
+	}
+	gw.ServeHTTP(w, clone)
+}

--- a/internal/server/quickstart_facade_test.go
+++ b/internal/server/quickstart_facade_test.go
@@ -29,7 +29,7 @@ func TestQuickstartFacade_PathMappingAnd404(t *testing.T) {
 
 	facade, _ := newFacadeForTest(t, upstream.URL)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer sk-facade")
 	rec := httptest.NewRecorder()
@@ -41,7 +41,7 @@ func TestQuickstartFacade_PathMappingAnd404(t *testing.T) {
 		t.Fatalf("upstream path=%q", gotPath)
 	}
 
-	reqNotFound := httptest.NewRequest(http.MethodPost, "/v1/embeddings", nil)
+	reqNotFound := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/embeddings", nil)
 	recNotFound := httptest.NewRecorder()
 	facade.ServeHTTP(recNotFound, reqNotFound)
 	if recNotFound.Code != http.StatusNotFound {
@@ -66,7 +66,7 @@ func TestQuickstartFacade_ResponsesStoreInjection(t *testing.T) {
 	defer upstream.Close()
 
 	facade, _ := newFacadeForTest(t, upstream.URL)
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-4o-mini","input":"hello","store":false}`))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-4o-mini","input":"hello","store":false}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer sk-facade")
 	rec := httptest.NewRecorder()
@@ -89,7 +89,7 @@ func TestQuickstartFacade_InjectsSyntheticCaller(t *testing.T) {
 
 	facade, evStore := newFacadeForTest(t, upstream.URL)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer sk-facade")
 	rec := httptest.NewRecorder()

--- a/internal/server/quickstart_facade_test.go
+++ b/internal/server/quickstart_facade_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+func TestQuickstartFacade_PathMappingAnd404(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	facade, _ := newFacadeForTest(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-facade")
+	rec := httptest.NewRecorder()
+	facade.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("upstream path=%q", gotPath)
+	}
+
+	reqNotFound := httptest.NewRequest(http.MethodPost, "/v1/embeddings", nil)
+	recNotFound := httptest.NewRecorder()
+	facade.ServeHTTP(recNotFound, reqNotFound)
+	if recNotFound.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s", recNotFound.Code, recNotFound.Body.String())
+	}
+	if !strings.Contains(recNotFound.Body.String(), "partial OpenAI compatibility") {
+		t.Fatalf("expected partial compatibility message, got %s", recNotFound.Body.String())
+	}
+}
+
+func TestQuickstartFacade_ResponsesStoreInjection(t *testing.T) {
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	facade, _ := newFacadeForTest(t, upstream.URL)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-4o-mini","input":"hello","store":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-facade")
+	rec := httptest.NewRecorder()
+	facade.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(string(gotBody), `"store":true`) {
+		t.Fatalf("expected store:true injection, body=%s", string(gotBody))
+	}
+}
+
+func TestQuickstartFacade_InjectsSyntheticCaller(t *testing.T) {
+	var gotTenant string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	facade, evStore := newFacadeForTest(t, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-facade")
+	rec := httptest.NewRecorder()
+	facade.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	list, err := evStore.List(context.Background(), "quickstart", "quickstart-local", time.Time{}, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("list evidence: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("expected quickstart evidence record")
+	}
+	gotTenant = list[0].TenantID
+	if gotTenant != "quickstart" {
+		t.Fatalf("tenant=%q", gotTenant)
+	}
+}
+
+func newFacadeForTest(t *testing.T, upstreamURL string) (http.Handler, *evidence.Store) {
+	t.Helper()
+	cfg := &gateway.GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         gateway.ModeEnforce,
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: upstreamURL, UpstreamAuthMode: "client_bearer"},
+		},
+		Callers: []gateway.CallerConfig{
+			{Name: "quickstart-local", TenantID: "quickstart", Tags: []string{"quickstart"}, AllowedProviders: []string{"openai"}},
+		},
+		ServerDefaults: gateway.ServerDefaults{
+			DefaultPIIAction: "redact",
+			RequireCallerID:  boolPtr(false),
+		},
+		RateLimits: gateway.RateLimitsConfig{GlobalRequestsPerMin: 1000, PerCallerRequestsPerMin: 1000},
+		Timeouts: gateway.TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate cfg: %v", err)
+	}
+	dir := t.TempDir()
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	if err != nil {
+		t.Fatalf("evidence store: %v", err)
+	}
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	if err != nil {
+		t.Fatalf("secrets store: %v", err)
+	}
+	t.Cleanup(func() { _ = secStore.Close() })
+	gw, err := gateway.NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	if err != nil {
+		t.Fatalf("new gateway: %v", err)
+	}
+	return newQuickstartFacade(gw, "/v1/proxy", &cfg.Callers[0]), evStore
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,8 @@ type Server struct {
 	overrideStoreRef     *agent.OverrideStore
 	toolApprovalStoreRef *agent.ToolApprovalStore
 	graphEventsHandler   http.Handler
+	proxyQuickstart      http.Handler
+	quickstartEnabled    bool
 }
 
 // Option configures the Server.
@@ -129,6 +131,16 @@ func WithGateway(h http.Handler) Option {
 	return func(s *Server) { s.gateway = h }
 }
 
+// WithProxyQuickstart sets the OpenAI-compatible host-root quickstart proxy facade.
+func WithProxyQuickstart(h http.Handler) Option {
+	return func(s *Server) { s.proxyQuickstart = h }
+}
+
+// WithQuickstartEnabled toggles quickstart route behavior.
+func WithQuickstartEnabled(enabled bool) Option {
+	return func(s *Server) { s.quickstartEnabled = enabled }
+}
+
 // WithGatewayDashboard sets the embedded gateway dashboard HTML.
 func WithGatewayDashboard(html string) Option {
 	return func(s *Server) { s.gatewayDashboardHTML = html }
@@ -199,6 +211,11 @@ func (s *Server) Routes() http.Handler {
 			r.Handle("/*", s.gateway)
 		})
 	}
+	// OpenAI-compatible quickstart facade (must be above tenant middleware routes).
+	if s.quickstartEnabled && s.proxyQuickstart != nil {
+		r.Post("/v1/chat/completions", s.proxyQuickstart.ServeHTTP)
+		r.Post("/v1/responses", s.proxyQuickstart.ServeHTTP)
+	}
 
 	// Tenant-only API group
 	r.Group(func(r chi.Router) {
@@ -207,7 +224,11 @@ func (s *Server) Routes() http.Handler {
 
 		// Long-running: no request timeout so handler 30min deadline applies (middleware.Timeout would override).
 		r.Post("/v1/agents/run", s.handleAgentRun)
-		r.Post("/v1/chat/completions", s.handleChatCompletions)
+		if s.quickstartEnabled {
+			r.Post("/v1/agents/chat/completions", s.handleChatCompletions)
+		} else {
+			r.Post("/v1/chat/completions", s.handleChatCompletions)
+		}
 		if s.mcpServer != nil {
 			r.Post("/mcp", s.mcpServer.ServeHTTP)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -224,10 +224,17 @@ func (s *Server) Routes() http.Handler {
 
 		// Long-running: no request timeout so handler 30min deadline applies (middleware.Timeout would override).
 		r.Post("/v1/agents/run", s.handleAgentRun)
-		if s.quickstartEnabled {
-			r.Post("/v1/agents/chat/completions", s.handleChatCompletions)
-		} else {
+		switch {
+		case !s.quickstartEnabled:
 			r.Post("/v1/chat/completions", s.handleChatCompletions)
+		case len(s.tenantKeys) > 0:
+			// Quickstart mode: the relocated agent chat is only mounted when the
+			// operator has configured real tenant keys (e.g. via a gateway
+			// config). This preserves the strict "host-root facade only" boundary
+			// when quickstart is used without any tenant-auth setup: the
+			// relocated path returns 404 rather than becoming a dev-mode-open
+			// backdoor to tenant agent chat.
+			r.Post("/v1/agents/chat/completions", s.handleChatCompletions)
 		}
 		if s.mcpServer != nil {
 			r.Post("/mcp", s.mcpServer.ServeHTTP)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -217,6 +217,63 @@ func TestRouteAuthBehavior_GatewayMetricsRequireAdminKey(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestQuickstartRoutingEnabled(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+
+	quickstartCalled := false
+	qsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		quickstartCalled = true
+		writeJSON(w, http.StatusCreated, map[string]string{"ok": "quickstart"})
+	})
+	srv := NewServer(nil, nil, nil, engine, pol, "", nil, "", map[string]string{"tenant-secret": "default"},
+		WithProxyQuickstart(qsHandler),
+		WithQuickstartEnabled(true),
+	)
+	r := srv.Routes()
+
+	// Host-root chat route must be served by quickstart facade without tenant auth.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.True(t, quickstartCalled)
+
+	// Agent chat is relocated under /v1/agents/chat/completions in quickstart mode.
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/agents/chat/completions", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tenant-secret")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuickstartRoutingDisabledKeepsTenantChatPath(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+
+	srv := NewServer(nil, nil, nil, engine, pol, "", nil, "", map[string]string{"tenant-secret": "default"})
+	r := srv.Routes()
+
+	// Without auth, tenant middleware still protects /v1/chat/completions.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// With tenant auth, request reaches existing handler path.
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tenant-secret")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestStatusEndpoint(t *testing.T) {
 	pol := minimalPolicy()
 	engine, err := policy.NewEngine(context.Background(), pol)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -250,6 +250,43 @@ func TestQuickstartRoutingEnabled(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestQuickstartRoutingWithoutTenantKeysOmitsRelocatedPath(t *testing.T) {
+	// Quickstart without any configured tenant keys must not mount the
+	// relocated /v1/agents/chat/completions route. The host-root facade is
+	// still served, but tenant agent chat is absent (404) so quickstart stays
+	// a strict facade-only surface and does not become a dev-mode-open
+	// backdoor to tenant APIs.
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+
+	quickstartCalled := false
+	qsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		quickstartCalled = true
+		writeJSON(w, http.StatusCreated, map[string]string{"ok": "quickstart"})
+	})
+	srv := NewServer(nil, nil, nil, engine, pol, "", nil, "", map[string]string{},
+		WithProxyQuickstart(qsHandler),
+		WithQuickstartEnabled(true),
+	)
+	r := srv.Routes()
+
+	// Host-root facade still serves chat.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.True(t, quickstartCalled)
+
+	// Relocated tenant agent chat path is NOT mounted.
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/agents/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestQuickstartRoutingDisabledKeepsTenantChatPath(t *testing.T) {
 	pol := minimalPolicy()
 	engine, err := policy.NewEngine(context.Background(), pol)

--- a/tests/e2e/quickstart_test.go
+++ b/tests/e2e/quickstart_test.go
@@ -1,0 +1,212 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestE2E_Quickstart_OpenAISDKChatAndFallback(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := RunTalon(t, dir, nil, "init", "--scaffold", "--name", "quickstart-e2e")
+	if code != 0 {
+		t.Fatalf("talon init failed: %d", code)
+	}
+
+	var upstreamAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/chat/completions"):
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"quickstart ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/responses"):
+			_, _ = w.Write([]byte(`{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer upstream.Close()
+
+	port := freePort(t)
+	stdErr, stop := startQuickstartServe(t, dir, port, map[string]string{
+		"TALON_QUICKSTART_OPENAI_BASE_URL": strings.TrimSuffix(upstream.URL, "/"),
+		"OPENAI_API_KEY":                   "sk-env-fallback-e2e",
+	})
+	defer stop()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	cfg := openai.DefaultConfig("sk-client-e2e")
+	cfg.BaseURL = baseURL + "/v1"
+	client := openai.NewClientWithConfig(cfg)
+	resp, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Model: "gpt-4o-mini",
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateChatCompletion error: %v", err)
+	}
+	if got := resp.Choices[0].Message.Content; got != "quickstart ok" {
+		t.Fatalf("unexpected chat response: %q", got)
+	}
+	if upstreamAuth != "Bearer sk-client-e2e" {
+		t.Fatalf("expected upstream client bearer, got %q", upstreamAuth)
+	}
+
+	// No Authorization header: should fall back to OPENAI_API_KEY env.
+	rawResp, err := http.Post(baseURL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("raw fallback request error: %v", err)
+	}
+	defer rawResp.Body.Close()
+	if rawResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(rawResp.Body)
+		t.Fatalf("expected 200 for env fallback, got %d body=%s", rawResp.StatusCode, string(body))
+	}
+	if upstreamAuth != "Bearer sk-env-fallback-e2e" {
+		t.Fatalf("expected env fallback bearer upstream, got %q", upstreamAuth)
+	}
+
+	if !strings.Contains(stdErr.String(), "openai_base_url") {
+		t.Fatalf("expected startup quickstart banner in stderr, got: %s", stdErr.String())
+	}
+}
+
+func TestE2E_Quickstart_NoKeyReturns401_AndNonLoopbackDenied(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := RunTalon(t, dir, nil, "init", "--scaffold", "--name", "quickstart-e2e")
+	if code != 0 {
+		t.Fatalf("talon init failed: %d", code)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("upstream should not be called when no key is provided")
+	}))
+	defer upstream.Close()
+
+	port := freePort(t)
+	stdErr, stop := startQuickstartServe(t, dir, port, map[string]string{
+		"TALON_QUICKSTART_OPENAI_BASE_URL": strings.TrimSuffix(upstream.URL, "/"),
+	})
+	defer stop()
+	_ = stdErr
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	noKeyResp, err := http.Post(baseURL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	if err != nil {
+		t.Fatalf("no-key request error: %v", err)
+	}
+	defer noKeyResp.Body.Close()
+	if noKeyResp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(noKeyResp.Body)
+		t.Fatalf("expected 401 with no key, got %d body=%s", noKeyResp.StatusCode, string(body))
+	}
+
+	port2 := freePort(t)
+	exitCode, stderr := runCommand(t, dir, 5*time.Second, map[string]string{
+		"TALON_QUICKSTART_OPENAI_BASE_URL": strings.TrimSuffix(upstream.URL, "/"),
+	}, "serve", "--proxy-quickstart", "--host", "0.0.0.0", "--port", fmt.Sprintf("%d", port2))
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit for non-loopback quickstart without --unsafe-listen")
+	}
+	if !strings.Contains(stderr, "--unsafe-listen") {
+		t.Fatalf("expected unsafe-listen guidance in stderr, got: %s", stderr)
+	}
+}
+
+func startQuickstartServe(t *testing.T, dir string, port int, env map[string]string) (*bytes.Buffer, func()) {
+	t.Helper()
+	args := []string{"serve", "--proxy-quickstart", "--port", fmt.Sprintf("%d", port)}
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"TALON_DATA_DIR="+dir,
+		"TALON_SECRETS_KEY="+testSecretsKey,
+		"TALON_SIGNING_KEY="+testSigningKey,
+	)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start quickstart serve: %v", err)
+	}
+	waitForHealth(t, fmt.Sprintf("http://127.0.0.1:%d/health", port), 10*time.Second, &stderr)
+	stop := func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}
+	return &stderr, stop
+}
+
+func waitForHealth(t *testing.T, url string, timeout time.Duration, stderr *bytes.Buffer) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("serve not healthy within %s; stderr:\n%s", timeout, stderr.String())
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func runCommand(t *testing.T, dir string, timeout time.Duration, env map[string]string, args ...string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"TALON_DATA_DIR="+dir,
+		"TALON_SECRETS_KEY="+testSecretsKey,
+		"TALON_SIGNING_KEY="+testSigningKey,
+	)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return 0, stderr.String()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), stderr.String()
+	}
+	return -1, stderr.String()
+}

--- a/tests/integration/quickstart_test.go
+++ b/tests/integration/quickstart_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/server"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+func TestQuickstartFacadeGatewayIntegration_BYOKAndFallback(t *testing.T) {
+	t.Run("client bearer", func(t *testing.T) {
+		var upstreamAuth string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			upstreamAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+		}))
+		defer upstream.Close()
+
+		api, evStore := newQuickstartIntegrationServer(t, upstream.URL)
+		defer api.Close()
+
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, api.URL+"/v1/chat/completions",
+			strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer sk-client-integration")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "Bearer sk-client-integration", upstreamAuth)
+
+		list, err := evStore.List(context.Background(), "quickstart", "quickstart-local", time.Time{}, time.Time{}, 10)
+		require.NoError(t, err)
+		require.NotEmpty(t, list)
+		require.Equal(t, "client_bearer", list[0].UpstreamAuthMode)
+		require.Equal(t, "client", list[0].UpstreamKeySource)
+		require.NotEmpty(t, list[0].UpstreamKeyFingerprint)
+	})
+
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("OPENAI_API_KEY", "sk-env-integration")
+		var upstreamAuth string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			upstreamAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+		}))
+		defer upstream.Close()
+
+		api, evStore := newQuickstartIntegrationServer(t, upstream.URL)
+		defer api.Close()
+		resp, err := http.Post(api.URL+"/v1/chat/completions", "application/json",
+			strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "Bearer sk-env-integration", upstreamAuth)
+
+		list, err := evStore.List(context.Background(), "quickstart", "quickstart-local", time.Time{}, time.Time{}, 10)
+		require.NoError(t, err)
+		require.NotEmpty(t, list)
+		require.Equal(t, "env", list[0].UpstreamKeySource)
+	})
+}
+
+func TestQuickstartFacadeGatewayIntegration_401AndRedactAndResponses(t *testing.T) {
+	var capturedBodies [][]byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBodies = append(capturedBodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/responses"):
+			_, _ = w.Write([]byte(`{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+		default:
+			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`))
+		}
+	}))
+	defer upstream.Close()
+
+	api, _ := newQuickstartIntegrationServer(t, upstream.URL)
+	defer api.Close()
+
+	// No key anywhere => 401.
+	resp401, err := http.Post(api.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`))
+	require.NoError(t, err)
+	defer resp401.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp401.StatusCode)
+
+	// PII redaction by default.
+	reqPII, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, api.URL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"IBAN DE89370400440532013000"}]}`))
+	reqPII.Header.Set("Content-Type", "application/json")
+	reqPII.Header.Set("Authorization", "Bearer sk-redact")
+	respPII, err := http.DefaultClient.Do(reqPII)
+	require.NoError(t, err)
+	defer respPII.Body.Close()
+	require.Equal(t, http.StatusOK, respPII.StatusCode)
+	require.NotEmpty(t, capturedBodies)
+	require.NotContains(t, string(capturedBodies[len(capturedBodies)-1]), "DE89370400440532013000")
+
+	// Responses API should force store:true.
+	reqResp, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, api.URL+"/v1/responses",
+		strings.NewReader(`{"model":"gpt-4o-mini","input":"hello","store":false}`))
+	reqResp.Header.Set("Content-Type", "application/json")
+	reqResp.Header.Set("Authorization", "Bearer sk-responses")
+	resp1, err := http.DefaultClient.Do(reqResp)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+	require.Contains(t, string(capturedBodies[len(capturedBodies)-1]), `"store":true`)
+
+	reqResp2, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, api.URL+"/v1/responses",
+		strings.NewReader(`{"model":"gpt-4o-mini","input":"follow up","previous_response_id":"resp_1"}`))
+	reqResp2.Header.Set("Content-Type", "application/json")
+	reqResp2.Header.Set("Authorization", "Bearer sk-responses")
+	resp2, err := http.DefaultClient.Do(reqResp2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	require.Contains(t, string(capturedBodies[len(capturedBodies)-1]), `"store":true`)
+}
+
+func newQuickstartIntegrationServer(t *testing.T, upstreamURL string) (*httptest.Server, *evidence.Store) {
+	t.Helper()
+
+	quickstartCfg, err := gateway.QuickstartConfig(gateway.QuickstartOptions{OpenAIBaseURL: upstreamURL})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	evStore, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "secrets.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+
+	pol := &policy.Policy{Agent: policy.AgentConfig{Name: "integration", Version: "1.0"}, Policies: policy.PoliciesConfig{}}
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	gwPolicy, err := policy.NewGatewayEngine(context.Background())
+	require.NoError(t, err)
+	gw, err := gateway.NewGateway(quickstartCfg, classifier.MustNewScanner(), evStore, secStore, gwPolicy, nil)
+	require.NoError(t, err)
+
+	opts := []server.Option{
+		server.WithGateway(gw),
+		server.WithQuickstartEnabled(true),
+		server.WithProxyQuickstart(server.NewQuickstartFacade(gw, quickstartCfg.ListenPrefix, &quickstartCfg.Callers[0])),
+	}
+	srv := server.NewServer(nil, evStore, nil, engine, pol, "", secStore, "", map[string]string{"quickstart": "quickstart"}, opts...)
+	api := httptest.NewServer(srv.Routes())
+	t.Cleanup(api.Close)
+	return api, evStore
+}

--- a/tests/smoke_sections/31_quickstart.sh
+++ b/tests/smoke_sections/31_quickstart.sh
@@ -85,15 +85,16 @@ PY
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}')"
   assert_pass "quickstart no-key request returns 401" test "$code_no_key" = "401"
 
-  # Quickstart must NOT inject a synthetic tenant key. The relocated agent chat
-  # route exists but stays behind normal tenant-auth middleware, so an
-  # unauthenticated request produces 401 (not 404 from chi, not 400 from the
-  # handler). This asserts both: the route is mounted AND quickstart does not
-  # silently unlock tenant APIs.
+  # Quickstart must NOT inject a synthetic tenant key, and when no tenant keys
+  # are configured the relocated agent chat route is not mounted at all. This
+  # keeps quickstart a strict host-root facade: without an operator-provided
+  # tenant auth setup, there is no dev-mode-open backdoor to tenant agent chat.
+  # A 404 here proves both: the synthetic tenant key is gone AND the relocated
+  # route is gated on real tenant-key configuration.
   local code_relocated
   code_relocated="$(curl -s -o /tmp/talon_qs_agent.json -w '%{http_code}' -X POST "${quick_base}/v1/agents/chat/completions" \
-    -H "Content-Type: application/json" -d '{')"
-  assert_pass "agent chat relocated path is mounted but requires real tenant auth" test "$code_relocated" = "401"
+    -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}')"
+  assert_pass "agent chat relocated path is gated on real tenant-key configuration" test "$code_relocated" = "404"
 
   local code_emb
   code_emb="$(curl -s -o /tmp/talon_qs_emb.json -w '%{http_code}' -X POST "${quick_base}/v1/embeddings" \

--- a/tests/smoke_sections/31_quickstart.sh
+++ b/tests/smoke_sections/31_quickstart.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Smoke test section: 31_quickstart
+# Sourced by tests/smoke_test.sh — do not run directly.
+
+test_section_31_quickstart() {
+  local section="31_quickstart"
+  local quick_port="8081"
+  local quick_base="http://127.0.0.1:${quick_port}"
+  local dir; dir="$(setup_section_dir "$section")"
+  cd "$dir" || exit 1
+
+  if ! wait_port_free "$quick_port" 60 5; then
+    log_failure "quickstart section could not acquire port ${quick_port}" "port remained busy"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+
+  run_talon init --scaffold --name smoke-quickstart &>/dev/null; true
+
+  local mock_port="18081"
+  local mock_log="$dir/quickstart_mock.log"
+  local mock_pid=""
+  cat > "$dir/mock_openai.py" <<'PY'
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        if self.path.startswith("/v1/chat/completions"):
+            payload = {"id":"chatcmpl_quick","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"quickstart smoke ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}
+        elif self.path.startswith("/v1/responses"):
+            payload = {"id":"resp_quick","output":[{"type":"message","content":[{"type":"output_text","text":"quickstart smoke response"}]}],"usage":{"input_tokens":1,"output_tokens":1}}
+        else:
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode("utf-8"))
+    def log_message(self, format, *args):
+        return
+
+HTTPServer(("127.0.0.1", 18081), Handler).serve_forever()
+PY
+  python3 "$dir/mock_openai.py" >"$mock_log" 2>&1 &
+  mock_pid=$!
+
+  local qs_log="$dir/quickstart_serve.log"
+  OPENAI_API_KEY="" TALON_QUICKSTART_OPENAI_BASE_URL="http://127.0.0.1:${mock_port}" \
+    run_talon serve --proxy-quickstart --port "$quick_port" >"$qs_log" 2>&1 &
+  TALON_GATEWAY_PID=$!
+  if ! smoke_wait_health "$quick_base" 10 1; then
+    log_failure "quickstart server did not start" "url=${quick_base}/health"
+    dump_diag_file "quickstart serve log" "$qs_log"
+    kill "$mock_pid" 2>/dev/null || true
+    wait "$mock_pid" 2>/dev/null || true
+    kill "$TALON_GATEWAY_PID" 2>/dev/null || true
+    wait "$TALON_GATEWAY_PID" 2>/dev/null || true
+    TALON_GATEWAY_PID=""
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+
+  assert_pass "quickstart banner includes base URL" grep -q "openai_base_url" "$qs_log"
+  assert_pass "quickstart banner includes pii default redact" grep -q "pii_default" "$qs_log"
+
+  local code_chat
+  code_chat="$(curl -s -o /tmp/talon_qs_chat.json -w '%{http_code}' -X POST "${quick_base}/v1/chat/completions" \
+    -H "Authorization: Bearer sk-smoke-test" -H "Content-Type: application/json" \
+    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}')"
+  assert_pass "quickstart chat with BYOK returns 200" test "$code_chat" = "200"
+
+  local code_resp
+  code_resp="$(curl -s -o /tmp/talon_qs_resp.json -w '%{http_code}' -X POST "${quick_base}/v1/responses" \
+    -H "Authorization: Bearer sk-smoke-test" -H "Content-Type: application/json" \
+    -d '{"model":"gpt-4o-mini","input":"hello"}')"
+  assert_pass "quickstart responses returns 200" test "$code_resp" = "200"
+
+  local code_no_key
+  code_no_key="$(curl -s -o /tmp/talon_qs_no_key.json -w '%{http_code}' -X POST "${quick_base}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}')"
+  assert_pass "quickstart no-key request returns 401" test "$code_no_key" = "401"
+
+  local code_relocated
+  code_relocated="$(curl -s -o /tmp/talon_qs_agent.json -w '%{http_code}' -X POST "${quick_base}/v1/agents/chat/completions" \
+    -H "Authorization: Bearer quickstart" -H "Content-Type: application/json" -d '{')"
+  assert_pass "agent chat relocated path is active in quickstart mode" test "$code_relocated" = "400"
+
+  local code_emb
+  code_emb="$(curl -s -o /tmp/talon_qs_emb.json -w '%{http_code}' -X POST "${quick_base}/v1/embeddings" \
+    -H "Authorization: Bearer sk-smoke-test" -H "Content-Type: application/json" -d '{"model":"x","input":"x"}')"
+  assert_pass "unsupported embeddings path returns 404 in quickstart mode" test "$code_emb" = "404"
+
+  assert_fail "proxy quickstart is mutually exclusive with gateway flag" run_talon serve --proxy-quickstart --gateway --port 18090
+  assert_fail "proxy quickstart non-loopback host fails without unsafe-listen" run_talon serve --proxy-quickstart --host 0.0.0.0 --port 18091
+
+  kill "$TALON_GATEWAY_PID" 2>/dev/null || true
+  wait "$TALON_GATEWAY_PID" 2>/dev/null || true
+  TALON_GATEWAY_PID=""
+  kill "$mock_pid" 2>/dev/null || true
+  wait "$mock_pid" 2>/dev/null || true
+  rm -f /tmp/talon_qs_chat.json /tmp/talon_qs_resp.json /tmp/talon_qs_no_key.json /tmp/talon_qs_agent.json /tmp/talon_qs_emb.json
+  cd "$REPO_ROOT" || true
+}
+

--- a/tests/smoke_sections/31_quickstart.sh
+++ b/tests/smoke_sections/31_quickstart.sh
@@ -85,10 +85,15 @@ PY
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}')"
   assert_pass "quickstart no-key request returns 401" test "$code_no_key" = "401"
 
+  # Quickstart must NOT inject a synthetic tenant key. The relocated agent chat
+  # route exists but stays behind normal tenant-auth middleware, so an
+  # unauthenticated request produces 401 (not 404 from chi, not 400 from the
+  # handler). This asserts both: the route is mounted AND quickstart does not
+  # silently unlock tenant APIs.
   local code_relocated
   code_relocated="$(curl -s -o /tmp/talon_qs_agent.json -w '%{http_code}' -X POST "${quick_base}/v1/agents/chat/completions" \
-    -H "Authorization: Bearer quickstart" -H "Content-Type: application/json" -d '{')"
-  assert_pass "agent chat relocated path is active in quickstart mode" test "$code_relocated" = "400"
+    -H "Content-Type: application/json" -d '{')"
+  assert_pass "agent chat relocated path is mounted but requires real tenant auth" test "$code_relocated" = "401"
 
   local code_emb
   code_emb="$(curl -s -o /tmp/talon_qs_emb.json -w '%{http_code}' -X POST "${quick_base}/v1/embeddings" \

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -41,7 +41,7 @@
 #   14 deny | 15 multi-tenant | 16 shadow | 17 config-provider | 18 compliance-export |
 #   19 CI/CD | 20 edge-cases | 21 doctor/report/enforce | 22 cache | 23 dashboard-metrics | 24 plan-dispatch | 25 sessions |
 #   26 pii-enrichment | 27 runtime-governance | 28 control-plane | 29 consistency |
-#   30 graph-events.
+#   30 graph-events | 31 quickstart.
 #
 # QA notes (from brief):
 # - Section 16 (Shadow mode): Evidence shadow signal is in shadow_violations or
@@ -459,7 +459,7 @@ for _section_file in \
   20_edge_cases.sh 21_doctor_report_enforce.sh 22_cache.sh \
   23_dashboard_metrics.sh 24_plan_dispatch.sh 25_sessions.sh \
   26_pii_enrichment.sh 27_runtime_governance.sh 28_control_plane.sh \
-  29_consistency.sh 30_graph_events.sh; do
+  29_consistency.sh 30_graph_events.sh 31_quickstart.sh; do
   # shellcheck source=/dev/null
   source "${SMOKE_SECTIONS_DIR}/${_section_file}"
 done
@@ -542,6 +542,7 @@ main() {
   run_section "27_runtime_governance" test_section_27_runtime_governance
   run_section "28_control_plane" test_section_28_control_plane
   run_section "30_graph_events" test_section_30_graph_events
+  run_section "31_quickstart" test_section_31_quickstart
 
   # Section 29: Consistency checks — cross-command flow verification
   run_section "29_consistency" test_section_29_consistency


### PR DESCRIPTION
## Summary
- add `talon serve --proxy-quickstart` with host-root OpenAI-compatible facade for `POST /v1/chat/completions` and `POST /v1/responses`
- implement BYOK upstream auth via provider `upstream_auth_mode=client_bearer` with `OPENAI_API_KEY` fallback and additive gateway evidence fields
- add full coverage across unit, integration, e2e, and smoke tests, plus tutorial/reference/ADR/README/changelog updates

## Test plan
- [x] `go test ./internal/gateway ./internal/server ./internal/cmd ./internal/evidence`
- [x] `go test ./tests/integration -tags integration -run Quickstart`
- [x] `go test ./tests/e2e -tags e2e -run Quickstart`
- [x] `bash -n tests/smoke_sections/31_quickstart.sh tests/smoke_test.sh`
- [x] `make lint`
- [x] `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new dev-mode request path and upstream authentication behavior (client bearer forwarding / env fallback) inside the gateway and `serve` routing, which could regress proxy auth or routing if misconfigured despite keeping the default `secret` provider mode unchanged.
> 
> **Overview**
> Adds a dev/local **OpenAI-compatible quickstart proxy mode** via `talon serve --proxy-quickstart`, exposing host-root `POST /v1/chat/completions` and `POST /v1/responses` through a new server-side facade that injects a synthetic `quickstart` tenant/caller while keeping governance (policy/PII/evidence) active.
> 
> Extends the gateway with provider-level `upstream_auth_mode` (`secret` default, `client_bearer` for quickstart) to forward the caller bearer token upstream, fall back to `OPENAI_API_KEY`, and return an explicit `401` when no upstream key is available; quickstart is enforced as mutually exclusive with `--gateway/--gateway-config` and defaults to loopback binding unless `--unsafe-listen`.
> 
> Evidence/export surfaces are updated with additive upstream-auth metadata (`upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`) plus constrained `gateway_annotations`, and the PR adds broad unit/integration/e2e/smoke coverage and documentation/ADR updates for the quickstart workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b4dbd4de072746d26acebba1a1a155dcc5e096. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->