### PR TITLE
docs(quickstart): improve drop-in onboarding and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ One URL change. PII scan, tool block, tamper-proof record. No code rewrites.
 
 Talon is a single Go binary in front of OpenAI, Anthropic, and Bedrock. Point your app at `localhost:8080/v1/proxy/openai` instead of `api.openai.com` — same API, same response. Every call is policy-checked, PII-scanned, cost-tracked, and logged. Works with Slack bots, OpenClaw, CoPaw, and other OpenAI-compatible clients. Built for EU teams that need strong governance signals (GDPR, NIS2, DORA, EU AI Act); Apache 2.0.
 
+### Zero-config drop-in (dev)
+
+```bash
+talon serve --proxy-quickstart --port 8080
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_API_KEY=sk-...
+```
+
+Use your normal OpenAI SDK and keep the same request shape. See [Tutorial: OpenAI proxy quickstart](docs/tutorials/proxy-quickstart.md).
+
 ---
 
 
@@ -314,6 +324,7 @@ talon serve --proxy-quickstart --port 8080
 - Supported host-root endpoints: `POST /v1/chat/completions`, `POST /v1/responses`.
 - Upstream auth precedence: client bearer token, then `OPENAI_API_KEY`, then `401`.
 - Governance remains active (policy, PII scan/redaction, evidence) with `enforce` default.
+- Default quickstart model allowlist is `gpt-4o-mini`, `gpt-4o`; set `TALON_QUICKSTART_ALLOW_ALL_MODELS=1` for local-only broad model testing.
 
 Use loopback by default; non-loopback binds require `--unsafe-listen`.
 For production gateway behavior, keep using `--gateway` + `talon.config.yaml`.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -37,6 +37,8 @@ talon run "Your query here"   # Uses agent name from policy when --agent omitted
 # Server (API + dashboard + optional gateway/proxy)
 export TALON_ADMIN_KEY="replace-with-strong-admin-key"
 talon serve --port 8080
+# OpenAI-compatible local drop-in (dev): OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+talon serve --proxy-quickstart --port 8080
 # With LLM gateway: talon serve --gateway --gateway-config examples/gateway/talon.config.gateway.yaml
 # With MCP proxy:   talon serve --proxy-config path/to/proxy.yaml
 ```

--- a/docs/guides/add-talon-to-existing-app.md
+++ b/docs/guides/add-talon-to-existing-app.md
@@ -8,15 +8,28 @@ Get Talon intercepting your real traffic in a few minutes. You have an app (Pyth
 - Your real OpenAI API key.
 - An existing app or script that calls OpenAI (any language or curl).
 
-## Steps
+## Choose your track
 
-### 0. Fastest path (dev/local quickstart)
+### Track A: dev-mode quickstart (2 minutes)
 
-If you want the quickest OpenAI-compatible local wiring first, start with:
+Use this when you want a local OpenAI-compatible drop-in with no gateway YAML:
 
-- [Tutorial: OpenAI proxy quickstart](../tutorials/proxy-quickstart.md)
+```bash
+talon serve --proxy-quickstart --port 8080
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_API_KEY=sk-your-key
+```
 
-Then return here to move from quickstart into full gateway config for production.
+Run one request from your existing app, then verify with:
+
+```bash
+talon audit list --tenant quickstart --limit 5
+```
+
+For full walk-through and troubleshooting, use [Tutorial: OpenAI proxy quickstart](../tutorials/proxy-quickstart.md).
+When you are ready for production caller separation and vaulted upstream keys, continue with Track B.
+
+### Track B: production gateway with YAML
 
 ### 1. Create a project directory and gateway config
 

--- a/docs/reference/proxy-quickstart.md
+++ b/docs/reference/proxy-quickstart.md
@@ -32,7 +32,7 @@ Unsupported paths return `404` with a partial-compatibility message.
 |---|---|
 | `OPENAI_API_KEY` | Upstream fallback when caller bearer is absent. |
 | `TALON_QUICKSTART_OPENAI_BASE_URL` | Upstream OpenAI-compatible base URL. |
-| `TALON_QUICKSTART_MODE` | `shadow` to opt into shadow mode (default `enforce`). |
+| `TALON_QUICKSTART_MODE` | Set to `shadow` to opt into shadow mode; any other value uses default `enforce`. |
 | `TALON_QUICKSTART_ALLOW_ALL_MODELS` | `1/true` clears quickstart model allowlist. |
 
 ## Auth model
@@ -47,7 +47,13 @@ Quickstart uses upstream BYOK as a scoped exception:
 
 - Enforcement mode: `enforce`.
 - PII default action: `redact`.
+- Default model allowlist: `gpt-4o-mini`, `gpt-4o` (use `TALON_QUICKSTART_ALLOW_ALL_MODELS=1` to disable for local-only experiments).
 - Evidence includes `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and optional `gateway_annotations` (e.g. `quickstart_mode`, `quickstart_shadow_mode`, `quickstart_model_allowlist_disabled`, `quickstart_unsafe_listen`).
+
+## Common errors
+
+- `401` with `no upstream credential: set OPENAI_API_KEY or send Authorization: Bearer ...` means Talon received neither a client bearer key nor a usable `OPENAI_API_KEY`.
+- `404` with `partial OpenAI compatibility in quickstart mode; see docs` means the requested `/v1/*` path is outside quickstart scope.
 
 ## Tenant auth boundary
 

--- a/docs/tutorials/proxy-quickstart.md
+++ b/docs/tutorials/proxy-quickstart.md
@@ -20,6 +20,8 @@ export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
 export OPENAI_API_KEY=sk-your-key
 ```
 
+If your SDK already appends `/v1`, set `OPENAI_BASE_URL=http://127.0.0.1:8080` instead.
+
 Your app keeps using the OpenAI SDK. Talon is now in the request path.
 
 ## 3) Test with curl
@@ -51,6 +53,7 @@ Look for:
 - `tenant_id=quickstart`
 - `agent_id=quickstart-local`
 - `upstream_auth_mode=client_bearer`
+- `upstream_key_source=openai_api_key_env` when no bearer was sent and env fallback was used
 
 ## Behavior notes
 
@@ -58,5 +61,12 @@ Look for:
 - PII default action is `redact`.
 - Key source precedence: client bearer > `OPENAI_API_KEY` > 401.
 - Partial OpenAI compatibility: only chat completions and responses create endpoints are supported at host root.
+
+## Troubleshooting
+
+- `401` with `no upstream credential: set OPENAI_API_KEY or send Authorization: Bearer ...` means Talon did not receive any usable upstream key. Send a bearer token from the client or set `OPENAI_API_KEY` in the Talon process.
+- Model denied in policy means quickstart's default allowlist blocked it. Default models are `gpt-4o-mini` and `gpt-4o`. For local-only testing, set `TALON_QUICKSTART_ALLOW_ALL_MODELS=1`.
+- `404` for `/v1/embeddings` or `GET /v1/responses/{id}` is expected in v1 quickstart scope. See [Reference: proxy quickstart](../reference/proxy-quickstart.md#scope).
+- Startup bind error on non-loopback host requires `--unsafe-listen` in quickstart mode. This is recorded in evidence via the `quickstart_unsafe_listen` annotation and is intended for local/dev exceptions.
 
 For production gateway rollout, use `--gateway` and [gateway guides](../guides/add-talon-to-existing-app.md).


### PR DESCRIPTION
## Summary
- improve quickstart discoverability in `README.md` by adding a zero-config drop-in block near the top and documenting default quickstart model allowlist behavior
- update `docs/QUICKSTART.md` and `docs/guides/add-talon-to-existing-app.md` to present `--proxy-quickstart` as a first-class local/dev path before production gateway YAML setup
- expand proxy quickstart reference/tutorial docs with base URL compatibility guidance, common runtime error messages, and troubleshooting notes tied to current gateway behavior

## Test plan
- [x] `make test-all`
- [x] `make lint`
- [x] `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust quickstart positioning and add troubleshooting guidance, with no runtime or API behavior changes.
> 
> **Overview**
> Highlights `--proxy-quickstart` earlier as a **zero-config dev drop-in**, including a copy-paste `OPENAI_BASE_URL` setup block in `README.md` and `docs/QUICKSTART.md`.
> 
> Reworks the “add Talon to an existing app” guide into two tracks (dev quickstart vs production gateway YAML) and expands quickstart reference/tutorial docs with **base URL compatibility notes**, default model allowlist behavior (`gpt-4o-mini`, `gpt-4o` + `TALON_QUICKSTART_ALLOW_ALL_MODELS`), and concrete `401/404` troubleshooting messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faffa68e3acb52131f64bab0a915930469874f1f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->