### PR TITLE
docs: add newcomer contributor paths to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,24 @@ This documentation is organised around the [Diátaxis](https://diataxis.fr/) fra
 - [60-Second Demo](tutorials/quickstart-demo.md) — Docker Compose demo: `docker compose up`, send a curl request, see evidence immediately.
 - [QUICKSTART.md](QUICKSTART.md) — Short entry point for native Talon (requires Go).
 
+
+
+## New contributer? Start here.
+
+Choose your path based on what you want to do:
+
+1. **Want to fix a small bug or improve documents?**
+   - Start: [Good first issues](https://github.com/dativo-io/talon/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+   - Then:  [CONTRIBUTING.md](../CONTRIBUTING.md)
+   
+2. **Want to add a feature or integration?**
+   - Start: [Help wanted issues](https://github.com/dativo-io/talon/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+   - Then: [Architecture: MCP proxy](ARCHITECTURE_MCP_PROXY.md) for context
+   
+3. **Want to understand the codebase before adding any changes?**
+   - Start: [What Talon does to your request](explanation/what-talon-does-to-your-request.md)
+   - Then: [ROADMAP.md](../ROADMAP.md) to see what's planned
+  
 ## Start Here (jobs-to-be-done)
 
 Choose the shortest path for your situation:


### PR DESCRIPTION
Adds a "New Contributor? Start here." section to the docs index with 3 jobs-to-be-done paths for newcomers, addressing issue #53

## Description
<!-- Describe your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] `make check` passes (tests + lint + vet)
- [ ] Contribution guidelines in `CONTRIBUTING.md` followed
- [ ] AI usage, if any, follows `AI_ASSISTANCE.md`
- [ ] Tests added/updated (target: 65% overall coverage, goal 70%)
- [ ] Coverage ≥65% for changed packages
- [ ] Docs updated (if user-facing)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Conventional commit messages used
- [ ] OTel spans on significant functions
- [ ] Evidence generated for auditable operations
- [ ] No secrets hardcoded

## Related Issues
<!-- Link related issues: Fixes #123 -->

## Testing
<!-- How did you test this? -->

## Release Note Draft (for user-facing changes)
<!-- Keep this concise and concrete -->
- Problem solved:
- Who should care:
- How to verify:
- Upgrade/migration impact:

## AI Assistance Disclosure
<!-- If AI tooling was used, summarize where and how you validated outputs -->
- AI tooling used: none / <tool names>
- Human verification performed: