### PR TITLE
feat(runtime): unify evidence-first events pipeline (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **change(serve): `--gateway-config` exclusivity check uses explicit flag set.** `--proxy-quickstart` is rejected alongside `--gateway` or any explicitly passed `--gateway-config`, detected via `cobra.Flags().Changed` rather than the default string value.
 - **change(gateway): quickstart `unsafe-listen` signal threaded via config.** The `quickstart_unsafe_listen` evidence annotation is driven by `GatewayConfig.QuickstartUnsafeListen`, populated from `--unsafe-listen` through `QuickstartOptions`, instead of a process environment variable.
 
+### Fixed
+
+- **fix(session): auto-migrate legacy `sessions` schema on startup.** Session store initialization now adds missing `max_cost` and `reasoning` columns when older SQLite tables are detected, preventing run/session creation failures on upgraded installs. Verify with `go test ./internal/session -run MigratesLegacySessionsTable`.
+- **fix(agent): preserve audit trail on evidence write failures.** Runner paths that previously ignored evidence/step write errors now log structured failures (`correlation_id`, `tenant_id`, `agent_id`) so silent audit-loss conditions are observable during denied, dry-run, cached, and tool-step flows.
+- **fix(memory): redact low-risk PII before memory governance checks.** Memory observations now sanitize `person`/`location` entities before validation, allowing safe useful memories while sensitive PII still fails closed under governance policy.
+- **fix(events): expand stream reliability telemetry.** Event stream handling now increments disconnect and backlog-drop counters (in addition to gap/replay signals) and exposes them in status output for faster operator diagnosis.
+
 ### Release Note Quality Bar
 
 For user-facing entries, include:

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -576,7 +576,7 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResponse, error)
 			Str("agent_id", req.AgentName).
 			Strs("pii_detected", effectivePIINames).
 			Msg("block_on_pii: input contains PII, run denied")
-		_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+		if _, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 			CorrelationID:   correlationID,
 			TenantID:        req.TenantID,
 			AgentID:         req.AgentName,
@@ -602,7 +602,13 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResponse, error)
 				PolicyRef:       explanationPolicyRef(pol.VersionTag),
 				VersionIdentity: pol.VersionTag,
 			}},
-		})
+		}); err != nil {
+			log.Error().Err(err).
+				Str("correlation_id", correlationID).
+				Str("tenant_id", req.TenantID).
+				Str("agent_id", req.AgentName).
+				Msg("evidence_write_failed_block_on_pii")
+		}
 		return &RunResponse{PolicyAllow: false, DenyReason: "Input contains PII (policy: block_on_pii)", SessionID: req.SessionID}, nil
 	}
 
@@ -737,7 +743,7 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResponse, error)
 	if req.DryRun {
 		// Record evidence for dry-run so audit trail includes policy-check attempts (no LLM call).
 		duration := time.Since(startTime)
-		_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+		if _, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 			CorrelationID:   correlationID,
 			TenantID:        req.TenantID,
 			AgentID:         req.AgentName,
@@ -757,7 +763,13 @@ func (r *Runner) Run(ctx context.Context, req *RunRequest) (*RunResponse, error)
 			AgentVerified:    req.AgentVerified,
 			Compliance:       complianceInfo,
 			ExplanationFacts: buildPolicyDecisionFacts(decision, explanation.StagePolicyEvaluation),
-		})
+		}); err != nil {
+			log.Error().Err(err).
+				Str("correlation_id", correlationID).
+				Str("tenant_id", req.TenantID).
+				Str("agent_id", req.AgentName).
+				Msg("evidence_write_failed_dry_run")
+		}
 		resp := &RunResponse{PolicyAllow: true, PIIDetected: effectivePIINames, InputTier: effectiveTier, SessionID: req.SessionID}
 		if attachmentScan != nil {
 			resp.AttachmentInjectionsDetected = attachmentScan.InjectionsDetected
@@ -979,7 +991,7 @@ func (r *Runner) recordPolicyDenial(ctx context.Context, span trace.Span, correl
 		Str("deny_reason", decision.Action).
 		Msg("policy_denied")
 
-	_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+	if _, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 		CorrelationID:   correlationID,
 		TenantID:        req.TenantID,
 		AgentID:         req.AgentName,
@@ -1000,7 +1012,13 @@ func (r *Runner) recordPolicyDenial(ctx context.Context, span trace.Span, correl
 		ExplanationFacts: buildPolicyDecisionFacts(decision, explanation.StagePolicyEvaluation),
 		Status:           string(RunStatusDenied),
 		FailureReason:    string(FailurePolicyDeny),
-	})
+	}); err != nil {
+		log.Error().Err(err).
+			Str("correlation_id", correlationID).
+			Str("tenant_id", req.TenantID).
+			Str("agent_id", req.AgentName).
+			Msg("evidence_write_failed_policy_denial")
+	}
 }
 
 // setRunState updates the RunRegistry state for a run if the registry is available.
@@ -1033,7 +1051,7 @@ func (r *Runner) recordEarlyTermination(ctx context.Context, correlationID strin
 		status = string(RunStatusDenied)
 		failureReason = string(FailurePolicyDeny)
 	}
-	_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+	if _, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 		CorrelationID:   correlationID,
 		TenantID:        req.TenantID,
 		AgentID:         req.AgentName,
@@ -1049,7 +1067,13 @@ func (r *Runner) recordEarlyTermination(ctx context.Context, correlationID strin
 		ExplanationFacts: explanation.BuildLegacyFacts(false, "early_termination", []string{reason}, explanation.StagePreExecution, "", ""),
 		Status:           status,
 		FailureReason:    failureReason,
-	})
+	}); err != nil {
+		log.Error().Err(err).
+			Str("correlation_id", correlationID).
+			Str("tenant_id", req.TenantID).
+			Str("agent_id", req.AgentName).
+			Msg("evidence_write_failed_early_termination")
+	}
 }
 
 // executeLLMPipeline runs steps 5-9: route provider, call LLM, classify output, generate evidence.
@@ -1183,7 +1207,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 								Str("correlation_id", correlationID).
 								Strs("pii_detected", cacheOutputPIINames).
 								Msg("block_on_output_pii: cached response contains PII, run denied")
-							_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+							if _, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 								CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 								InvocationType: req.InvocationType, RequestSourceID: req.InvocationType,
 								PolicyDecision: evidence.PolicyDecision{
@@ -1202,7 +1226,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 									PolicyRef:       explanationPolicyRef(pol.VersionTag),
 									VersionIdentity: pol.VersionTag,
 								}},
-							})
+							}); err != nil {
+								log.Error().Err(err).
+									Str("correlation_id", correlationID).
+									Str("tenant_id", req.TenantID).
+									Str("agent_id", req.AgentName).
+									Msg("evidence_write_failed_cache_output_pii_block")
+							}
 							return &RunResponse{PolicyAllow: false, DenyReason: "Cached output contains PII (policy: block_on_pii + output_scan)", SessionID: req.SessionID}, nil
 						}
 						if dc.ShouldRedactOutput() {
@@ -1212,7 +1242,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					}
 
 					duration := time.Since(startTime)
-					cacheEv, _ := r.evidence.Generate(ctx, evidence.GenerateParams{
+					cacheEv, err := r.evidence.Generate(ctx, evidence.GenerateParams{
 						CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 						InvocationType: req.InvocationType, RequestSourceID: req.InvocationType,
 						PolicyDecision: policyDec,
@@ -1236,6 +1266,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 							VersionIdentity: pol.VersionTag,
 						}},
 					})
+					if err != nil {
+						log.Error().Err(err).
+							Str("correlation_id", correlationID).
+							Str("tenant_id", req.TenantID).
+							Str("agent_id", req.AgentName).
+							Msg("evidence_write_failed_cache_hit")
+					}
 					resp := &RunResponse{
 						Response:    cacheResponseText,
 						Cost:        0,
@@ -1332,7 +1369,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				}
 				r.setRunState(correlationID, RunStatusFailed, llmFailReason)
 				duration := time.Since(startTime)
-				_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+				if _, evErr := r.evidence.Generate(ctx, evidence.GenerateParams{
 					CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 					InvocationType: req.InvocationType, RequestSourceID: req.InvocationType,
 					PolicyDecision: policyDec, Classification: evidence.Classification{InputTier: tier, PIIDetected: piiNames},
@@ -1345,7 +1382,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					RoutingDecision: evRouting,
 					Status:          string(RunStatusFailed),
 					FailureReason:   string(llmFailReason),
-				})
+				}); evErr != nil {
+					log.Error().Err(evErr).
+						Str("correlation_id", correlationID).
+						Str("tenant_id", req.TenantID).
+						Str("agent_id", req.AgentName).
+						Msg("evidence_write_failed_agentic_llm_error")
+				}
 				return nil, fmt.Errorf("calling LLM: %w", err)
 			}
 			iterDuration := time.Since(iterStart).Milliseconds()
@@ -1359,13 +1402,19 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			})
 
 			// Step-level evidence: one record per LLM call in the loop
-			_, _ = r.evidence.GenerateStep(ctx, evidence.StepParams{
+			if _, stepErr := r.evidence.GenerateStep(ctx, evidence.StepParams{
 				CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 				StepIndex: stepIndex, Type: "llm_call",
 				InputSummary:  stepInputSummary,
 				OutputSummary: evidence.TruncateForSummary(resp.Content, 500),
 				DurationMS:    iterDuration, Cost: iterCost,
-			})
+			}); stepErr != nil {
+				log.Error().Err(stepErr).
+					Str("correlation_id", correlationID).
+					Str("tenant_id", req.TenantID).
+					Str("agent_id", req.AgentName).
+					Msg("evidence_step_write_failed_agentic_llm")
+			}
 			stepIndex++
 
 			llmResp = resp
@@ -1511,10 +1560,22 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					if pendingStep != nil {
 						pendingStep.ToolName = toolName
 						if executed {
-							_ = r.evidence.CompleteStep(ctx, pendingStep,
-								evidence.TruncateForSummary(resultContent, 500), toolDuration, 0)
+							if stepErr := r.evidence.CompleteStep(ctx, pendingStep,
+								evidence.TruncateForSummary(resultContent, 500), toolDuration, 0); stepErr != nil {
+								log.Error().Err(stepErr).
+									Str("correlation_id", correlationID).
+									Str("tenant_id", req.TenantID).
+									Str("agent_id", req.AgentName).
+									Msg("evidence_pending_step_complete_failed")
+							}
 						} else {
-							_ = r.evidence.FailStep(ctx, pendingStep, resultContent, toolDuration)
+							if stepErr := r.evidence.FailStep(ctx, pendingStep, resultContent, toolDuration); stepErr != nil {
+								log.Error().Err(stepErr).
+									Str("correlation_id", correlationID).
+									Str("tenant_id", req.TenantID).
+									Str("agent_id", req.AgentName).
+									Msg("evidence_pending_step_fail_failed")
+							}
 						}
 					} else {
 						// Fallback: pending step write failed; ensure one record for this tool call.
@@ -1524,12 +1585,18 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 							stepStatus = "failed"
 							stepError = resultContent
 						}
-						_, _ = r.evidence.GenerateStep(ctx, evidence.StepParams{
+						if _, stepErr := r.evidence.GenerateStep(ctx, evidence.StepParams{
 							CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 							StepIndex: stepIndex, Type: "tool_call", ToolName: toolName,
 							OutputSummary: evidence.TruncateForSummary(resultContent, 500),
 							DurationMS:    toolDuration, Cost: 0, Status: stepStatus, Error: stepError,
-						})
+						}); stepErr != nil {
+							log.Error().Err(stepErr).
+								Str("correlation_id", correlationID).
+								Str("tenant_id", req.TenantID).
+								Str("agent_id", req.AgentName).
+								Msg("evidence_step_write_failed_tool_fallback")
+						}
 					}
 					stepIndex++
 					_, _ = r.fireHook(ctx, HookPostTool, req.TenantID, req.AgentName, correlationID, map[string]interface{}{
@@ -1543,12 +1610,18 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					"result_summary": evidence.TruncateForSummary(resultContent, 200),
 				})
 				if atLimit {
-					_, _ = r.evidence.GenerateStep(ctx, evidence.StepParams{
+					if _, stepErr := r.evidence.GenerateStep(ctx, evidence.StepParams{
 						CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 						StepIndex: stepIndex, Type: "tool_call", ToolName: toolName,
 						OutputSummary: "max_tool_calls_per_run limit reached",
 						DurationMS:    0, Cost: 0,
-					})
+					}); stepErr != nil {
+						log.Error().Err(stepErr).
+							Str("correlation_id", correlationID).
+							Str("tenant_id", req.TenantID).
+							Str("agent_id", req.AgentName).
+							Msg("evidence_step_write_failed_tool_limit")
+					}
 					stepIndex++
 				}
 				sandboxedResult := fmt.Sprintf("[TOOL-RESULT:%s]\n%s\n[/TOOL-RESULT]", tc.Name, resultContent)
@@ -1576,7 +1649,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			}
 			r.setRunState(correlationID, RunStatusFailed, singleFailReason)
 			duration := time.Since(startTime)
-			_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+			if _, evErr := r.evidence.Generate(ctx, evidence.GenerateParams{
 				CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 				InvocationType: req.InvocationType, RequestSourceID: req.InvocationType,
 				PolicyDecision: policyDec, Classification: evidence.Classification{InputTier: tier, PIIDetected: piiNames},
@@ -1587,7 +1660,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				RoutingDecision:         evRouting,
 				Status:                  string(RunStatusFailed),
 				FailureReason:           string(singleFailReason),
-			})
+			}); evErr != nil {
+				log.Error().Err(evErr).
+					Str("correlation_id", correlationID).
+					Str("tenant_id", req.TenantID).
+					Str("agent_id", req.AgentName).
+					Msg("evidence_write_failed_single_llm_error")
+			}
 			return nil, fmt.Errorf("calling LLM: %w", err)
 		}
 		llmResp = resp
@@ -1607,7 +1686,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			r.setRunState(correlationID, RunStatusBlocked, FailureCostExceeded)
 			span.SetAttributes(attribute.Bool("cost.exceeded_per_request", true))
 			duration := time.Since(startTime)
-			_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+			if _, evErr := r.evidence.Generate(ctx, evidence.GenerateParams{
 				CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 				InvocationType: req.InvocationType, RequestSourceID: req.InvocationType,
 				PolicyDecision: policyDec, Classification: evidence.Classification{InputTier: tier, PIIDetected: piiNames},
@@ -1618,7 +1697,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				ObservationModeOverride: observationOverride, RoutingDecision: evRouting,
 				Cost: cost, Tokens: evidence.TokenUsage{Input: totalInputTokens, Output: totalOutputTokens},
 				Status: string(RunStatusBlocked), FailureReason: string(FailureCostExceeded),
-			})
+			}); evErr != nil {
+				log.Error().Err(evErr).
+					Str("correlation_id", correlationID).
+					Str("tenant_id", req.TenantID).
+					Str("agent_id", req.AgentName).
+					Msg("evidence_write_failed_single_cost_exceeded")
+			}
 			return &RunResponse{
 				PolicyAllow: false,
 				DenyReason:  fmt.Sprintf("per-request cost exceeded (%.4f > %.4f)", cost, pol.Policies.CostLimits.PerRequest),
@@ -1631,13 +1716,19 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 		_, _ = r.fireHook(ctx, HookPostLLM, req.TenantID, req.AgentName, correlationID, map[string]interface{}{
 			"model": model, "cost_estimate": cost, "input_tokens": resp.InputTokens, "output_tokens": resp.OutputTokens,
 		})
-		_, _ = r.evidence.GenerateStep(ctx, evidence.StepParams{
+		if _, stepErr := r.evidence.GenerateStep(ctx, evidence.StepParams{
 			CorrelationID: correlationID, TenantID: req.TenantID, AgentID: req.AgentName,
 			StepIndex: 0, Type: "llm_call",
 			InputSummary:  stepInputSummary,
 			OutputSummary: evidence.TruncateForSummary(resp.Content, 500),
 			DurationMS:    singleDuration, Cost: cost,
-		})
+		}); stepErr != nil {
+			log.Error().Err(stepErr).
+				Str("correlation_id", correlationID).
+				Str("tenant_id", req.TenantID).
+				Str("agent_id", req.AgentName).
+				Msg("evidence_step_write_failed_single_llm")
+		}
 		// Store in semantic cache when allowed (PII-scrubbed response)
 		if cacheAllowStore && r.cacheStore != nil && r.cacheScrubber != nil && r.cacheEmbedder != nil && r.cacheConfig != nil {
 			scrubbed := r.cacheScrubber.Scrub(ctx, resp.Content)
@@ -1676,7 +1767,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				Str("agent_id", req.AgentName).
 				Strs("pii_detected", outputEntityNames).
 				Msg("block_on_output_pii: output contains PII, run denied")
-			_, _ = r.evidence.Generate(ctx, evidence.GenerateParams{
+			if _, evErr := r.evidence.Generate(ctx, evidence.GenerateParams{
 				CorrelationID:   correlationID,
 				TenantID:        req.TenantID,
 				AgentID:         req.AgentName,
@@ -1708,7 +1799,13 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					PolicyRef:       explanationPolicyRef(pol.VersionTag),
 					VersionIdentity: pol.VersionTag,
 				}},
-			})
+			}); evErr != nil {
+				log.Error().Err(evErr).
+					Str("correlation_id", correlationID).
+					Str("tenant_id", req.TenantID).
+					Str("agent_id", req.AgentName).
+					Msg("evidence_write_failed_output_pii_block")
+			}
 			return &RunResponse{PolicyAllow: false, DenyReason: "Output contains PII (policy: block_on_pii + output_scan)", SessionID: req.SessionID}, nil
 		}
 		if dc.ShouldRedactOutput() {
@@ -2682,6 +2779,11 @@ func (r *Runner) writeMemoryObservation(ctx context.Context, req *RunRequest, po
 		SourceEvidenceID: ev.ID,
 		InputHash:        ev.AuditTrail.InputHash,
 	}
+	// Governance rejects memory entries containing any PII. Sanitize only low-risk
+	// entities (person/location) so general observations can be stored while
+	// sensitive PII (email/iban/phone/etc.) still fails closed in governance.
+	observation.Title = sanitizeMemoryObservationText(ctx, r.classifier, observation.Title)
+	observation.Content = sanitizeMemoryObservationText(ctx, r.classifier, observation.Content)
 
 	if err := r.governance.ValidateWrite(ctx, &observation, pol, policyEval); err != nil {
 		log.Warn().Err(err).
@@ -2969,6 +3071,55 @@ func sourceTypeFromInvocation(invocationType string) string {
 		return memory.SourceWebhook
 	default:
 		return memory.SourceAgentRun
+	}
+}
+
+func sanitizeMemoryObservationText(ctx context.Context, scanner *classifier.Scanner, text string) string {
+	if scanner == nil || text == "" {
+		return text
+	}
+	class := scanner.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), text)
+	if !class.HasPII {
+		return text
+	}
+
+	type replacement struct {
+		start int
+		end   int
+		kind  string
+	}
+	var replacements []replacement
+	for i := range class.Entities {
+		e := class.Entities[i]
+		if !isLowRiskMemoryEntityType(e.Type) {
+			continue
+		}
+		start := e.Position
+		end := e.Position + len(e.Value)
+		if start < 0 || end <= start || end > len(text) {
+			continue
+		}
+		replacements = append(replacements, replacement{start: start, end: end, kind: e.Type})
+	}
+	if len(replacements) == 0 {
+		return text
+	}
+
+	sort.Slice(replacements, func(i, j int) bool { return replacements[i].start > replacements[j].start })
+	out := []byte(text)
+	for i := range replacements {
+		placeholder := "[" + strings.ToUpper(replacements[i].kind) + "]"
+		out = append(out[:replacements[i].start], append([]byte(placeholder), out[replacements[i].end:]...)...)
+	}
+	return string(out)
+}
+
+func isLowRiskMemoryEntityType(entityType string) bool {
+	switch strings.ToLower(entityType) {
+	case "person", "location":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -3105,11 +3105,28 @@ func sanitizeMemoryObservationText(ctx context.Context, scanner *classifier.Scan
 		return text
 	}
 
-	sort.Slice(replacements, func(i, j int) bool { return replacements[i].start > replacements[j].start })
+	sort.Slice(replacements, func(i, j int) bool { return replacements[i].start < replacements[j].start })
+	var merged []replacement
+	for _, r := range replacements {
+		if len(merged) == 0 {
+			merged = append(merged, r)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if r.start < last.end {
+			if r.end > last.end {
+				last.end = r.end
+			}
+		} else {
+			merged = append(merged, r)
+		}
+	}
+
+	// Replace back-to-front so byte offsets stay valid.
 	out := []byte(text)
-	for i := range replacements {
-		placeholder := "[" + strings.ToUpper(replacements[i].kind) + "]"
-		out = append(out[:replacements[i].start], append([]byte(placeholder), out[replacements[i].end:]...)...)
+	for i := len(merged) - 1; i >= 0; i-- {
+		placeholder := "[" + strings.ToUpper(merged[i].kind) + "]"
+		out = append(out[:merged[i].start], append([]byte(placeholder), out[merged[i].end:]...)...)
 	}
 	return string(out)
 }

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -547,6 +547,56 @@ func TestSafePolicyPathUnder(t *testing.T) {
 	}
 }
 
+func TestWriteMemoryObservation_RedactsPIIBeforeGovernance(t *testing.T) {
+	ctx := context.Background()
+	memStore, err := memory.NewStore(filepath.Join(t.TempDir(), "memory.db"))
+	require.NoError(t, err)
+	defer memStore.Close()
+
+	cls := classifier.MustNewScanner()
+	gov := memory.NewGovernance(memStore, cls)
+	r := &Runner{
+		memory:     memStore,
+		governance: gov,
+		classifier: cls,
+	}
+
+	pol := &policy.Policy{
+		Memory: &policy.MemoryConfig{
+			Enabled:           true,
+			Mode:              "active",
+			AllowedCategories: []string{memory.CategoryDomainKnowledge},
+		},
+		Policies: policy.PoliciesConfig{},
+	}
+	req := &RunRequest{
+		TenantID:       "default",
+		AgentName:      "agent-1",
+		InvocationType: "manual",
+	}
+	resp := &RunResponse{
+		Response:   "Our headquarters is Berlin.",
+		ModelUsed:  "gpt-4o-mini",
+		Cost:       0.001,
+		DurationMS: 100,
+	}
+	ev := &evidence.Evidence{
+		ID: "req_test",
+		AuditTrail: evidence.AuditTrail{
+			InputHash: "hash_test",
+		},
+	}
+
+	r.writeMemoryObservation(ctx, req, pol, nil, resp, ev)
+
+	entries, err := memStore.List(ctx, "default", "agent-1", "", 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "memory write should be persisted after redaction")
+	assert.NotContains(t, entries[0].Title, "Berlin")
+	assert.NotContains(t, entries[0].Content, "Berlin")
+	assert.Contains(t, entries[0].Content, "[LOCATION]")
+}
+
 // TestRun_acceptsAbsolutePolicyPathOutsidePolicyDir ensures that when PolicyPath is an
 // absolute path (e.g. from --policy or serve config / Docker volume), the runner accepts it
 // even though it is outside policyDir. This fixes serve chat completions and talon run --policy

--- a/internal/cmd/init_wizard.go
+++ b/internal/cmd/init_wizard.go
@@ -809,7 +809,11 @@ func applyFeatureToAgent(pol *policy.Policy, featureID string) error {
 		}
 		pol.Policies.DataClassification.InputScan = true
 		pol.Policies.DataClassification.OutputScan = true
-		pol.Policies.DataClassification.RedactPII = true
+		pol.Policies.DataClassification.RedactPII = false
+		redactInput := true
+		redactOutput := false
+		pol.Policies.DataClassification.RedactInput = &redactInput
+		pol.Policies.DataClassification.RedactOutput = &redactOutput
 	case "audit":
 		if pol.Audit == nil {
 			pol.Audit = &policy.AuditConfig{}

--- a/internal/cmd/init_wizard_test.go
+++ b/internal/cmd/init_wizard_test.go
@@ -102,6 +102,28 @@ func TestBuildConfigs_AllFeatures_BothFilesValid(t *testing.T) {
 	assert.Contains(t, agentCfg.Compliance.Frameworks, "dora")
 }
 
+func TestBuildConfigs_PIIFeature_RedactsInputNotOutputByDefault(t *testing.T) {
+	state := WizardState{
+		AgentName:       "pii-agent",
+		WorkloadType:    "agent",
+		ProviderID:      "openai",
+		DataSovereignty: "global",
+		EnabledFeatures: []string{"pii"},
+	}
+	agentCfg, _, err := BuildConfigs(state)
+	require.NoError(t, err)
+	require.NotNil(t, agentCfg.Policies.DataClassification)
+	dc := agentCfg.Policies.DataClassification
+
+	assert.True(t, dc.InputScan)
+	assert.True(t, dc.OutputScan)
+	assert.False(t, dc.RedactPII, "wizard should use granular input/output redaction defaults")
+	require.NotNil(t, dc.RedactInput)
+	require.NotNil(t, dc.RedactOutput)
+	assert.True(t, *dc.RedactInput, "input redaction should be enabled by default")
+	assert.False(t, *dc.RedactOutput, "output redaction should be disabled by default")
+}
+
 func TestBuildConfigs_NoFeatures_BothFilesValid(t *testing.T) {
 	state := WizardState{
 		AgentName:       "minimal-agent",

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -525,12 +525,10 @@ type metricsRecorderAdapter struct {
 }
 
 func (a *metricsRecorderAdapter) RecordGatewayEvent(event interface{}) {
-	m, ok := event.(map[string]interface{})
+	e, ok := metrics.MapToGatewayEvent(event)
 	if !ok {
 		return
 	}
-
-	e := metrics.GatewayEventFromMap(m)
 	a.collector.Record(e)
 }
 

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -34,7 +34,8 @@ func TestMapToGatewayEvent_MapsAllFields(t *testing.T) {
 		"cache_hit":          true,
 	}
 
-	got := metrics.GatewayEventFromMap(event)
+	got, ok := metrics.MapToGatewayEvent(event)
+	assert.True(t, ok)
 
 	assert.Equal(t, now, got.Timestamp)
 	assert.Equal(t, "openclaw-main", got.CallerID)
@@ -59,7 +60,8 @@ func TestMapToGatewayEvent_MapsAllFields(t *testing.T) {
 }
 
 func TestMapToGatewayEvent_DefaultTimestampWhenMissing(t *testing.T) {
-	got := metrics.GatewayEventFromMap(map[string]interface{}{"caller_id": "test"})
+	got, ok := metrics.MapToGatewayEvent(map[string]interface{}{"caller_id": "test"})
+	assert.True(t, ok)
 
 	assert.False(t, got.Timestamp.IsZero(), "timestamp should be populated when absent")
 	assert.Equal(t, "test", got.CallerID)

--- a/internal/health/events_stream.go
+++ b/internal/health/events_stream.go
@@ -6,6 +6,8 @@ var (
 	activeEventStreams int64
 	eventStreamGaps    int64
 	eventReplayMisses  int64
+	eventDisconnects   int64
+	eventBacklogDrops  int64
 )
 
 // IncActiveEventStreams increments active SSE stream count.
@@ -43,9 +45,31 @@ func EventReplayMisses() int64 {
 	return atomic.LoadInt64(&eventReplayMisses)
 }
 
+// IncEventStreamDisconnect increments count of disconnected SSE clients.
+func IncEventStreamDisconnect() {
+	atomic.AddInt64(&eventDisconnects, 1)
+}
+
+// EventStreamDisconnects returns total disconnected SSE clients.
+func EventStreamDisconnects() int64 {
+	return atomic.LoadInt64(&eventDisconnects)
+}
+
+// IncEventBacklogDrop increments count of replay/backlog overflows.
+func IncEventBacklogDrop() {
+	atomic.AddInt64(&eventBacklogDrops, 1)
+}
+
+// EventBacklogDrops returns total replay/backlog overflows.
+func EventBacklogDrops() int64 {
+	return atomic.LoadInt64(&eventBacklogDrops)
+}
+
 // ResetEventStreamStatsForTest resets stream counters used in tests.
 func ResetEventStreamStatsForTest() {
 	atomic.StoreInt64(&activeEventStreams, 0)
 	atomic.StoreInt64(&eventStreamGaps, 0)
 	atomic.StoreInt64(&eventReplayMisses, 0)
+	atomic.StoreInt64(&eventDisconnects, 0)
+	atomic.StoreInt64(&eventBacklogDrops, 0)
 }

--- a/internal/metrics/backfill.go
+++ b/internal/metrics/backfill.go
@@ -28,7 +28,10 @@ func (c *Collector) BackfillFromStore(ctx context.Context, store EvidenceLister)
 	defer c.mu.Unlock()
 
 	for i := range records {
-		ev := GatewayEventFromEvidence(&records[i])
+		ev, ok := MapToGatewayEvent(&records[i])
+		if !ok {
+			continue
+		}
 		c.processEvent(ev)
 	}
 

--- a/internal/metrics/events_integration_test.go
+++ b/internal/metrics/events_integration_test.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+func TestEventsIntegration_BackfillMatchesEvidenceProjection(t *testing.T) {
+	ctx := context.Background()
+	store, err := evidence.NewStore(filepath.Join(t.TempDir(), "evidence.db"), "test-hmac-key-that-is-at-least-32-bytes-long")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Now().UTC()
+	records := []evidence.Evidence{
+		{
+			ID:              "ev-int-1",
+			CorrelationID:   "corr-int-1",
+			Timestamp:       now.Add(-3 * time.Minute),
+			TenantID:        "acme",
+			AgentID:         "agent-a",
+			RequestSourceID: "caller-a",
+			InvocationType:  "gateway",
+			PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+			Classification:  evidence.Classification{PIIDetected: []string{"email"}},
+			Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.01, DurationMS: 120},
+		},
+		{
+			ID:              "ev-int-2",
+			CorrelationID:   "corr-int-2",
+			Timestamp:       now.Add(-2 * time.Minute),
+			TenantID:        "acme",
+			AgentID:         "agent-a",
+			RequestSourceID: "caller-a",
+			InvocationType:  "gateway",
+			PolicyDecision:  evidence.PolicyDecision{Allowed: false, Reasons: []string{"policy deny"}},
+			Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.00, DurationMS: 90},
+		},
+		{
+			ID:              "ev-int-3",
+			CorrelationID:   "corr-int-3",
+			Timestamp:       now.Add(-1 * time.Minute),
+			TenantID:        "acme",
+			AgentID:         "agent-b",
+			RequestSourceID: "caller-b",
+			InvocationType:  "gateway",
+			PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+			Execution:       evidence.Execution{ModelUsed: "claude-3", Cost: 0.02, DurationMS: 180, Error: "upstream timeout"},
+		},
+	}
+	for i := range records {
+		require.NoError(t, store.Store(ctx, &records[i]))
+	}
+
+	list, err := store.List(ctx, "acme", "", time.Time{}, now.Add(time.Minute), 100)
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+
+	projected := SnapshotFromEvidenceRecords(list, now)
+
+	collector := NewCollector("enforce", store, WithTenantID("acme"))
+	t.Cleanup(collector.Close)
+	require.NoError(t, collector.BackfillFromStore(ctx, store))
+	snap := collector.Snapshot(ctx)
+
+	assert.Equal(t, projected.Summary.TotalRequests, snap.Summary.TotalRequests)
+	assert.Equal(t, projected.Summary.BlockedRequests, snap.Summary.BlockedRequests)
+	assert.Equal(t, projected.Summary.TotalFailed, snap.Summary.TotalFailed)
+	assert.InDelta(t, projected.Summary.TotalCostEUR, snap.Summary.TotalCostEUR, 0.0001)
+	assert.Equal(t, projected.Summary.PIIDetections, snap.Summary.PIIDetections)
+}

--- a/internal/metrics/parity_test.go
+++ b/internal/metrics/parity_test.go
@@ -265,3 +265,41 @@ func TestDashboardCountMayLeadPersistedEvidence(t *testing.T) {
 	require.GreaterOrEqual(t, drift, 0)
 	require.LessOrEqual(t, drift, 5)
 }
+
+func TestParity_EvidenceWriteMatchesMappedEventProjection(t *testing.T) {
+	dir := t.TempDir()
+	store, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), "test-hmac-key-that-is-at-least-32-bytes-long")
+	require.NoError(t, err)
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	ev := evidence.Evidence{
+		ID:              "ev-proj-1",
+		CorrelationID:   "corr-proj-1",
+		Timestamp:       now,
+		TenantID:        "default",
+		AgentID:         "agent-proj",
+		RequestSourceID: "caller-proj",
+		InvocationType:  "gateway",
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+		Classification:  evidence.Classification{PIIDetected: []string{"email"}},
+		Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.07, DurationMS: 210},
+	}
+	require.NoError(t, store.Store(ctx, &ev))
+
+	records, err := store.List(ctx, "default", "", time.Time{}, now.Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	fromEvidence := GatewayEventFromEvidence(&records[0])
+	fromMap, ok := MapToGatewayEvent(&records[0])
+	require.True(t, ok)
+
+	assert.Equal(t, fromEvidence.CallerID, fromMap.CallerID)
+	assert.Equal(t, fromEvidence.Model, fromMap.Model)
+	assert.Equal(t, fromEvidence.Blocked, fromMap.Blocked)
+	assert.Equal(t, fromEvidence.CostEUR, fromMap.CostEUR)
+	assert.Equal(t, fromEvidence.LatencyMS, fromMap.LatencyMS)
+	assert.Equal(t, fromEvidence.PIIDetected, fromMap.PIIDetected)
+}

--- a/internal/metrics/projection.go
+++ b/internal/metrics/projection.go
@@ -7,19 +7,59 @@ import (
 	"github.com/dativo-io/talon/internal/evidence"
 )
 
+// MapToGatewayEvent converts supported event payloads into a GatewayEvent.
+func MapToGatewayEvent(input interface{}) (GatewayEvent, bool) {
+	return mapToGatewayEvent(input)
+}
+
 // GatewayEventFromMap converts the legacy gateway event map into a typed event.
 func GatewayEventFromMap(m map[string]interface{}) GatewayEvent {
-	e := GatewayEvent{}
-	mapTimestampField(m, &e)
-	mapStringFields(m, &e)
-	mapSliceFields(m, &e)
-	mapNumericFields(m, &e)
-	mapBoolFields(m, &e)
+	e, ok := mapToGatewayEvent(m)
+	if !ok {
+		return GatewayEvent{}
+	}
 	return e
 }
 
 // GatewayEventFromEvidence creates the unified event projection from evidence.
 func GatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
+	ev, ok := mapToGatewayEvent(e)
+	if !ok {
+		return GatewayEvent{}
+	}
+	return ev
+}
+
+func mapToGatewayEvent(input interface{}) (GatewayEvent, bool) {
+	switch v := input.(type) {
+	case GatewayEvent:
+		return v, true
+	case *GatewayEvent:
+		if v == nil {
+			return GatewayEvent{}, false
+		}
+		return *v, true
+	case map[string]interface{}:
+		ev := GatewayEvent{}
+		mapTimestampField(v, &ev)
+		mapStringFields(v, &ev)
+		mapSliceFields(v, &ev)
+		mapNumericFields(v, &ev)
+		mapBoolFields(v, &ev)
+		return ev, true
+	case evidence.Evidence:
+		return gatewayEventFromEvidence(&v), true
+	case *evidence.Evidence:
+		if v == nil {
+			return GatewayEvent{}, false
+		}
+		return gatewayEventFromEvidence(v), true
+	default:
+		return GatewayEvent{}, false
+	}
+}
+
+func gatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
 	ev := GatewayEvent{
 		Timestamp:        e.Timestamp,
 		CallerID:         firstNonEmpty(e.RequestSourceID, e.AgentID),

--- a/internal/metrics/tenant_isolation_test.go
+++ b/internal/metrics/tenant_isolation_test.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+func TestTenantIsolation_MapToGatewayEventFromTenantScopedEvidence(t *testing.T) {
+	ctx := context.Background()
+	store, err := evidence.NewStore(filepath.Join(t.TempDir(), "evidence.db"), "test-hmac-key-that-is-at-least-32-bytes-long")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Now().UTC()
+	seed := []evidence.Evidence{
+		{
+			ID:              "ev-acme-1",
+			CorrelationID:   "corr-acme-1",
+			Timestamp:       now.Add(-2 * time.Minute),
+			TenantID:        "acme",
+			AgentID:         "agent-a",
+			RequestSourceID: "caller-a",
+			InvocationType:  "gateway",
+			PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+			Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.03, DurationMS: 100},
+		},
+		{
+			ID:              "ev-other-1",
+			CorrelationID:   "corr-other-1",
+			Timestamp:       now.Add(-1 * time.Minute),
+			TenantID:        "other",
+			AgentID:         "agent-b",
+			RequestSourceID: "caller-b",
+			InvocationType:  "gateway",
+			PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+			Execution:       evidence.Execution{ModelUsed: "claude-3", Cost: 0.50, DurationMS: 200},
+		},
+	}
+	for i := range seed {
+		require.NoError(t, store.Store(ctx, &seed[i]))
+	}
+
+	acmeOnly, err := store.List(ctx, "acme", "", time.Time{}, now.Add(time.Minute), 100)
+	require.NoError(t, err)
+	require.Len(t, acmeOnly, 1)
+
+	collector := NewCollector("enforce", store, WithTenantID("acme"))
+	t.Cleanup(collector.Close)
+	for i := range acmeOnly {
+		ev, ok := MapToGatewayEvent(&acmeOnly[i])
+		require.True(t, ok)
+		collector.Record(ev)
+	}
+
+	require.Eventually(t, func() bool {
+		return collector.Snapshot(ctx).Summary.TotalRequests == 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	snap := collector.Snapshot(ctx)
+	assert.Equal(t, 1, snap.Summary.TotalRequests)
+	assert.InDelta(t, 0.03, snap.Summary.TotalCostEUR, 0.0001)
+	assert.Equal(t, 0, snap.Summary.BlockedRequests)
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -247,7 +247,7 @@ func setAdminSessionCookie(w http.ResponseWriter, r *http.Request, key string) {
 		Value:    key,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   r.TLS != nil,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   adminSessionCookieMaxAge,
 	})

--- a/internal/server/events_api.go
+++ b/internal/server/events_api.go
@@ -97,10 +97,10 @@ func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
 			}
 			if gapDetected {
 				health.IncEventStreamGap()
-			if _, writeErr := fmt.Fprintf(w, "event: gap\ndata: {\"reason\":\"replay_window_miss\"}\n\n"); writeErr != nil {
-				health.IncEventStreamDisconnect()
-				return
-			}
+				if _, writeErr := fmt.Fprintf(w, "event: gap\ndata: {\"reason\":\"replay_window_miss\"}\n\n"); writeErr != nil {
+					health.IncEventStreamDisconnect()
+					return
+				}
 				flush()
 			}
 			for i := range next {

--- a/internal/server/events_api.go
+++ b/internal/server/events_api.go
@@ -97,9 +97,10 @@ func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
 			}
 			if gapDetected {
 				health.IncEventStreamGap()
-				if _, writeErr := fmt.Fprintf(w, "event: gap\ndata: {\"reason\":\"replay_window_miss\"}\n\n"); writeErr != nil {
-					return
-				}
+			if _, writeErr := fmt.Fprintf(w, "event: gap\ndata: {\"reason\":\"replay_window_miss\"}\n\n"); writeErr != nil {
+				health.IncEventStreamDisconnect()
+				return
+			}
 				flush()
 			}
 			for i := range next {

--- a/internal/server/events_api.go
+++ b/internal/server/events_api.go
@@ -88,6 +88,7 @@ func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-ctx.Done():
+			health.IncEventStreamDisconnect()
 			return
 		case <-ticker.C:
 			next, gapDetected, err := s.listEventsForStream(r, tenantID, cursor)
@@ -104,6 +105,7 @@ func (s *Server) handleEventsStream(w http.ResponseWriter, r *http.Request) {
 			for i := range next {
 				payload, _ := json.Marshal(next[i])
 				if _, writeErr := fmt.Fprintf(w, "id: %s\ndata: %s\n\n", next[i].EventID, payload); writeErr != nil {
+					health.IncEventStreamDisconnect()
 					return
 				}
 				cursor = next[i].EventID
@@ -161,6 +163,7 @@ func (s *Server) listEventsForStream(r *http.Request, tenantID, sinceID string) 
 	gap := sinceID != "" && !foundCursor && len(desc) == s.eventsReplayBacklog
 	if gap {
 		health.IncEventReplayMiss()
+		health.IncEventBacklogDrop()
 	}
 
 	asc := make([]events.OperationalEvent, 0, len(desc))

--- a/internal/server/events_api_test.go
+++ b/internal/server/events_api_test.go
@@ -130,6 +130,7 @@ func TestEventsStreamGapSignalAndTelemetry(t *testing.T) {
 	assert.Contains(t, body, "event: gap")
 	assert.GreaterOrEqual(t, health.EventReplayMisses(), int64(1))
 	assert.GreaterOrEqual(t, health.EventStreamGaps(), int64(1))
+	assert.GreaterOrEqual(t, health.EventBacklogDrops(), int64(1))
 }
 
 func TestEventsStreamTenantIsolation(t *testing.T) {
@@ -153,6 +154,7 @@ func TestEventsStreamTenantIsolation(t *testing.T) {
 	assert.Contains(t, body, "\"evidence_id\":\"ev-acme-2\"")
 	assert.NotContains(t, body, "\"tenant_id\":\"other\"")
 	assert.NotContains(t, body, "\"evidence_id\":\"ev-other-1\"")
+	assert.GreaterOrEqual(t, health.EventStreamDisconnects(), int64(1))
 }
 
 func TestEventsStreamHonorsConnectionLimit(t *testing.T) {
@@ -197,7 +199,9 @@ func TestStatusIncludesEvidenceDegradedFields(t *testing.T) {
 	_, hasStreamActive := out["events_stream_active"]
 	_, hasStreamGaps := out["events_stream_gaps"]
 	_, hasReplayMisses := out["events_replay_misses"]
-	assert.True(t, hasStreamActive && hasStreamGaps && hasReplayMisses)
+	_, hasDisconnects := out["events_stream_disconnects"]
+	_, hasBacklogDrops := out["events_backlog_drops"]
+	assert.True(t, hasStreamActive && hasStreamGaps && hasReplayMisses && hasDisconnects && hasBacklogDrops)
 }
 
 func newEventsTestServer(t *testing.T, tenantKeys map[string]string) (*Server, *evidence.Store) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -628,6 +628,8 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp["events_stream_active"] = health.ActiveEventStreams()
 	resp["events_stream_gaps"] = health.EventStreamGaps()
 	resp["events_replay_misses"] = health.EventReplayMisses()
+	resp["events_stream_disconnects"] = health.EventStreamDisconnects()
+	resp["events_backlog_drops"] = health.EventBacklogDrops()
 	if s.evidenceStore != nil {
 		if n, err := s.evidenceStore.CountInRange(r.Context(), tenantID, "", dayStart, dayEnd); err == nil {
 			resp["evidence_count_today"] = n

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -90,6 +90,48 @@ func (s *Store) init(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating sessions table: %w", err)
 	}
+	if err := s.ensureSessionColumns(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) ensureSessionColumns(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(sessions)`)
+	if err != nil {
+		return fmt.Errorf("reading sessions schema: %w", err)
+	}
+	defer rows.Close()
+
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notNull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if scanErr := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); scanErr != nil {
+			return fmt.Errorf("scanning sessions schema: %w", scanErr)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating sessions schema: %w", err)
+	}
+
+	if !cols["max_cost"] {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE sessions ADD COLUMN max_cost REAL NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("adding sessions.max_cost column: %w", err)
+		}
+	}
+	if !cols["reasoning"] {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE sessions ADD COLUMN reasoning TEXT`); err != nil {
+			return fmt.Errorf("adding sessions.reasoning column: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -2,9 +2,11 @@ package session
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,4 +111,41 @@ func TestIncrementStageCountAndGetStageCounts(t *testing.T) {
 	require.Equal(t, 0, empty.Generation)
 	require.Equal(t, 0, empty.Judge)
 	require.Equal(t, 0, empty.Commit)
+}
+
+func TestNewStore_MigratesLegacySessionsTable(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "evidence.db")
+
+	rawDB, err := sql.Open("sqlite3", db)
+	require.NoError(t, err)
+	_, err = rawDB.ExecContext(context.Background(), `
+	CREATE TABLE sessions (
+		id TEXT PRIMARY KEY,
+		tenant_id TEXT NOT NULL,
+		agent_id TEXT NOT NULL,
+		status TEXT NOT NULL,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL,
+		completed_at DATETIME,
+		total_cost REAL NOT NULL DEFAULT 0,
+		total_tokens INTEGER NOT NULL DEFAULT 0
+	);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, rawDB.Close())
+
+	s, err := NewStore(db)
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx := context.Background()
+	ss, err := s.Create(ctx, "acme", "agent-a", "legacy table migration", 12.5)
+	require.NoError(t, err)
+	require.Equal(t, 12.5, ss.MaxCost)
+	require.Equal(t, "legacy table migration", ss.Reasoning)
+
+	got, err := s.Get(ctx, ss.ID)
+	require.NoError(t, err)
+	require.Equal(t, 12.5, got.MaxCost)
+	require.Equal(t, "legacy table migration", got.Reasoning)
 }


### PR DESCRIPTION
## Summary
- add a unified operational events pipeline backed by evidence projections across server API, CLI (`talon events tail`), and dashboard surfaces
- harden runtime evidence handling and health telemetry, including stream gap/disconnect/backlog counters and degraded evidence-write status in `/v1/status`
- improve reliability and usability with legacy session schema auto-migration and updated init/memory behavior and tests

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] validate `/api/v1/events/recent` and `/api/v1/events/stream` return expected events and SSE frames
- [x] verify `talon events tail --url ...` follows live operational stream with cursor support
- [x] verify `/v1/status` includes evidence and events stream health fields
- [x] run manual memory checks for low-risk PII sanitization and fail-closed write denial behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches audit/evidence, memory governance, session migrations, and admin cookie security—important operational paths but mostly additive logging and fail-safe behavior with tests.
> 
> **Overview**
> This PR tightens **runtime reliability and observability** around evidence, sessions, memory, and the events/metrics path, with changelog entries under **Fixed**.
> 
> **Agent runner** no longer discards evidence and step write failures: denied runs, dry-runs, cache paths, LLM errors, and tool-step completion/fallback paths emit structured error logs with `correlation_id`, `tenant_id`, and `agent_id` so audit gaps are visible instead of silent.
> 
> **Memory** observations are sanitized for low-risk **person** and **location** entities before governance validation, so useful domain text can persist while email/phone/IBAN-class PII still fails closed. The init wizard’s PII feature now defaults to **input redaction on** and **output redaction off** via granular `RedactInput` / `RedactOutput` instead of blanket `redact_pii`.
> 
> **Sessions** auto-migrate legacy SQLite `sessions` tables on store init by adding missing `max_cost` and `reasoning` columns. **Events** SSE handling increments disconnect and backlog-drop counters (alongside existing gap/replay signals) and surfaces them on status. **Metrics** routing uses a unified `MapToGatewayEvent` for maps and evidence records (serve adapter, backfill); new parity/tenant/backfill tests guard projections. **Admin session cookies** are always set `Secure`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26906abe36f5dbe1b2f618a449927ba20f8cd78a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->