### PR TITLE
docs: add compliance wording checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,11 @@ Thanks for helping improve Talon.
 
 - Keep behavior changes accompanied by tests.
 - Prefer clear, verifiable claims in docs (commands, source links, or test references).
-- For compliance wording, use "supports controls" language; do not claim guaranteed compliance.
+- For compliance wording, use "supports controls" language; do not claim guaranteed compliance:
+  - Do: "Talon helps teams collect audit evidence for GDPR review."
+  - Do: "This policy supports SOC 2 change-management controls."
+  - Do not: "Talon makes your app GDPR compliant."
+  - Do not: "Enabling this setting guarantees SOC 2 compliance."
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Adds a small compliance wording checklist to `CONTRIBUTING.md` for documentation contributors.

The checklist keeps the existing guidance to:

- use "supports controls" wording;
- avoid guaranteed-compliance claims;
- include concrete good/bad phrasing examples.

## Verification

```text
git diff --cached --check
git ls-files --eol -- CONTRIBUTING.md
rg -n "supports controls|guaranteed compliance|guarantees SOC 2|GDPR compliant|compliance wording" CONTRIBUTING.md
go test ./...
```

Notes:

- whitespace check passed;
- `CONTRIBUTING.md` remains line-ending clean in the staged diff;
- `go test ./...` could not complete in my fresh local clone because multiple Go module downloads from `proxy.golang.org` timed out. This PR is docs-only and does not change Go code, tests, or module files.

Closes #49.
