### PR TITLE
feat(runtime): complete evidence-first SSOT parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **change(serve): quickstart no longer registers a synthetic tenant key.** Quickstart mode is strictly a host-root OpenAI-compatibility facade; it will not silently unlock tenant APIs. When tenant keys are configured, the relocated tenant endpoint sits behind standard tenant-auth middleware and returns `401 Unauthorized` without a valid key.
 - **change(serve): `--gateway-config` exclusivity check uses explicit flag set.** `--proxy-quickstart` is rejected alongside `--gateway` or any explicitly passed `--gateway-config`, detected via `cobra.Flags().Changed` rather than the default string value.
 - **change(gateway): quickstart `unsafe-listen` signal threaded via config.** The `quickstart_unsafe_listen` evidence annotation is driven by `GatewayConfig.QuickstartUnsafeListen`, populated from `--unsafe-listen` through `QuickstartOptions`, instead of a process environment variable.
+- **change(events/metrics): evidence-first projection parity hardening.** Operational event reason fields now prefer deterministic explanation payloads, evidence/event ordering is stabilized on `timestamp DESC, id DESC`, and metrics conversion is unified through evidence-driven projection paths for stronger CLI/API/dashboard parity.
 
 ### Fixed
 
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **fix(agent): preserve audit trail on evidence write failures.** Runner paths that previously ignored evidence/step write errors now log structured failures (`correlation_id`, `tenant_id`, `agent_id`) so silent audit-loss conditions are observable during denied, dry-run, cached, and tool-step flows.
 - **fix(memory): redact low-risk PII before memory governance checks.** Memory observations now sanitize `person`/`location` entities before validation, allowing safe useful memories while sensitive PII still fails closed under governance policy.
 - **fix(events): expand stream reliability telemetry.** Event stream handling now increments disconnect and backlog-drop counters (in addition to gap/replay signals) and exposes them in status output for faster operator diagnosis.
+- **fix(gateway/metrics): no metrics emission without persisted evidence.** Gateway collector events are now emitted only after successful evidence persistence, preventing runtime telemetry drift when evidence writes fail.
+- **fix(metrics): surface collector backpressure drops.** Collector channel overflow drops now increment `dropped_events`, emit OTel counter `talon.metrics.events_dropped.total`, and appear in `/v1/status` as `metrics_events_dropped`.
 
 ### Release Note Quality Bar
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -172,11 +172,16 @@ The dashboard snapshot includes:
 
 See [Gateway dashboard reference](reference/gateway-dashboard.md) for full configuration, authentication, and API details.
 
-Operational-event projection note:
+### Operational-event projection
 
-- Runtime projection follows `Evidence -> OperationalEvent -> Metrics/UI/CLI`.
-- Live gateway dashboard metrics are emitted only after successful evidence persistence.
-- If collector buffers overflow, drops are surfaced via `dropped_events`, OTel metric `talon.metrics.events_dropped.total`, and `/v1/status` as `metrics_events_dropped`.
+Projection: `Evidence → OperationalEvent → Metrics / UI / CLI`. Metrics emit only after evidence persists. Collector overflow is exposed as `dropped_events` in the snapshot, `metrics_events_dropped` in `/v1/status`, and OTel counter `talon.metrics.events_dropped.total`.
+
+| Surface | Endpoint / source | Parity expectation |
+|---------|-------------------|--------------------|
+| Evidence list | `/v1/evidence` | authoritative ordering: `timestamp DESC, id DESC` |
+| Events API | `/api/v1/events/recent`, `/api/v1/events/stream` | same ordering and evidence-linked fields |
+| Dashboard | `/dashboard` recent-events table | reflects events API without manual refresh |
+| Status | `/v1/status` | exposes `metrics_events_dropped`, `events_stream_gaps`, `events_replay_misses`, `events_backlog_drops` |
 
 ---
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -168,8 +168,15 @@ The dashboard snapshot includes:
 | `budget_status` | object | Budget utilization (daily/monthly used, limit, percentage). |
 | `cache_stats` | object | Semantic cache performance (hits, hit rate, cost saved). |
 | `plan_stats` | object | Plan lifecycle counters (pending/approved/rejected/modified/dispatched/failures). |
+| `dropped_events` | int | Collector events dropped due to in-process backpressure. |
 
 See [Gateway dashboard reference](reference/gateway-dashboard.md) for full configuration, authentication, and API details.
+
+Operational-event projection note:
+
+- Runtime projection follows `Evidence -> OperationalEvent -> Metrics/UI/CLI`.
+- Live gateway dashboard metrics are emitted only after successful evidence persistence.
+- If collector buffers overflow, drops are surfaced via `dropped_events`, OTel metric `talon.metrics.events_dropped.total`, and `/v1/status` as `metrics_events_dropped`.
 
 ---
 

--- a/docs/explanation/evidence-store.md
+++ b/docs/explanation/evidence-store.md
@@ -15,13 +15,13 @@ compliance story.
 Request → Pipeline → Evidence Record → HMAC Sign → SQLite Write → Export
 ```
 
-Operational projection contract:
+Operational projection: `Evidence → OperationalEvent → Metrics / UI / CLI`. Explanations come from `explanations[]` first; legacy `policy_decision.reasons` is a fallback only.
 
-```
-Evidence → OperationalEvent → Metrics / UI / CLI
-```
+Invariants:
 
-The event projection is derived from persisted evidence and deterministic explanations first, with legacy policy-reason fallback only when explanation payloads are unavailable.
+- Ordering: `timestamp DESC, id DESC` across `/v1/evidence` and `/api/v1/events/recent`.
+- Event rows expose `evidence_id`, `correlation_id`, `decision`, `reason_code`, `reason_text`, `suggested_fix`.
+- No evidence write → no event → no live metric.
 
 ## Evidence Record Structure
 

--- a/docs/explanation/evidence-store.md
+++ b/docs/explanation/evidence-store.md
@@ -15,6 +15,14 @@ compliance story.
 Request → Pipeline → Evidence Record → HMAC Sign → SQLite Write → Export
 ```
 
+Operational projection contract:
+
+```
+Evidence → OperationalEvent → Metrics / UI / CLI
+```
+
+The event projection is derived from persisted evidence and deterministic explanations first, with legacy policy-reason fallback only when explanation payloads are unavailable.
+
 ## Evidence Record Structure
 
 Each record contains these sections:

--- a/docs/reference/gateway-dashboard.md
+++ b/docs/reference/gateway-dashboard.md
@@ -308,6 +308,17 @@ The dashboard metrics and CLI commands (`talon costs`, `talon audit list`, `talo
 
 The in-memory collector adds real-time aggregation (5-minute buckets, latency percentiles) on top of the querier, so the dashboard may reflect very recent events slightly sooner than CLI queries that read directly from SQLite.
 
+Evidence-first runtime note:
+
+- Live gateway collector events are emitted from persisted evidence projection (not request-context-only maps).
+- If evidence storage fails for a request, Talon does not emit a corresponding gateway collector event.
+- Backpressure drops are exposed as `dropped_events` in `/api/v1/metrics` and `metrics_events_dropped` in `/v1/status`.
+
+Open product decisions tracked for SSOT completion:
+
+- Whether `/api/v1/metrics` should remain gateway-only or expand to all Talon activity.
+- Whether the operational event feed should include only completed invocations or lifecycle sub-events.
+
 ---
 
 ## Security

--- a/docs/reference/gateway-dashboard.md
+++ b/docs/reference/gateway-dashboard.md
@@ -308,16 +308,27 @@ The dashboard metrics and CLI commands (`talon costs`, `talon audit list`, `talo
 
 The in-memory collector adds real-time aggregation (5-minute buckets, latency percentiles) on top of the querier, so the dashboard may reflect very recent events slightly sooner than CLI queries that read directly from SQLite.
 
-Evidence-first runtime note:
+## Evidence-first runtime
 
-- Live gateway collector events are emitted from persisted evidence projection (not request-context-only maps).
-- If evidence storage fails for a request, Talon does not emit a corresponding gateway collector event.
-- Backpressure drops are exposed as `dropped_events` in `/api/v1/metrics` and `metrics_events_dropped` in `/v1/status`.
+Invariants:
 
-Open product decisions tracked for SSOT completion:
+- Metrics emission requires a successful evidence write. No evidence → no event → no metric.
+- Backpressure drops surface as `dropped_events` in `/api/v1/metrics` and `metrics_events_dropped` in `/v1/status`.
 
-- Whether `/api/v1/metrics` should remain gateway-only or expand to all Talon activity.
-- Whether the operational event feed should include only completed invocations or lifecycle sub-events.
+Open (tracked for SSOT completion):
+
+- `/api/v1/metrics` scope: gateway-only vs all Talon activity.
+- Event feed scope: terminal invocations only vs lifecycle sub-events.
+
+## Validation
+
+| Check | Command | Pass condition |
+|-------|---------|----------------|
+| Gates | `make test && make lint && make check` | exit 0 |
+| Status fields | `curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" http://localhost:8080/v1/status` | includes `metrics_events_dropped`, `events_stream_gaps`, `events_replay_misses`, `events_backlog_drops` |
+| Recent events | `curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" "http://localhost:8080/api/v1/events/recent?limit=10"` | each row has `event_id`, `evidence_id`, `decision`, `reason_code`, `cost_eur`, `correlation_id` |
+| SSE resume | `curl -N -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" -H "Last-Event-ID: <id>" http://localhost:8080/api/v1/events/stream` | stream resumes after `<id>`; emits `event: gap` on cursor miss |
+| Dashboard parity | open `http://localhost:8080/dashboard?talon_admin_key=$TALON_ADMIN_KEY` | "Session timeline" rows match `/api/v1/events/recent` |
 
 ---
 

--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -172,9 +172,9 @@ func printOperationalEvent(outWriter interface{ Write([]byte) (int, error) }, ev
 		return
 	}
 	line := fmt.Sprintf(
-		"%s | tenant=%s | caller=%s | decision=%s | cost=%.4f | model=%s | evidence=%s\n",
+		"%s | tenant=%s | caller=%s | decision=%s | reason_code=%s | reason_text=%s | cost=%.4f | model=%s | evidence=%s | correlation=%s\n",
 		ev.Timestamp.Format(time.RFC3339), valueOrDash(ev.TenantID), valueOrDash(ev.Caller), valueOrDash(ev.Decision),
-		ev.CostEUR, valueOrDash(ev.Model), valueOrDash(ev.EvidenceID),
+		valueOrDash(ev.ReasonCode), valueOrDash(ev.ReasonText), ev.CostEUR, valueOrDash(ev.Model), valueOrDash(ev.EvidenceID), valueOrDash(ev.CorrelationID),
 	)
 	_, _ = outWriter.Write([]byte(line))
 }

--- a/internal/cmd/events_test.go
+++ b/internal/cmd/events_test.go
@@ -15,18 +15,24 @@ func TestPrintOperationalEvent_Text(t *testing.T) {
 	eventsJSON = false
 	var out bytes.Buffer
 	printOperationalEvent(&out, events.OperationalEvent{
-		Timestamp:  time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
-		TenantID:   "acme",
-		Caller:     "hr-service",
-		Decision:   "blocked",
-		CostEUR:    0.0,
-		Model:      "gpt-4o",
-		EvidenceID: "ev-123",
+		Timestamp:     time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		TenantID:      "acme",
+		Caller:        "hr-service",
+		Decision:      "blocked",
+		ReasonCode:    "POLICY_DENIED",
+		ReasonText:    "Request blocked by policy.",
+		CostEUR:       0.0,
+		Model:         "gpt-4o",
+		EvidenceID:    "ev-123",
+		CorrelationID: "corr-123",
 	})
 	text := out.String()
 	assert.Contains(t, text, "tenant=acme")
 	assert.Contains(t, text, "decision=blocked")
+	assert.Contains(t, text, "reason_code=POLICY_DENIED")
+	assert.Contains(t, text, "reason_text=Request blocked by policy.")
 	assert.Contains(t, text, "evidence=ev-123")
+	assert.Contains(t, text, "correlation=corr-123")
 }
 
 func TestPrintOperationalEvent_JSON(t *testing.T) {

--- a/internal/events/operational_event.go
+++ b/internal/events/operational_event.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/explanation"
 )
 
 // OperationalEvent is the stable, minimal runtime projection used by UI/API/CLI.
@@ -65,6 +66,9 @@ func FromEvidence(ev *evidence.Evidence) OperationalEvent {
 		out.ToolsFiltered = append([]string(nil), ev.ToolGovernance.ToolsFiltered...)
 	}
 	out.Decision, out.ReasonCode, out.ReasonText, out.SuggestedFix = decisionFields(ev)
+	if decision, code, text, fix, ok := decisionFromExplanation(ev); ok {
+		out.Decision, out.ReasonCode, out.ReasonText, out.SuggestedFix = decision, code, text, fix
+	}
 	out.PrimaryCode, out.PrimaryReason = primaryExplanation(ev)
 	if out.ReasonCode == "" {
 		out.ReasonCode = out.PrimaryCode
@@ -72,17 +76,25 @@ func FromEvidence(ev *evidence.Evidence) OperationalEvent {
 	if out.ReasonText == "" {
 		out.ReasonText = out.PrimaryReason
 	}
+	out.ReasonText = sanitizeReasonText(out.ReasonText)
+	out.PIIDetected = sanitizeSignals(out.PIIDetected)
+	out.ToolsFiltered = sanitizeSignals(out.ToolsFiltered)
 	return out
 }
 
 // SortDesc sorts events newest-first with deterministic tie-break.
 func SortDesc(events []OperationalEvent) {
 	sort.Slice(events, func(i, j int) bool {
-		if events[i].Timestamp.Equal(events[j].Timestamp) {
-			return events[i].EvidenceID > events[j].EvidenceID
-		}
-		return events[i].Timestamp.After(events[j].Timestamp)
+		return LessDesc(events[i], events[j])
 	})
+}
+
+// LessDesc returns true if a should sort before b.
+func LessDesc(a, b OperationalEvent) bool {
+	if a.Timestamp.Equal(b.Timestamp) {
+		return a.EvidenceID > b.EvidenceID
+	}
+	return a.Timestamp.After(b.Timestamp)
 }
 
 func firstNonEmpty(values ...string) string {
@@ -95,10 +107,50 @@ func firstNonEmpty(values ...string) string {
 }
 
 func primaryExplanation(ev *evidence.Evidence) (code string, reason string) {
-	if len(ev.Explanations) == 0 {
+	item, ok := explanation.Primary(ev.Explanations)
+	if !ok {
 		return "", ""
 	}
-	return ev.Explanations[0].Code, ev.Explanations[0].Reason
+	return item.Code, item.Reason
+}
+
+func decisionFromExplanation(ev *evidence.Evidence) (decision, reasonCode, reasonText, suggestedFix string, ok bool) {
+	item, ok := explanation.Primary(ev.Explanations)
+	if !ok {
+		return "", "", "", "", false
+	}
+	reasonCode = item.Code
+	reasonText = item.Reason
+	suggestedFix = item.Fix
+
+	hasFilteredTools := ev.ToolGovernance != nil && len(ev.ToolGovernance.ToolsFiltered) > 0
+	hasRedaction := ev.Classification.PIIRedacted || ev.Classification.OutputPIIDetected
+
+	switch item.Decision {
+	case explanation.DecisionFailure:
+		decision = "error"
+	case explanation.DecisionDeny:
+		decision = "blocked"
+	case explanation.DecisionFilter:
+		decision = projectedAllowDecision(hasFilteredTools, true)
+	case explanation.DecisionModify:
+		decision = projectedAllowDecision(hasFilteredTools, hasRedaction)
+	default:
+		decision = projectedAllowDecision(hasFilteredTools, hasRedaction)
+	}
+
+	return decision, reasonCode, reasonText, suggestedFix, true
+}
+
+func projectedAllowDecision(hasFilteredTools bool, hasRedaction bool) string {
+	switch {
+	case hasFilteredTools:
+		return "filtered_tool"
+	case hasRedaction:
+		return "redacted"
+	default:
+		return "allowed"
+	}
 }
 
 func decisionFields(ev *evidence.Evidence) (decision, reasonCode, reasonText, suggestedFix string) {
@@ -153,4 +205,35 @@ func fixFromCode(code string) string {
 	default:
 		return ""
 	}
+}
+
+func sanitizeReasonText(in string) string {
+	s := strings.Join(strings.Fields(strings.TrimSpace(in)), " ")
+	if len(s) > 220 {
+		return s[:220]
+	}
+	return s
+}
+
+func sanitizeSignals(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/events/operational_event_test.go
+++ b/internal/events/operational_event_test.go
@@ -1,0 +1,104 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/explanation"
+)
+
+func TestFromEvidence_UsesExplanationFirst(t *testing.T) {
+	ev := &evidence.Evidence{
+		ID:            "ev-1",
+		Timestamp:     time.Now().UTC(),
+		TenantID:      "acme",
+		AgentID:       "agent-a",
+		CorrelationID: "corr-1",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"budget exceeded"},
+		},
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.11,
+			DurationMS: 120,
+		},
+		Explanations: []explanation.Item{
+			{
+				Code:     explanation.CodePolicyDeniedPIIInput,
+				Decision: explanation.DecisionDeny,
+				Reason:   "Request blocked because input PII was detected.",
+				Fix:      "Remove or mask sensitive data before retrying the request.",
+			},
+		},
+	}
+
+	out := FromEvidence(ev)
+	assert.Equal(t, "blocked", out.Decision)
+	assert.Equal(t, explanation.CodePolicyDeniedPIIInput, out.ReasonCode)
+	assert.Equal(t, "Request blocked because input PII was detected.", out.ReasonText)
+	assert.Equal(t, "Remove or mask sensitive data before retrying the request.", out.SuggestedFix)
+}
+
+func TestFromEvidence_FallsBackWithoutExplanation(t *testing.T) {
+	ev := &evidence.Evidence{
+		ID:        "ev-2",
+		Timestamp: time.Now().UTC(),
+		TenantID:  "acme",
+		AgentID:   "agent-a",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"IBAN detected in input"},
+		},
+	}
+
+	out := FromEvidence(ev)
+	assert.Equal(t, "blocked", out.Decision)
+	assert.Equal(t, "PII_IBAN", out.ReasonCode)
+	assert.Equal(t, "IBAN detected in input", out.ReasonText)
+}
+
+func TestFromEvidence_SanitizesSignalsAndReasonText(t *testing.T) {
+	ev := &evidence.Evidence{
+		ID:        "ev-3",
+		Timestamp: time.Now().UTC(),
+		TenantID:  "acme",
+		AgentID:   "agent-a",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"line1\nline2\tline3"},
+		},
+		Classification: evidence.Classification{
+			PIIDetected: []string{"email", "email", " ", "iban"},
+		},
+		ToolGovernance: &evidence.ToolGovernance{
+			ToolsFiltered: []string{"rm", "", "rm", "curl"},
+		},
+	}
+
+	out := FromEvidence(ev)
+	assert.Equal(t, "line1 line2 line3", out.ReasonText)
+	assert.Equal(t, []string{"email", "iban"}, out.PIIDetected)
+	assert.Equal(t, []string{"rm", "curl"}, out.ToolsFiltered)
+}
+
+func TestSortDesc_StableTieBreakOnEvidenceID(t *testing.T) {
+	ts := time.Now().UTC()
+	items := []OperationalEvent{
+		{Timestamp: ts, EvidenceID: "ev-a"},
+		{Timestamp: ts, EvidenceID: "ev-z"},
+		{Timestamp: ts.Add(1 * time.Second), EvidenceID: "ev-b"},
+	}
+	SortDesc(items)
+
+	assert.Equal(t, "ev-b", items[0].EvidenceID)
+	assert.Equal(t, "ev-z", items[1].EvidenceID)
+	assert.Equal(t, "ev-a", items[2].EvidenceID)
+	assert.True(t, LessDesc(items[1], items[2]))
+}

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -633,7 +633,7 @@ func (s *Store) List(ctx context.Context, tenantID, agentID string, from, to tim
 		args = append(args, to)
 	}
 
-	query += ` ORDER BY timestamp DESC`
+	query += ` ORDER BY timestamp DESC, id DESC`
 	if limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, limit)
@@ -1349,7 +1349,7 @@ func (s *Store) ListIndex(ctx context.Context, tenantID, agentID string, from, t
 		query += ` AND timestamp <= ?`
 		args = append(args, to)
 	}
-	query += ` ORDER BY timestamp DESC`
+	query += ` ORDER BY timestamp DESC, id DESC`
 	if limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, limit)

--- a/internal/gateway/blocked_metrics_test.go
+++ b/internal/gateway/blocked_metrics_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/health"
+	"github.com/dativo-io/talon/internal/metrics"
 	"github.com/dativo-io/talon/internal/secrets"
 	"github.com/dativo-io/talon/internal/testutil"
 	"github.com/go-chi/chi/v5"
@@ -31,6 +32,23 @@ func (s *metricsRecorderSpy) RecordGatewayEvent(event interface{}) {
 	defer s.mu.Unlock()
 	if m, ok := event.(map[string]interface{}); ok {
 		s.events = append(s.events, m)
+		return
+	}
+	ev, ok := metrics.MapToGatewayEvent(event)
+	if ok {
+		s.events = append(s.events, map[string]interface{}{
+			"caller_id":      ev.CallerID,
+			"model":          ev.Model,
+			"blocked":        ev.Blocked,
+			"cost_eur":       ev.CostEUR,
+			"latency_ms":     ev.LatencyMS,
+			"has_error":      ev.HasError,
+			"timed_out":      ev.TimedOut,
+			"cache_hit":      ev.CacheHit,
+			"cost_saved":     ev.CostSaved,
+			"tools_filtered": ev.ToolsFiltered,
+			"pii_detected":   ev.PIIDetected,
+		})
 	}
 }
 
@@ -445,4 +463,44 @@ func TestBlockedPath_AllBlockedPathsConsistent(t *testing.T) {
 			assert.Equal(t, "test-caller", ev["caller_id"], "blocked path %q should include caller_id", tt.name)
 		})
 	}
+}
+
+func TestGatewayMetrics_RuntimeEventMatchesEvidenceProjection(t *testing.T) {
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "http://localhost:1"},
+		},
+		Callers: []CallerConfig{
+			{
+				Name:             "test-caller",
+				TenantKey:        "talon-gw-test-001",
+				TenantID:         "default",
+				AllowedProviders: []string{"anthropic"},
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		Timeouts:       TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+	gw, spy, evStore := setupGatewayWithSpy(t, cfg, nil)
+
+	w := postGateway(gw, "/v1/proxy/openai/v1/chat/completions", "talon-gw-test-001",
+		`{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}`)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Equal(t, 1, spy.count())
+
+	list, err := evStore.List(context.Background(), "default", "test-caller", time.Time{}, time.Time{}, 1)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	projected := metrics.GatewayEventFromEvidence(&list[0])
+	observed := spy.lastEvent()
+	require.NotNil(t, observed)
+	assert.Equal(t, projected.Blocked, observed["blocked"])
+	assert.Equal(t, projected.HasError, observed["has_error"])
+	assert.Equal(t, projected.CallerID, observed["caller_id"])
+	assert.Equal(t, projected.Model, observed["model"])
+	assert.Equal(t, projected.CostEUR, observed["cost_eur"])
 }

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -60,7 +60,7 @@ type RecordGatewayEvidenceParams struct {
 
 // RecordGatewayEvidence creates and stores a signed evidence record for a gateway request.
 // Never logs or stores real provider API keys.
-func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params RecordGatewayEvidenceParams) error {
+func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params RecordGatewayEvidenceParams) (*evidence.Evidence, error) {
 	var toolGov *evidence.ToolGovernance
 	if len(params.ToolsRequested) > 0 || len(params.ToolsFiltered) > 0 || len(params.ToolsForwarded) > 0 {
 		toolGov = &evidence.ToolGovernance{
@@ -148,7 +148,10 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		}
 	}
 	ev.Explanations = explanation.BuildFromFacts(facts)
-	return store.Store(ctx, ev)
+	if err := store.Store(ctx, ev); err != nil {
+		return nil, err
+	}
+	return ev, nil
 }
 
 func sanitizeGatewayAnnotations(in []string) []string {

--- a/internal/gateway/evidence_test.go
+++ b/internal/gateway/evidence_test.go
@@ -20,7 +20,7 @@ func TestRecordGatewayEvidence(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	ctx := context.Background()
-	err = RecordGatewayEvidence(ctx, store, RecordGatewayEvidenceParams{
+	_, err = RecordGatewayEvidence(ctx, store, RecordGatewayEvidenceParams{
 		CorrelationID:          "corr-1",
 		TenantID:               "default",
 		CallerName:             "test-caller",
@@ -65,7 +65,7 @@ func TestRecordGatewayEvidence_ToolGovernanceRoundTrip(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 
 	ctx := context.Background()
-	err = RecordGatewayEvidence(ctx, store, RecordGatewayEvidenceParams{
+	_, err = RecordGatewayEvidence(ctx, store, RecordGatewayEvidenceParams{
 		CorrelationID:  "corr-tools",
 		TenantID:       "default",
 		CallerName:     "openclaw-main",

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dativo-io/talon/internal/explanation"
 	"github.com/dativo-io/talon/internal/health"
 	"github.com/dativo-io/talon/internal/llm"
+	"github.com/dativo-io/talon/internal/metrics"
 	"github.com/dativo-io/talon/internal/secrets"
 	"github.com/dativo-io/talon/internal/session"
 )
@@ -274,11 +275,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
-			if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, 0, false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, 0, false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
+			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
 			}
-			g.emitMetrics(ctx, caller, route.Provider, "", nil, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0)
+			g.emitMetrics(ctx, caller, route.Provider, "", nil, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0, persisted)
 			return
 		}
 	}
@@ -326,13 +328,14 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest,
 				"Request blocked: attachment violates policy")
-			if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
 				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, 0, false,
-				[]string{"attachment policy block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+				[]string{"attachment policy block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
 			}
-			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, nil, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0)
+			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, nil, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0, persisted)
 			return
 		}
 	}
@@ -361,11 +364,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
-			if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
 			}
-			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0)
+			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0, persisted)
 			return
 		}
 	}
@@ -388,11 +392,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
-			if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
 			}
-			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0)
+			g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0, persisted)
 			return
 		}
 	}
@@ -438,11 +443,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
-				if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
 				}
-				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0)
+				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			}
 		}
@@ -459,11 +465,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusForbidden, reasons[0])
-				if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0); err != nil {
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
 				}
-				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0)
+				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			}
 		}
@@ -492,12 +499,13 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Msg("gateway_tool_blocked")
 				WriteProviderError(w, route.Provider, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
-				if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-					classification, nil, 0, 0, 0, false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0); err != nil {
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
+					classification, nil, 0, 0, 0, false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
 				}
-				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0)
+				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			default:
 				filtered, filterErr := FilterRequestBodyTools(route.Provider, forwardBody, tr.Kept)
@@ -509,12 +517,13 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						Msg("gateway_tool_filter_failed")
 					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
-					if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-						classification, nil, 0, 0, 0, false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0); err != nil {
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
+						classification, nil, 0, 0, 0, false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
 					}
-					g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, nil, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0)
+					g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, nil, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0, persisted)
 					return
 				}
 				forwardBody = filtered
@@ -587,11 +596,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0); err != nil {
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
+					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
 					}
-					g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, false, false, piiAction, true, costSaved, 0, 0)
+					g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, false, false, piiAction, true, costSaved, 0, 0, persisted)
 					writeCachedCompletion(w, route.Provider, extracted.Model, hit.ResponseText)
 					return
 				}
@@ -662,11 +672,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-				if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0); err != nil {
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
+				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
 				}
-				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0)
+				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			}
 			if route.Provider == "anthropic" {
@@ -685,6 +696,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var tokenUsage TokenUsage
 	var responsePII *ResponsePIIScanResult
 	needsResponseScan := responsePIIAction != "allow" && responsePIIAction != ""
+	var forwardErr error
 
 	var streamingMetrics StreamingMetrics
 	fwdParams := ForwardParams{
@@ -703,8 +715,8 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case needsResponseScan && !isStreaming:
 		// Non-streaming: capture response, scan, then write
 		capture := &responseCapture{ResponseWriter: w}
-		err = Forward(capture, fwdParams)
-		if err == nil {
+		forwardErr = Forward(capture, fwdParams)
+		if forwardErr == nil {
 			scannedBody, scanResult := scanResponseForPII(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), capture.body.Bytes(), responsePIIAction, g.classifier)
 			responsePII = scanResult
 			if capture.statusCode != 0 {
@@ -743,15 +755,15 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// scan for PII. If clean, forward the original buffered events. If
 		// PII found, return the redacted content wrapped in SSE format.
 		capture := &responseCapture{ResponseWriter: w}
-		err = Forward(capture, fwdParams)
-		if err == nil {
+		forwardErr = Forward(capture, fwdParams)
+		if forwardErr == nil {
 			responsePII = handleStreamingPIIScan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), w, capture, responsePIIAction, g.classifier)
 		} else {
 			capture.flushTo(w)
 		}
 
 	default:
-		err = Forward(w, fwdParams)
+		forwardErr = Forward(w, fwdParams)
 	}
 
 	durationMS := time.Since(start).Milliseconds()
@@ -778,21 +790,22 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		outputPIITypes = responsePII.PIITypes
 	}
 
-	if err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, 0, true, nil, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS); err != nil {
-		g.handleEvidenceWriteFailure(ctx, err)
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, 0, true, nil, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
+	if recordErr != nil {
+		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
 	}
 	g.trackSessionUsage(ctx, sessionID, caller.TenantID, caller.Name, cost, tokenUsage.Input+tokenUsage.Output)
 
 	// Emit OTel + dashboard metrics
 	g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations,
-		&tokenUsage, cost, durationMS, err != nil, false, piiAction, false, 0, ttftMS, tpotMS)
-	if err != nil {
-		log.Warn().Err(err).Msg("gateway_forward_error")
+		&tokenUsage, cost, durationMS, forwardErr != nil, false, piiAction, false, 0, ttftMS, tpotMS, persisted)
+	if forwardErr != nil {
+		log.Warn().Err(forwardErr).Msg("gateway_forward_error")
 	}
 }
 
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, _ int, allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) error {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, _ int, allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -807,6 +820,13 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	piiDetected := []string{}
 	for _, e := range classification.Entities {
 		piiDetected = append(piiDetected, e.Type)
+	}
+	execErr := ""
+	for _, reason := range reasons {
+		if strings.Contains(strings.ToLower(reason), "error") {
+			execErr = reason
+			break
+		}
 	}
 
 	var attScan *evidence.AttachmentScan
@@ -848,6 +868,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 		InputTokens:             inputTokens,
 		OutputTokens:            outputTokens,
 		DurationMS:              durationMS,
+		Error:                   execErr,
 		SecretsAccessed:         secretsAccessed,
 		AttachmentScan:          attScan,
 		AgentReasoning:          agentReasoningFromContext(ctx),
@@ -871,13 +892,13 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	params.GatewayAnnotations = gatewayAnnotationsForEvidence(g, caller)
 	params.TTFTMS = ttftMS
 	params.TPOTMS = tpotMS
-	err := RecordGatewayEvidence(ctx, g.evidenceStore, params)
+	ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, params)
 	if err != nil {
 		health.MarkEvidenceWriteFailure(time.Now().UTC(), err)
-		return err
+		return nil, err
 	}
 	health.MarkEvidenceWriteSuccess(time.Now().UTC())
-	return nil
+	return ev, nil
 }
 
 func (g *Gateway) handleEvidenceWriteFailure(ctx context.Context, err error) {
@@ -1120,11 +1141,8 @@ func (g *Gateway) emitMetrics(ctx context.Context, caller *CallerConfig, provide
 	classification *classifier.Classification, toolResult *ToolGovernanceResult,
 	shadowViolations []evidence.ShadowViolation, usage *TokenUsage,
 	cost float64, durationMS int64, hasError, blocked bool, piiAction string,
-	cacheHit bool, costSaved float64, ttftMS int64, tpotMS float64,
+	cacheHit bool, costSaved float64, ttftMS int64, tpotMS float64, persistedEvidence *evidence.Evidence,
 ) {
-	timedOut := hasError && g.timeouts.RequestTimeout > 0 &&
-		durationMS >= g.timeouts.RequestTimeout.Milliseconds()
-
 	status := "ok"
 	if hasError {
 		status = "error"
@@ -1177,49 +1195,11 @@ func (g *Gateway) emitMetrics(ctx context.Context, caller *CallerConfig, provide
 	llm.RecordProviderAvailability(ctx, provider, !hasError)
 
 	if g.metricsRecorder != nil {
-		var piiTypes []string
-		if classification != nil {
-			for _, e := range classification.Entities {
-				piiTypes = append(piiTypes, e.Type)
-			}
+		if persistedEvidence == nil {
+			log.Warn().Msg("skipping_metrics_recorder_emit_without_persisted_evidence")
+			return
 		}
-		var toolsRequested, toolsFiltered []string
-		if toolResult != nil {
-			toolsRequested = toolResult.Requested
-			toolsFiltered = toolResult.Removed
-		}
-		var svTypes []string
-		for _, sv := range shadowViolations {
-			svTypes = append(svTypes, sv.Type)
-		}
-		evt := map[string]interface{}{
-			"timestamp":          time.Now(),
-			"caller_id":          caller.Name,
-			"model":              model,
-			"pii_detected":       piiTypes,
-			"pii_action":         piiAction,
-			"tools_requested":    toolsRequested,
-			"tools_filtered":     toolsFiltered,
-			"blocked":            blocked,
-			"cost_eur":           cost,
-			"tokens_input":       tokIn,
-			"tokens_output":      tokOut,
-			"latency_ms":         durationMS,
-			"enforcement_mode":   g.config.Mode,
-			"would_have_blocked": len(shadowViolations) > 0,
-			"shadow_violations":  svTypes,
-			"has_error":          hasError,
-			"timed_out":          timedOut,
-			"cache_hit":          cacheHit,
-			"cost_saved":         costSaved,
-		}
-		if ttftMS > 0 {
-			evt["ttft_ms"] = ttftMS
-		}
-		if tpotMS > 0 {
-			evt["tpot_ms"] = tpotMS
-		}
-		g.metricsRecorder.RecordGatewayEvent(evt)
+		g.metricsRecorder.RecordGatewayEvent(metrics.GatewayEventFromEvidence(persistedEvidence))
 	}
 }
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -825,15 +825,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	for _, e := range classification.Entities {
 		piiDetected = append(piiDetected, e.Type)
 	}
-	execErr := executionError
-	if execErr == "" {
-		for _, reason := range reasons {
-			if strings.Contains(strings.ToLower(reason), "error") {
-				execErr = reason
-				break
-			}
-		}
-	}
+	execErr := resolveExecutionError(executionError, reasons)
 
 	var attScan *evidence.AttachmentScan
 	if attSummary != nil && attSummary.FilesScanned > 0 {
@@ -910,6 +902,21 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 func (g *Gateway) handleEvidenceWriteFailure(ctx context.Context, err error) {
 	RecordGatewayError(ctx, "evidence_store")
 	log.Error().Err(err).Msg("gateway_evidence_store_failed")
+}
+
+// resolveExecutionError returns the explicit execution error when set, otherwise
+// the first policy reason that looks like an error (legacy behavior preserved
+// so blocked/error invariants still surface in evidence).
+func resolveExecutionError(explicit string, reasons []string) string {
+	if explicit != "" {
+		return explicit
+	}
+	for _, reason := range reasons {
+		if strings.Contains(strings.ToLower(reason), "error") {
+			return reason
+		}
+	}
+	return ""
 }
 
 func buildGatewayExplanationFacts(allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, _ string) []explanation.Fact {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -275,7 +275,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, 0, false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -329,7 +329,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			WriteProviderError(w, route.Provider, http.StatusBadRequest,
 				"Request blocked: attachment violates policy")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, 0, false,
+				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, "", false,
 				[]string{"attachment policy block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -364,7 +364,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -392,7 +392,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -443,7 +443,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -465,7 +465,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusForbidden, reasons[0])
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, 0, false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -500,7 +500,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				WriteProviderError(w, route.Provider, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-					classification, nil, 0, 0, 0, false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -518,7 +518,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
 					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-						classification, nil, 0, 0, 0, false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -596,7 +596,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -672,7 +672,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, 0, false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -790,7 +790,11 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		outputPIITypes = responsePII.PIITypes
 	}
 
-	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, 0, true, nil, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
+	var forwardErrStr string
+	if forwardErr != nil {
+		forwardErrStr = forwardErr.Error()
+	}
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
@@ -805,7 +809,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, _ int, allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -821,11 +825,13 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	for _, e := range classification.Entities {
 		piiDetected = append(piiDetected, e.Type)
 	}
-	execErr := ""
-	for _, reason := range reasons {
-		if strings.Contains(strings.ToLower(reason), "error") {
-			execErr = reason
-			break
+	execErr := executionError
+	if execErr == "" {
+		for _, reason := range reasons {
+			if strings.Contains(strings.ToLower(reason), "error") {
+				execErr = reason
+				break
+			}
 		}
 	}
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/rs/zerolog/log"
 )
 
 // Snapshot is the complete dashboard state returned by GET /api/v1/metrics.
@@ -14,6 +16,7 @@ type Snapshot struct {
 	GeneratedAt      time.Time           `json:"generated_at"`
 	EnforcementMode  string              `json:"enforcement_mode"`
 	Uptime           string              `json:"uptime"`
+	DroppedEvents    uint64              `json:"dropped_events,omitempty"`
 	Summary          Summary             `json:"summary"`
 	RequestsTimeline []TimePoint         `json:"requests_timeline"`
 	PIITimeline      []TimePoint         `json:"pii_timeline"`
@@ -285,6 +288,7 @@ type Collector struct {
 	budgetMonthly  float64
 	tenantID       string
 	planStatsFn    func(context.Context, string) (PlanStats, error)
+	droppedEvents  uint64
 }
 
 // CollectorOption configures a Collector.
@@ -340,7 +344,17 @@ func (c *Collector) Record(e GatewayEvent) {
 	select {
 	case c.events <- e:
 	default:
+		dropped := atomic.AddUint64(&c.droppedEvents, 1)
+		recordCollectorEventDrop()
+		if dropped == 1 || dropped%100 == 0 {
+			log.Warn().Uint64("dropped_events", dropped).Msg("metrics_collector_event_dropped")
+		}
 	}
+}
+
+// DroppedEvents returns number of collector events dropped due to backpressure.
+func (c *Collector) DroppedEvents() uint64 {
+	return atomic.LoadUint64(&c.droppedEvents)
 }
 
 // Close stops the background consumer goroutine.
@@ -601,6 +615,7 @@ func (c *Collector) buildInMemorySnapshot() Snapshot {
 		GeneratedAt:     now,
 		EnforcementMode: c.enforcementMode,
 		Uptime:          uptime,
+		DroppedEvents:   c.DroppedEvents(),
 		Summary: Summary{
 			TotalRequests:   c.totalRequests,
 			BlockedRequests: c.blockedRequests,

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -318,6 +318,20 @@ func TestPlanStatsCallback(t *testing.T) {
 	assert.Equal(t, 1, snap.Summary.PlanDispatchErr)
 }
 
+func TestCollectorDroppedEventsBackpressure(t *testing.T) {
+	c := newTestCollector("enforce", nil)
+	// Stop consumer loop to force channel saturation deterministically.
+	c.Close()
+
+	for i := 0; i < 1200; i++ {
+		c.Record(GatewayEvent{Timestamp: time.Now()})
+	}
+
+	assert.Greater(t, c.DroppedEvents(), uint64(0))
+	snap := c.Snapshot(context.Background())
+	assert.Equal(t, c.DroppedEvents(), snap.DroppedEvents)
+}
+
 func TestPIITimelineAndCostTimeline(t *testing.T) {
 	c := newTestCollector("enforce", nil)
 	defer c.Close()

--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -18,6 +18,7 @@ var (
 	mTaskDeniedTotal   metric.Int64Counter
 	mCostPerSuccess    metric.Float64Histogram
 	mViolationsDaily   metric.Int64Counter
+	mEventsDropped     metric.Int64Counter
 
 	collectorMetricsOnce       sync.Once
 	collectorMetricsRegistered bool
@@ -64,6 +65,13 @@ func initCollectorMetrics() {
 	mViolationsDaily, err = collectorMeter.Int64Counter("talon.violations.daily",
 		metric.WithDescription("Daily policy or tool violations"),
 		metric.WithUnit("{violation}"))
+	if err != nil {
+		return
+	}
+
+	mEventsDropped, err = collectorMeter.Int64Counter("talon.metrics.events_dropped.total",
+		metric.WithDescription("Dropped collector events due to backpressure"),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return
 	}
@@ -117,4 +125,12 @@ func recordViolationDaily(dayKey, callerID string) {
 		attribute.String("date", dayKey),
 		attribute.String("caller_id", callerID),
 	))
+}
+
+func recordCollectorEventDrop() {
+	ensureCollectorMetrics()
+	if !collectorMetricsRegistered {
+		return
+	}
+	mEventsDropped.Add(context.Background(), 1)
 }

--- a/internal/metrics/parity_test.go
+++ b/internal/metrics/parity_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dativo-io/talon/internal/events"
 	"github.com/dativo-io/talon/internal/evidence"
 )
 
@@ -302,4 +303,38 @@ func TestParity_EvidenceWriteMatchesMappedEventProjection(t *testing.T) {
 	assert.Equal(t, fromEvidence.CostEUR, fromMap.CostEUR)
 	assert.Equal(t, fromEvidence.LatencyMS, fromMap.LatencyMS)
 	assert.Equal(t, fromEvidence.PIIDetected, fromMap.PIIDetected)
+}
+
+func TestParity_OperationalEventConversionMatchesEvidenceConversion(t *testing.T) {
+	now := time.Now().UTC()
+	ev := evidence.Evidence{
+		ID:              "ev-op-1",
+		CorrelationID:   "corr-op-1",
+		Timestamp:       now,
+		TenantID:        "default",
+		AgentID:         "agent-op",
+		RequestSourceID: "caller-op",
+		InvocationType:  "gateway",
+		PolicyDecision:  evidence.PolicyDecision{Allowed: false, Reasons: []string{"budget denied"}},
+		Classification:  evidence.Classification{PIIDetected: []string{"email"}},
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.05,
+			DurationMS: 250,
+			Tokens:     evidence.TokenUsage{Input: 123, Output: 45},
+		},
+	}
+
+	fromEvidence := GatewayEventFromEvidence(&ev)
+	fromOpEvent := GatewayEventFromOperationalEvent(events.FromEvidence(&ev))
+
+	assert.Equal(t, fromEvidence.Timestamp, fromOpEvent.Timestamp)
+	assert.Equal(t, fromEvidence.CallerID, fromOpEvent.CallerID)
+	assert.Equal(t, fromEvidence.Model, fromOpEvent.Model)
+	assert.Equal(t, fromEvidence.Blocked, fromOpEvent.Blocked)
+	assert.Equal(t, fromEvidence.CostEUR, fromOpEvent.CostEUR)
+	assert.Equal(t, fromEvidence.LatencyMS, fromOpEvent.LatencyMS)
+	assert.Equal(t, fromEvidence.HasError, fromOpEvent.HasError)
+	assert.Equal(t, fromEvidence.AgentID, fromOpEvent.AgentID)
+	assert.Equal(t, fromEvidence.PIIDetected, fromOpEvent.PIIDetected)
 }

--- a/internal/metrics/projection.go
+++ b/internal/metrics/projection.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dativo-io/talon/internal/events"
 	"github.com/dativo-io/talon/internal/evidence"
 )
 
@@ -54,30 +55,47 @@ func mapToGatewayEvent(input interface{}) (GatewayEvent, bool) {
 			return GatewayEvent{}, false
 		}
 		return gatewayEventFromEvidence(v), true
+	case events.OperationalEvent:
+		return GatewayEventFromOperationalEvent(v), true
+	case *events.OperationalEvent:
+		if v == nil {
+			return GatewayEvent{}, false
+		}
+		return GatewayEventFromOperationalEvent(*v), true
 	default:
 		return GatewayEvent{}, false
 	}
 }
 
-func gatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
-	ev := GatewayEvent{
-		Timestamp:        e.Timestamp,
-		CallerID:         firstNonEmpty(e.RequestSourceID, e.AgentID),
-		Model:            e.Execution.ModelUsed,
-		Blocked:          !e.PolicyDecision.Allowed,
-		CostEUR:          e.Execution.Cost,
-		TokensInput:      e.Execution.Tokens.Input,
-		TokensOutput:     e.Execution.Tokens.Output,
-		LatencyMS:        e.Execution.DurationMS,
-		TTFTMS:           e.Execution.TTFTMS,
-		TPOTMS:           e.Execution.TPOTMS,
-		HasError:         e.Execution.Error != "",
-		TimedOut:         isTimedOutError(e.Execution.Error),
-		WouldHaveBlocked: e.ObservationModeOverride,
-		CacheHit:         e.CacheHit,
-		CostSaved:        e.CostSaved,
-		AgentID:          e.AgentID,
+// GatewayEventFromOperationalEvent converts the canonical operational projection into
+// dashboard metrics event shape.
+func GatewayEventFromOperationalEvent(ev events.OperationalEvent) GatewayEvent {
+	return GatewayEvent{
+		Timestamp:     ev.Timestamp,
+		CallerID:      firstNonEmpty(ev.Caller, ev.AgentID),
+		Model:         ev.Model,
+		Blocked:       ev.Decision == "blocked",
+		CostEUR:       ev.CostEUR,
+		LatencyMS:     ev.DurationMS,
+		HasError:      ev.HasError || ev.Decision == "error",
+		TimedOut:      isTimedOutError(ev.ReasonText),
+		PIIDetected:   append([]string(nil), ev.PIIDetected...),
+		ToolsFiltered: append([]string(nil), ev.ToolsFiltered...),
+		CacheHit:      ev.CacheHit,
+		CostSaved:     ev.CostSaved,
+		AgentID:       ev.AgentID,
 	}
+}
+
+func gatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
+	ev := GatewayEventFromOperationalEvent(events.FromEvidence(e))
+	ev.CallerID = firstNonEmpty(e.RequestSourceID, ev.CallerID)
+	ev.TokensInput = e.Execution.Tokens.Input
+	ev.TokensOutput = e.Execution.Tokens.Output
+	ev.TTFTMS = e.Execution.TTFTMS
+	ev.TPOTMS = e.Execution.TPOTMS
+	ev.WouldHaveBlocked = e.ObservationModeOverride
+	ev.TimedOut = isTimedOutError(e.Execution.Error)
 
 	if len(e.Classification.PIIDetected) > 0 {
 		ev.PIIDetected = append([]string(nil), e.Classification.PIIDetected...)

--- a/internal/server/events_api_test.go
+++ b/internal/server/events_api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dativo-io/talon/internal/events"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/health"
 	"github.com/dativo-io/talon/internal/policy"
@@ -49,6 +50,39 @@ func TestEventsRecentParityWithEvidenceList(t *testing.T) {
 
 	require.Len(t, recent.Events, len(evList.Entries))
 	assert.Equal(t, evList.Entries[0].ID, recent.Events[0]["evidence_id"])
+}
+
+func TestEventsRecentParityWithEvidenceList_TieBreakByEvidenceID(t *testing.T) {
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	now := time.Now().UTC()
+	insertEvidence(t, store, "ev-a", "default", "agent-a", now, true, 0.12)
+	insertEvidence(t, store, "ev-z", "default", "agent-a", now, false, 0.0)
+
+	r := srv.Routes()
+	evidenceReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/evidence?limit=10", nil)
+	evidenceReq.Header.Set("Authorization", "Bearer k-default")
+	evidenceRec := httptest.NewRecorder()
+	r.ServeHTTP(evidenceRec, evidenceReq)
+	require.Equal(t, http.StatusOK, evidenceRec.Code)
+
+	eventsReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/recent?limit=10", nil)
+	eventsReq.Header.Set("Authorization", "Bearer k-default")
+	eventsRec := httptest.NewRecorder()
+	r.ServeHTTP(eventsRec, eventsReq)
+	require.Equal(t, http.StatusOK, eventsRec.Code)
+
+	var evList struct {
+		Entries []evidence.Index `json:"entries"`
+	}
+	require.NoError(t, json.NewDecoder(evidenceRec.Body).Decode(&evList))
+	var recent struct {
+		Events []map[string]interface{} `json:"events"`
+	}
+	require.NoError(t, json.NewDecoder(eventsRec.Body).Decode(&recent))
+	require.GreaterOrEqual(t, len(evList.Entries), 2)
+	require.GreaterOrEqual(t, len(recent.Events), 2)
+	assert.Equal(t, evList.Entries[0].ID, recent.Events[0]["evidence_id"])
+	assert.Equal(t, "ev-z", evList.Entries[0].ID)
 }
 
 func TestEventsRecentTenantIsolation(t *testing.T) {
@@ -104,6 +138,64 @@ func TestEventsStreamRespectsLastEventID(t *testing.T) {
 	assert.Contains(t, body, "id: ")
 	assert.Contains(t, body, "\"evidence_id\":\"ev-2\"")
 	assert.NotContains(t, body, "\"evidence_id\":\"ev-1\"")
+}
+
+func TestEventsParity_BoundedWindowAcrossCLIAndAPI(t *testing.T) {
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	now := time.Now().UTC()
+	insertEvidence(t, store, "ev-p1", "default", "agent-a", now.Add(-2*time.Second), true, 0.01)
+	insertEvidence(t, store, "ev-p2", "default", "agent-a", now.Add(-1*time.Second), false, 0.00)
+
+	cliSource, err := store.List(context.Background(), "default", "", time.Time{}, time.Now().UTC(), 20)
+	require.NoError(t, err)
+	cliEvents := make([]map[string]interface{}, 0, len(cliSource))
+	for i := range cliSource {
+		ev := events.FromEvidence(&cliSource[i])
+		cliEvents = append(cliEvents, map[string]interface{}{
+			"event_id":       ev.EventID,
+			"evidence_id":    ev.EvidenceID,
+			"tenant_id":      ev.TenantID,
+			"agent_id":       ev.AgentID,
+			"correlation_id": ev.CorrelationID,
+			"allowed":        ev.Allowed,
+			"decision":       ev.Decision,
+			"cost_eur":       ev.CostEUR,
+			"model":          ev.Model,
+		})
+	}
+
+	r := srv.Routes()
+	evidenceReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/evidence?limit=20", nil)
+	evidenceReq.Header.Set("Authorization", "Bearer k-default")
+	evidenceRec := httptest.NewRecorder()
+	r.ServeHTTP(evidenceRec, evidenceReq)
+	require.Equal(t, http.StatusOK, evidenceRec.Code)
+	var evList struct {
+		Entries []evidence.Index `json:"entries"`
+	}
+	require.NoError(t, json.NewDecoder(evidenceRec.Body).Decode(&evList))
+
+	eventsReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/recent?limit=20", nil)
+	eventsReq.Header.Set("Authorization", "Bearer k-default")
+	eventsRec := httptest.NewRecorder()
+	r.ServeHTTP(eventsRec, eventsReq)
+	require.Equal(t, http.StatusOK, eventsRec.Code)
+	var recent struct {
+		Events []map[string]interface{} `json:"events"`
+	}
+	require.NoError(t, json.NewDecoder(eventsRec.Body).Decode(&recent))
+
+	require.Equal(t, len(evList.Entries), len(recent.Events))
+	require.Equal(t, len(cliEvents), len(recent.Events))
+	for i := range recent.Events {
+		assert.Equal(t, evList.Entries[i].ID, recent.Events[i]["evidence_id"])
+		assert.Equal(t, cliEvents[i]["evidence_id"], recent.Events[i]["evidence_id"])
+		assert.Equal(t, cliEvents[i]["decision"], recent.Events[i]["decision"])
+		assert.Equal(t, cliEvents[i]["tenant_id"], recent.Events[i]["tenant_id"])
+		assert.Equal(t, cliEvents[i]["agent_id"], recent.Events[i]["agent_id"])
+		assert.Equal(t, cliEvents[i]["correlation_id"], recent.Events[i]["correlation_id"])
+		assert.InDelta(t, cliEvents[i]["cost_eur"].(float64), recent.Events[i]["cost_eur"].(float64), 0.0001)
+	}
 }
 
 func TestEventsStreamGapSignalAndTelemetry(t *testing.T) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -653,6 +653,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		snap := s.metricsCollector.Snapshot(r.Context())
 		resp["error_rate"] = snap.Summary.ErrorRate
 		resp["enforcement_mode"] = snap.EnforcementMode
+		resp["metrics_events_dropped"] = s.metricsCollector.DroppedEvents()
 	}
 	if s.activeRunTracker != nil {
 		resp["active_runs"] = s.activeRunTracker.Count(tenantID)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -374,6 +374,36 @@ func TestStatusEndpoint_ActiveRunsFromTracker(t *testing.T) {
 	assert.Equal(t, float64(0), out["active_runs"], "default tenant has no runs")
 }
 
+func TestStatusEndpoint_IncludesMetricsDroppedEvents(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	collector := metrics.NewCollector("enforce", store)
+	collector.Close() // stop consumer to force backpressure drops
+	for i := 0; i < 1200; i++ {
+		collector.Record(metrics.GatewayEvent{Timestamp: time.Now().UTC(), CallerID: "app"})
+	}
+
+	srv := NewServer(nil, store, nil, engine, pol, "", nil, "", map[string]string{"k": "default"}, WithMetricsCollector(collector))
+	r := srv.Routes()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer k")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	assert.Contains(t, out, "metrics_events_dropped")
+	assert.Greater(t, out["metrics_events_dropped"].(float64), float64(0))
+}
+
 func TestCostsAndBudgetEndpoints(t *testing.T) {
 	pol := minimalPolicy()
 	engine, err := policy.NewEngine(context.Background(), pol)

--- a/tests/smoke_lib.sh
+++ b/tests/smoke_lib.sh
@@ -11,6 +11,9 @@ SMOKE_PATH_METRICS="/api/v1/metrics"
 SMOKE_PATH_METRICS_STREAM="/api/v1/metrics/stream"
 SMOKE_PATH_GATEWAY_DASHBOARD="/gateway/dashboard"
 SMOKE_PATH_EVIDENCE="/v1/evidence"
+SMOKE_PATH_EVENTS_RECENT="/api/v1/events/recent"
+SMOKE_PATH_EVENTS_STREAM="/api/v1/events/stream"
+SMOKE_PATH_STATUS="/v1/status"
 
 # --- Canonical request bodies (reused across sections; no duplicate JSON) ---
 # PII: email + IBAN (used for redact path, block path, and metrics volume)
@@ -108,6 +111,41 @@ smoke_get_latest_evidence() {
   ev_id="$(echo "$idx" | jq -r '.entries[0].id // empty')"
   [[ -z "$ev_id" ]] && return 1
   curl -s -H "X-Talon-Admin-Key: $admin_key" "${base}${SMOKE_PATH_EVIDENCE}/${ev_id}"
+}
+
+# --- Events API: GET recent operational events JSON ---
+# Usage: smoke_get_events_recent base_url admin_key [limit]
+# Outputs: JSON body (stdout) shaped { "events": [...], "cursor": "..." }
+smoke_get_events_recent() {
+  local base="$1" admin_key="$2" limit="${3:-50}"
+  curl -s -H "X-Talon-Admin-Key: $admin_key" "${base}${SMOKE_PATH_EVENTS_RECENT}?limit=${limit}" 2>/dev/null
+}
+
+# --- Events API: capture a short SSE window from the events stream ---
+# Usage: smoke_capture_events_stream base_url admin_key [seconds] [last_event_id]
+# Outputs: raw SSE body (stdout)
+smoke_capture_events_stream() {
+  local base="$1" admin_key="$2" seconds="${3:-3}" since="${4:-}"
+  local hdr=()
+  [[ -n "$since" ]] && hdr=(-H "Last-Event-ID: $since")
+  timeout "$seconds" curl -s -H "X-Talon-Admin-Key: $admin_key" "${hdr[@]}" \
+    "${base}${SMOKE_PATH_EVENTS_STREAM}" 2>/dev/null || true
+}
+
+# --- Status: GET /v1/status JSON ---
+# Usage: smoke_get_status base_url admin_key
+# Outputs: JSON body (stdout)
+smoke_get_status() {
+  local base="$1" admin_key="$2"
+  curl -s -H "X-Talon-Admin-Key: $admin_key" "${base}${SMOKE_PATH_STATUS}" 2>/dev/null
+}
+
+# --- Evidence index (admin): list recent evidence records ---
+# Usage: smoke_get_evidence_index base_url admin_key [limit]
+# Outputs: JSON body (stdout) shaped { "entries": [...] }
+smoke_get_evidence_index() {
+  local base="$1" admin_key="$2" limit="${3:-50}"
+  curl -s -H "X-Talon-Admin-Key: $admin_key" "${base}${SMOKE_PATH_EVIDENCE}?limit=${limit}" 2>/dev/null
 }
 
 # --- Wait until health returns 200 (for server startup) ---

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -1052,8 +1052,10 @@ CACHEEOF
     dump_diag_json "status_json" "$status_json"
   fi
 
-  assert_pass "metrics snapshot exposes dropped_events" \
-    jq -e 'has("dropped_events")' <<< "$snap_after_live" &>/dev/null
+  # dropped_events is omitempty in the JSON snapshot: absent when 0 (healthy),
+  # present and >=0 when collector backpressure has occurred.
+  assert_pass "metrics snapshot dropped_events absent (healthy) or numeric >=0" \
+    jq -e '(has("dropped_events") | not) or (.dropped_events | type == "number" and . >= 0)' <<< "$snap_after_live" &>/dev/null
 
   local events_json; events_json="$(smoke_get_events_recent "$dashboard_base_url" "$admin_key" 50)"
   if jq -e '.events | type == "array"' <<< "$events_json" &>/dev/null; then

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -1026,6 +1026,124 @@ CACHEEOF
   fi
   echo "[SMOKE] CONSISTENCY|live_monotonicity|before_total=$live_before_total after_total=$live_after_total"
 
+  # --- 23.12: Evidence-first SSOT parity (Issue #43) ---
+  # Invariants under verification:
+  #   1. /v1/status surfaces backpressure/degraded counters.
+  #   2. /api/v1/metrics snapshot includes dropped_events.
+  #   3. /api/v1/events/recent rows carry evidence-linked projection fields.
+  #   4. Event ordering is deterministic (timestamp DESC, evidence_id DESC tie-break).
+  #   5. Every event.evidence_id resolves to a real evidence record (no orphan events).
+  #   6. SSE stream emits `id:` + `data:` lines per event.
+  echo ""
+  echo "  -- 23.12: Evidence-first SSOT parity (Issue #43) --"
+
+  local status_json; status_json="$(smoke_get_status "$dashboard_base_url" "$admin_key")"
+  if jq -e '.' <<< "$status_json" &>/dev/null; then
+    assert_pass "status exposes metrics_events_dropped" \
+      jq -e 'has("metrics_events_dropped")' <<< "$status_json" &>/dev/null
+    assert_pass "status exposes events_stream_gaps" \
+      jq -e 'has("events_stream_gaps")' <<< "$status_json" &>/dev/null
+    assert_pass "status exposes events_replay_misses" \
+      jq -e 'has("events_replay_misses")' <<< "$status_json" &>/dev/null
+    assert_pass "status exposes events_backlog_drops" \
+      jq -e 'has("events_backlog_drops")' <<< "$status_json" &>/dev/null
+  else
+    log_failure "status endpoint not reachable for SSOT checks" "url=${dashboard_base_url}${SMOKE_PATH_STATUS}"
+    dump_diag_json "status_json" "$status_json"
+  fi
+
+  assert_pass "metrics snapshot exposes dropped_events" \
+    jq -e 'has("dropped_events")' <<< "$snap_after_live" &>/dev/null
+
+  local events_json; events_json="$(smoke_get_events_recent "$dashboard_base_url" "$admin_key" 50)"
+  if jq -e '.events | type == "array"' <<< "$events_json" &>/dev/null; then
+    assert_pass "events recent returns events array" \
+      jq -e '.events | type == "array"' <<< "$events_json" &>/dev/null
+
+    local events_len; events_len="$(jq '.events | length' <<< "$events_json")"
+    echo "[SMOKE] CONSISTENCY|events_recent_len|${events_len:-0}"
+
+    if [[ -n "$events_len" ]] && [[ "$events_len" -gt 0 ]]; then
+      assert_pass "every event has event_id" \
+        jq -e 'all(.events[]; has("event_id") and (.event_id | length > 0))' <<< "$events_json" &>/dev/null
+      assert_pass "every event has evidence_id" \
+        jq -e 'all(.events[]; has("evidence_id") and (.evidence_id | length > 0))' <<< "$events_json" &>/dev/null
+      assert_pass "every event has timestamp" \
+        jq -e 'all(.events[]; has("timestamp") and (.timestamp | length > 0))' <<< "$events_json" &>/dev/null
+      assert_pass "every event has decision" \
+        jq -e 'all(.events[]; has("decision") and (.decision | length > 0))' <<< "$events_json" &>/dev/null
+      assert_pass "every event exposes tenant_id" \
+        jq -e 'all(.events[]; has("tenant_id"))' <<< "$events_json" &>/dev/null
+      assert_pass "every event exposes cost_eur as number" \
+        jq -e 'all(.events[]; .cost_eur | type == "number")' <<< "$events_json" &>/dev/null
+
+      # Ordering: timestamps must be non-increasing (newest first)
+      assert_pass "events ordered newest-first by timestamp" \
+        jq -e '[.events[].timestamp] | . == (. | sort | reverse)' <<< "$events_json" &>/dev/null
+
+      # Evidence linkage: each event.evidence_id must exist in /v1/evidence index.
+      local ev_index; ev_index="$(smoke_get_evidence_index "$dashboard_base_url" "$admin_key" 200)"
+      if jq -e '.entries | type == "array"' <<< "$ev_index" &>/dev/null; then
+        local missing_links
+        missing_links="$(jq -n --argjson ev "$ev_index" --argjson op "$events_json" '
+          ($ev.entries // []) as $idx
+          | ($op.events // []) as $events
+          | [$idx[].id] as $ids
+          | [$events[] | select(.evidence_id as $eid | ($ids | index($eid)) == null) | .evidence_id]
+          | length
+        ' 2>/dev/null || echo "")"
+        if [[ -n "$missing_links" ]] && [[ "$missing_links" == "0" ]]; then
+          echo "  ✓  every event.evidence_id resolves to an /v1/evidence record"
+          record_pass
+        else
+          log_failure "events without matching evidence_id in /v1/evidence index" \
+            "missing=${missing_links:-unknown} (orphan events break evidence-first invariant)"
+          dump_diag_json "events_json" "$events_json"
+        fi
+      else
+        echo "  -  evidence index not parseable; skipping evidence-link integrity"
+      fi
+    else
+      echo "  -  events recent is empty (skip per-row invariants)"
+    fi
+  else
+    log_failure "events recent endpoint did not return events array" "url=${dashboard_base_url}${SMOKE_PATH_EVENTS_RECENT}"
+    dump_diag_json "events_json" "$events_json"
+  fi
+
+  # SSE: confirm stream emits both `id:` and `data:` lines for at least one event.
+  local sse_evts; sse_evts="$(smoke_capture_events_stream "$dashboard_base_url" "$admin_key" 4)"
+  if echo "$sse_evts" | grep -q '^data:' && echo "$sse_evts" | grep -q '^id:'; then
+    echo "  ✓  events SSE stream emits id+data per event"
+    record_pass
+    local sse_payload; sse_payload="$(echo "$sse_evts" | awk '/^data:/{print substr($0,7); exit}')"
+    if [[ -n "$sse_payload" ]] && jq -e 'has("event_id") and has("evidence_id")' <<< "$sse_payload" &>/dev/null; then
+      echo "  ✓  events SSE payload carries event_id+evidence_id"
+      record_pass
+    else
+      echo "  -  events SSE payload missing event_id/evidence_id (timing window)"
+    fi
+  else
+    echo "  -  events SSE stream did not emit id+data within window (may be quiet)"
+  fi
+
+  # CLI parity: `talon events tail --json` should produce the same shape as the API.
+  local cli_events_out; cli_events_out="$(timeout 4 env TALON_ADMIN_KEY="$admin_key" \
+    talon events tail --url "$dashboard_base_url" --json 2>/dev/null | head -1)" || true
+  if [[ -n "$cli_events_out" ]]; then
+    if jq -e 'has("event_id") and has("evidence_id") and has("decision")' <<< "$cli_events_out" &>/dev/null; then
+      echo "  ✓  talon events tail --json emits projection-shaped rows"
+      record_pass
+    else
+      echo "  -  talon events tail --json row missing event_id/evidence_id/decision"
+      dump_diag_kv "cli_events_first_row" "$cli_events_out"
+    fi
+  else
+    echo "  -  talon events tail --json produced no rows in window"
+  fi
+
+  echo "[SMOKE] CONSISTENCY|ssot_evidence_first_block|complete"
+
   kill "$GW_PID" 2>/dev/null || true
   wait "$GW_PID" 2>/dev/null || true
   sleep 2

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -223,11 +223,16 @@
     </div>
     <aside class="split-right">
       <div class="card">
-        <div class="label">Session timeline (lifecycle)</div>
-        <div class="refresh">Intent -> Guard -> Action -> Outcome -> Evidence</div>
-        <ul class="mission-feed-list" id="session-timeline-list">
-          <li>Waiting for recent evidence...</li>
-        </ul>
+        <div class="label">Session timeline (lifecycle) - recent operational events</div>
+        <div class="refresh">Live feed from /api/v1/events/stream (decision, reason, cost, model, actor, evidence)</div>
+        <table>
+          <thead>
+            <tr><th>Time</th><th>Tenant</th><th>Actor</th><th>Decision</th><th>Reason</th><th>Cost</th><th>Model</th><th>Evidence</th><th>Correlation</th></tr>
+          </thead>
+          <tbody id="session-timeline-list">
+            <tr><td colspan="9" class="refresh">Waiting for recent evidence...</td></tr>
+          </tbody>
+        </table>
       </div>
       <div class="card" style="margin-top:0.75rem;">
         <div class="label">Compliance report preview</div>
@@ -433,14 +438,30 @@
         var latest = recentEvents.slice(0, 8);
         timeline.innerHTML = '';
         if (latest.length === 0) {
-          timeline.innerHTML = '<li>No recent sessions recorded.</li>';
+          timeline.innerHTML = '<tr><td colspan="9" class="refresh">No recent sessions recorded.</td></tr>';
           return;
         }
         latest.forEach(function(ev) {
           var when = ev.timestamp ? new Date(ev.timestamp).toLocaleTimeString() : '--';
           var outcome = ev.decision || (ev.allowed ? 'allow' : 'deny');
           var actor = ev.caller || ev.agent_id || 'agent';
-          timeline.innerHTML += '<li>' + escapeHtml(when) + ' · ' + escapeHtml(actor) + ' · ' + escapeHtml(outcome) + ' · evidence ' + escapeHtml(ev.evidence_id || '—') + '</li>';
+          var tenant = ev.tenant_id || '—';
+          var reason = ev.reason_text || ev.reason_code || '—';
+          var model = ev.model || '—';
+          var cost = (ev.cost_eur != null && !isNaN(Number(ev.cost_eur))) ? Number(ev.cost_eur).toFixed(4) : '0.0000';
+          var evidenceId = ev.evidence_id || '—';
+          var corr = ev.correlation_id || '—';
+          timeline.innerHTML += '<tr>' +
+            '<td>' + escapeHtml(when) + '</td>' +
+            '<td>' + escapeHtml(tenant) + '</td>' +
+            '<td>' + escapeHtml(actor) + '</td>' +
+            '<td>' + escapeHtml(outcome) + '</td>' +
+            '<td>' + escapeHtml(reason) + '</td>' +
+            '<td>' + escapeHtml(cost) + '</td>' +
+            '<td>' + escapeHtml(model) + '</td>' +
+            '<td>' + escapeHtml(evidenceId) + '</td>' +
+            '<td>' + escapeHtml(corr) + '</td>' +
+            '</tr>';
         });
       }
 


### PR DESCRIPTION
## Summary
- unify runtime projection paths so live metrics, backfill, and parity tests converge on `Evidence -> OperationalEvent -> GatewayEvent`
- enforce post-persist emission in gateway flow and stabilize cross-surface ordering/decision semantics with deterministic tie-breaks
- expose backpressure/degraded telemetry in status/docs, and align dashboard/CLI recent events output with operational-event fields

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway metrics emission timing and operational-event decision/reason semantics across CLI, API, and dashboard; misalignment could briefly affect live dashboards until evidence writes succeed, but audit integrity improves by not emitting metrics without persisted evidence.
> 
> **Overview**
> This PR hardens **evidence-first** runtime parity so CLI, API, dashboard, and live gateway metrics read the same story from persisted evidence.
> 
> **Projection and ordering:** `OperationalEvent` now prefers deterministic **explanations** over legacy policy reasons, with sanitization and stable newest-first ordering (`timestamp DESC`, evidence ID tie-break). Evidence list/index queries use the same `ORDER BY timestamp DESC, id DESC`. Metrics conversion routes through `Evidence → OperationalEvent → GatewayEvent` (including `GatewayEventFromOperationalEvent`).
> 
> **Gateway metrics:** Live collector events are emitted **only after** successful evidence persistence (`RecordGatewayEvidence` returns the stored record; `emitMetrics` skips when persistence failed). Ad-hoc request-context metric maps are replaced by `metrics.GatewayEventFromEvidence(persisted)`.
> 
> **Observability:** Collector channel overflow increments `dropped_events`, OTel `talon.metrics.events_dropped.total`, and `/v1/status` field `metrics_events_dropped`; dashboard snapshot includes `dropped_events`. Docs/changelog document the `Evidence → OperationalEvent → Metrics/UI/CLI` contract.
> 
> **Surfaces:** `talon events tail` text output and the Mission Control session timeline show reason codes/text and correlation IDs; parity tests cover API vs evidence list, metrics vs evidence projection, and backpressure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98102b3bb84ce78336100ca68255faad3b0654e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->