### PR TITLE
feat(ssot): close remaining runtime parity gaps for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **feat(serve): OpenAI-compatible quickstart proxy mode.** Added `talon serve --proxy-quickstart` for dev/local host-root compatibility (`POST /v1/chat/completions`, `POST /v1/responses`) without gateway YAML, while keeping policy, PII redaction, and evidence active.
 - **feat(gateway): upstream auth mode support for quickstart.** Added provider `upstream_auth_mode` (`secret` default, `client_bearer` quickstart path) with client bearer forwarding, `OPENAI_API_KEY` fallback, and explicit 401 when no upstream key is available.
 - **feat(evidence): quickstart upstream auth metadata.** Evidence records now include additive fields `upstream_auth_mode`, `upstream_key_source`, `upstream_key_fingerprint`, and `gateway_annotations` (backward compatible with existing records).
+- **feat(metrics): periodic reconciliation loop and status telemetry.** Added bounded/idempotent collector reconciliation (`ReconcileFromStore` + loop), OTel reconcile metrics, and `/v1/status` fields for reconcile runs/recovered events/errors.
+- **feat(server): consolidated SSOT gate suite.** Added `internal/server/ssot_gate_test.go` plus `make test-ssot-gate` and wired it into `make check` as an explicit release gate.
 
 ### Changed
 
@@ -20,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **change(serve): `--gateway-config` exclusivity check uses explicit flag set.** `--proxy-quickstart` is rejected alongside `--gateway` or any explicitly passed `--gateway-config`, detected via `cobra.Flags().Changed` rather than the default string value.
 - **change(gateway): quickstart `unsafe-listen` signal threaded via config.** The `quickstart_unsafe_listen` evidence annotation is driven by `GatewayConfig.QuickstartUnsafeListen`, populated from `--unsafe-listen` through `QuickstartOptions`, instead of a process environment variable.
 - **change(events/metrics): evidence-first projection parity hardening.** Operational event reason fields now prefer deterministic explanation payloads, evidence/event ordering is stabilized on `timestamp DESC, id DESC`, and metrics conversion is unified through evidence-driven projection paths for stronger CLI/API/dashboard parity.
+- **change(dashboard/cli): reliability signals surfaced in routine flows.** Dashboard and gateway pages now expose degraded/reliability warning chips, and `talon metrics` / `talon events tail` print preflight warnings when `/v1/status` reports degradation.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **change(events/metrics): evidence-first projection parity hardening.** Operational event reason fields now prefer deterministic explanation payloads, evidence/event ordering is stabilized on `timestamp DESC, id DESC`, and metrics conversion is unified through evidence-driven projection paths for stronger CLI/API/dashboard parity.
 - **change(dashboard/cli): reliability signals surfaced in routine flows.** Dashboard and gateway pages now expose degraded/reliability warning chips, and `talon metrics` / `talon events tail` print preflight warnings when `/v1/status` reports degradation.
 - **change(observability/events): SSOT scope contract locked.** `/api/v1/metrics` is documented as all-activity (gateway and agent-run evidence-backed runtime), and `/api/v1/events/*` is documented as one event per persisted evidence row, including terminal outcomes plus evidence-backed lifecycle subset records (`plan_review`, graph runtime). Endpoint shapes remain backward-compatible.
+- **change(metrics/evidence): pragmatic SSOT live-feed unification.** Dashboard live metrics are now fed from `evidence.Store.Store()` post-commit observer notifications (all invocation types), while periodic reconciliation remains bounded/idempotent repair. Degraded evidence-write signaling is centralized in the evidence store path, and production serve wiring no longer double-emits via direct gateway metrics recorder attachment.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(UNAME_S),Darwin)
   GO_ENV := env -u CC CC=/usr/bin/clang CGO_ENABLED=1
 endif
 
-.PHONY: help build install test test-integration test-e2e test-smoke test-all lint fmt clean vet mod-tidy check docker-build demo-gateway demo-full demo-clean verify-flow0 nosec-count
+.PHONY: help build install test test-integration test-e2e test-smoke test-all test-ssot-gate lint fmt clean vet mod-tidy check docker-build demo-gateway demo-full demo-clean verify-flow0 nosec-count
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -49,6 +49,9 @@ test-smoke: build ## Run black-box smoke test (prereqs: TALON_SECRETS_KEY, OPENA
 
 test-all: test test-e2e ## Run unit, integration, and e2e tests (does not include test-smoke)
 
+test-ssot-gate: ## Run consolidated SSOT parity/resilience gate tests
+	@$(GO_ENV) go test -count=1 ./internal/server -run SSOTGate
+
 lint: ## Run linter
 	@golangci-lint run ./...
 
@@ -65,7 +68,7 @@ mod-tidy: ## Tidy go modules
 clean: ## Clean build artifacts
 	@rm -rf bin/ coverage.out coverage.html dist/
 
-check: lint vet test ## Run all checks (CI equivalent)
+check: lint vet test test-ssot-gate ## Run all checks (CI equivalent)
 
 docker-build: ## Build Docker image
 	@docker build -t $(BINARY_NAME):$(VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build: ## Build the binary to ./bin/talon (run from repo root: ./bin/talon)
 install: ## Install to $GOPATH/bin (or go env GOPATH/bin)
 	@$(GO_ENV) go install $(LDFLAGS) ./cmd/talon/
 
-test: ## Run tests (unit + integration). Coverage excludes cmd/talon and internal/testutil. Uses -count=1 so cache is disabled.
+test: test-ssot-gate ## Run tests (SSOT gate + unit + integration). Coverage excludes cmd/talon and internal/testutil. Uses -count=1 so cache is disabled.
 	@$(GO_ENV) go test -count=1 -race -coverprofile=coverage.out $$(go list ./internal/... ./cmd/... | grep -v internal/testutil | grep -v 'cmd/talon')
 	@$(GO_ENV) go test -count=1 -race -tags=integration ./tests/integration/...
 
@@ -68,7 +68,7 @@ mod-tidy: ## Tidy go modules
 clean: ## Clean build artifacts
 	@rm -rf bin/ coverage.out coverage.html dist/
 
-check: lint vet test test-ssot-gate ## Run all checks (CI equivalent)
+check: lint vet test ## Run all checks (CI equivalent)
 
 docker-build: ## Build Docker image
 	@docker build -t $(BINARY_NAME):$(VERSION) .

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -131,7 +131,9 @@ Registered by `internal/memory`. Emitted on memory operations.
 
 ## Gateway dashboard metrics
 
-In addition to OTel metrics, Talon provides a **real-time gateway dashboard** with an in-memory metrics collector. The dashboard aggregates evidence records into a live snapshot available at:
+In addition to OTel metrics, Talon provides a **real-time runtime dashboard** with an in-memory metrics collector. The collector is fed from successful `evidence.Store.Store()` commits (all invocation types), then periodically reconciled from evidence as an authoritative repair path.
+
+The dashboard snapshot is available at:
 
 - **HTML dashboard:** `GET /gateway/dashboard` — single-page HTML with auto-refreshing charts.
 - **JSON API:** `GET /api/v1/metrics` — full snapshot for programmatic access.
@@ -174,7 +176,7 @@ See [Gateway dashboard reference](reference/gateway-dashboard.md) for full confi
 
 ### Operational-event projection
 
-Projection: `Evidence → OperationalEvent → Metrics / UI / CLI`. Metrics emit only after evidence persists. Collector overflow is exposed as `dropped_events` in the snapshot, `metrics_events_dropped` in `/v1/status`, and OTel counter `talon.metrics.events_dropped.total`.
+Projection: `Evidence → OperationalEvent → Metrics / UI / CLI`. Metrics emit only after evidence persists, and live increments are driven by store post-commit observer notifications. Collector overflow is exposed as `dropped_events` in the snapshot, `metrics_events_dropped` in `/v1/status`, and OTel counter `talon.metrics.events_dropped.total`. Periodic reconciliation from evidence is bounded and idempotent, used to repair drift rather than define an alternate source of truth.
 
 | Surface | Endpoint / source | Scope | Parity expectation |
 |---------|-------------------|-------|--------------------|

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -176,12 +176,13 @@ See [Gateway dashboard reference](reference/gateway-dashboard.md) for full confi
 
 Projection: `Evidence → OperationalEvent → Metrics / UI / CLI`. Metrics emit only after evidence persists. Collector overflow is exposed as `dropped_events` in the snapshot, `metrics_events_dropped` in `/v1/status`, and OTel counter `talon.metrics.events_dropped.total`.
 
-| Surface | Endpoint / source | Parity expectation |
-|---------|-------------------|--------------------|
-| Evidence list | `/v1/evidence` | authoritative ordering: `timestamp DESC, id DESC` |
-| Events API | `/api/v1/events/recent`, `/api/v1/events/stream` | same ordering and evidence-linked fields |
-| Dashboard | `/dashboard` recent-events table | reflects events API without manual refresh |
-| Status | `/v1/status` | exposes `metrics_events_dropped`, `events_stream_gaps`, `events_replay_misses`, `events_backlog_drops` |
+| Surface | Endpoint / source | Scope | Parity expectation |
+|---------|-------------------|-------|--------------------|
+| Evidence list | `/v1/evidence` | all evidence rows in tenant window | authoritative ordering: `timestamp DESC, id DESC` |
+| Events API | `/api/v1/events/recent`, `/api/v1/events/stream` | `terminal_plus_lifecycle_subset` (evidence-backed only) | same ordering and evidence-linked fields |
+| Dashboard | `/dashboard` recent-events table | mirrors events API rows, with compact signal chips | reflects events API without manual refresh |
+| Metrics snapshot | `/api/v1/metrics` | `all_activity` collector projection | consistent summary/breakdown invariants and reconciliation health |
+| Status | `/v1/status` | reliability contract fields | exposes `metrics_events_dropped`, `events_stream_gaps`, `events_replay_misses`, `events_backlog_drops`, reconcile status |
 
 ---
 

--- a/docs/reference/gateway-dashboard.md
+++ b/docs/reference/gateway-dashboard.md
@@ -315,10 +315,10 @@ Invariants:
 - Metrics emission requires a successful evidence write. No evidence → no event → no metric.
 - Backpressure drops surface as `dropped_events` in `/api/v1/metrics` and `metrics_events_dropped` in `/v1/status`.
 
-Open (tracked for SSOT completion):
+Scope (locked in v1.5.0):
 
-- `/api/v1/metrics` scope: gateway-only vs all Talon activity.
-- Event feed scope: terminal invocations only vs lifecycle sub-events.
+- `/api/v1/metrics` is the runtime SSOT snapshot for all evidence-backed Talon activity visible to the collector, not gateway-only request counters.
+- Event feeds (`/api/v1/events/recent`, `/api/v1/events/stream`) emit terminal outcomes plus evidence-backed lifecycle events. No lifecycle row is emitted without a persisted evidence record.
 
 ## Validation
 
@@ -326,7 +326,7 @@ Open (tracked for SSOT completion):
 |-------|---------|----------------|
 | Gates | `make test && make lint && make check` | exit 0 |
 | Status fields | `curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" http://localhost:8080/v1/status` | includes `metrics_events_dropped`, `events_stream_gaps`, `events_replay_misses`, `events_backlog_drops` |
-| Recent events | `curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" "http://localhost:8080/api/v1/events/recent?limit=10"` | each row has `event_id`, `evidence_id`, `decision`, `reason_code`, `cost_eur`, `correlation_id` |
+| Recent events | `curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" "http://localhost:8080/api/v1/events/recent?limit=10"` | each row has `event_id`, `evidence_id`, `decision`, `reason_code`, optional `reasons[]`, `cost_eur`, `correlation_id` |
 | SSE resume | `curl -N -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" -H "Last-Event-ID: <id>" http://localhost:8080/api/v1/events/stream` | stream resumes after `<id>`; emits `event: gap` on cursor miss |
 | Dashboard parity | open `http://localhost:8080/dashboard?talon_admin_key=$TALON_ADMIN_KEY` | "Session timeline" rows match `/api/v1/events/recent` |
 

--- a/internal/agent/graphadapter/adapter.go
+++ b/internal/agent/graphadapter/adapter.go
@@ -245,7 +245,7 @@ func (a *Adapter) handleToolCall(ctx context.Context, span trace.Span, ev *Event
 		return a.capacityDecision(ctx, ev, err), nil
 	}
 	a.observeRunContext(rs, ev)
-	toolCalls := a.incrementToolCalls(rs, ev.Timestamp)
+	toolCalls := a.toolCallsForRun(ev.GraphRunID) + 1
 
 	policyInput := map[string]interface{}{
 		"event_type":        string(ev.Type),
@@ -282,6 +282,7 @@ func (a *Adapter) handleToolCall(ctx context.Context, span trace.Span, ev *Event
 		}
 	}
 
+	a.incrementToolCalls(rs, ev.Timestamp)
 	allowDec := &Decision{Action: ActionAllow, Allowed: true}
 	allowDec.EvidenceID = a.recordStepEvidence(ctx, ev, "tool_allowed", allowDec)
 	return allowDec, nil

--- a/internal/agent/graphadapter/adapter_policy_test.go
+++ b/internal/agent/graphadapter/adapter_policy_test.go
@@ -276,6 +276,58 @@ func TestAdapterWithPolicy_ToolCall_ExceedsMaxToolCallsPerRun(t *testing.T) {
 	assert.Contains(t, denied.Reasons[0], "max_tool_calls_per_run")
 }
 
+func TestAdapterWithPolicy_ForbiddenToolDoesNotConsumeToolCallBudget(t *testing.T) {
+	eng := newPolicyWithAllResourceLimits(t, 50, 10.0, 3, 1)
+	gen, store := newEvidenceStack(t)
+	adapter := NewAdapter(eng, gen, store)
+	ctx := context.Background()
+	graphRunID := "gr_policy_forbidden_tool_budget"
+
+	allowed, err := adapter.HandleEvent(ctx, &Event{
+		Type:       EventToolCall,
+		GraphRunID: graphRunID,
+		TenantID:   "acme",
+		AgentID:    "test-agent",
+		Timestamp:  time.Now(),
+		ToolMeta: &ToolMeta{
+			Name:      "google_search",
+			Arguments: map[string]interface{}{"query": "first"},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, allowed.Allowed)
+
+	deniedForbidden, err := adapter.HandleEvent(ctx, &Event{
+		Type:       EventToolCall,
+		GraphRunID: graphRunID,
+		TenantID:   "acme",
+		AgentID:    "test-agent",
+		Timestamp:  time.Now(),
+		ToolMeta: &ToolMeta{
+			Name:      "delete_database",
+			Arguments: map[string]interface{}{},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, deniedForbidden.Allowed)
+
+	retryAllowed, err := adapter.HandleEvent(ctx, &Event{
+		Type:       EventRetry,
+		GraphRunID: graphRunID,
+		TenantID:   "acme",
+		AgentID:    "test-agent",
+		NodeID:     "search_node",
+		Timestamp:  time.Now(),
+		Error: &ErrorMeta{
+			Message:    "temporary issue",
+			Retryable:  true,
+			RetryCount: 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, retryAllowed.Allowed)
+}
+
 func TestAdapterWithPolicy_RunEnd_EvidenceRecorded(t *testing.T) {
 	eng := newPolicyWithResourceLimits(t, 50, 10.0, 3)
 	gen, store := newEvidenceStack(t)

--- a/internal/cmd/degraded_warning.go
+++ b/internal/cmd/degraded_warning.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type statusSnapshot struct {
+	Status               string `json:"status"`
+	EvidenceOK           bool   `json:"evidence_ok"`
+	EvidenceError        string `json:"evidence_error"`
+	EventsStreamGaps     int64  `json:"events_stream_gaps"`
+	EventsReplayMisses   int64  `json:"events_replay_misses"`
+	EventsBacklogDrops   int64  `json:"events_backlog_drops"`
+	MetricsEventsDropped int64  `json:"metrics_events_dropped"`
+	ReconcileError       string `json:"metrics_reconcile_error"`
+}
+
+func warnIfDegraded(ctx context.Context, out io.Writer, baseURL string) {
+	snap, ok := fetchStatusSnapshot(ctx, baseURL)
+	if !ok {
+		return
+	}
+	issues := degradedIssues(snap)
+	if len(issues) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(out, "warning: runtime degraded (%s)\n", strings.Join(issues, "; "))
+}
+
+func fetchStatusSnapshot(ctx context.Context, baseURL string) (statusSnapshot, bool) {
+	base := trimRightSlash(baseURL)
+	if base == "" {
+		base = "http://localhost:8080"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/v1/status", nil)
+	if err != nil {
+		return statusSnapshot{}, false
+	}
+	if adminKey := os.Getenv("TALON_ADMIN_KEY"); adminKey != "" {
+		req.Header.Set("X-Talon-Admin-Key", adminKey)
+	}
+	resp, err := (&http.Client{Timeout: 3 * time.Second}).Do(req)
+	if err != nil {
+		return statusSnapshot{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return statusSnapshot{}, false
+	}
+	var snap statusSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		return statusSnapshot{}, false
+	}
+	return snap, true
+}
+
+func degradedIssues(snap statusSnapshot) []string {
+	issues := make([]string, 0, 5)
+	if !snap.EvidenceOK || strings.EqualFold(snap.Status, "degraded") {
+		if snap.EvidenceError != "" {
+			issues = append(issues, "evidence write failures")
+		} else {
+			issues = append(issues, "degraded server status")
+		}
+	}
+	if snap.EventsBacklogDrops > 0 || snap.MetricsEventsDropped > 0 {
+		issues = append(issues, "collector/backlog drops")
+	}
+	if snap.EventsStreamGaps > 0 || snap.EventsReplayMisses > 0 {
+		issues = append(issues, "event stream gaps")
+	}
+	if snap.ReconcileError != "" {
+		issues = append(issues, "metrics reconciliation errors")
+	}
+	return issues
+}

--- a/internal/cmd/degraded_warning_test.go
+++ b/internal/cmd/degraded_warning_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWarnIfDegraded_PrintsWarningWhenStatusDegraded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"degraded","evidence_ok":false,"evidence_error":"db timeout","events_backlog_drops":2}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	warnIfDegraded(context.Background(), &out, srv.URL)
+	assert.Contains(t, out.String(), "warning: runtime degraded")
+	assert.Contains(t, out.String(), "evidence write failures")
+	assert.Contains(t, out.String(), "collector/backlog drops")
+}
+
+func TestWarnIfDegraded_SilentWhenHealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","evidence_ok":true}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	warnIfDegraded(context.Background(), &out, srv.URL)
+	assert.Equal(t, "", out.String())
+}

--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -45,6 +45,9 @@ var eventsTailCmd = &cobra.Command{
 }
 
 func tailEventsHTTP(ctx context.Context, outWriter interface{ Write([]byte) (int, error) }) error {
+	if !eventsJSON {
+		warnIfDegraded(ctx, outWriter, eventsURL)
+	}
 	req, err := buildEventsStreamRequest(ctx)
 	if err != nil {
 		return err

--- a/internal/cmd/metrics.go
+++ b/internal/cmd/metrics.go
@@ -34,6 +34,9 @@ var metricsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if !metricsJSON {
+			warnIfDegraded(ctx, cmd.OutOrStdout(), metricsURL)
+		}
 
 		callers := snap.CallerStats
 		sort.Slice(callers, func(i, j int) bool { return callers[i].Requests > callers[j].Requests })

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -432,6 +432,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 		metricsCollector = metrics.NewCollector(enforcementMode, evidenceStore, collectorOpts...)
 		defer metricsCollector.Close()
+		evidenceStore.SetStoreObserver(func(ctx context.Context, ev *evidence.Evidence) {
+			metricsCollector.Record(metrics.GatewayEventFromEvidence(ev))
+		})
 
 		if err := metricsCollector.BackfillFromStore(ctx, evidenceStore); err != nil {
 			log.Warn().Err(err).Msg("dashboard backfill failed")
@@ -450,9 +453,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		stopReconcile := metricsCollector.StartReconcileLoop(ctx, evidenceStore, reconcileCfg)
 		defer stopReconcile()
 
-		// Wire the collector as the gateway's metrics recorder via adapter
 		if gw, ok := gatewayHandler.(*gateway.Gateway); ok {
-			gw.SetMetricsRecorder(&metricsRecorderAdapter{collector: metricsCollector})
 			gw.SetSessionStore(sessionStore)
 		}
 
@@ -530,19 +531,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	log.Info().Msg("server_stopped")
 	return nil
-}
-
-// metricsRecorderAdapter bridges gateway.MetricsRecorder to metrics.Collector.
-type metricsRecorderAdapter struct {
-	collector *metrics.Collector
-}
-
-func (a *metricsRecorderAdapter) RecordGatewayEvent(event interface{}) {
-	e, ok := metrics.MapToGatewayEvent(event)
-	if !ok {
-		return
-	}
-	a.collector.Record(e)
 }
 
 func resolveServeAddress(host string, port int, quickstartEnabled, unsafeListen bool) (string, error) {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -436,6 +436,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err := metricsCollector.BackfillFromStore(ctx, evidenceStore); err != nil {
 			log.Warn().Err(err).Msg("dashboard backfill failed")
 		}
+		reconcileCfg := metrics.DefaultReconcileLoopConfig()
+		if raw := strings.TrimSpace(os.Getenv("TALON_METRICS_RECONCILE_INTERVAL")); raw != "" {
+			if d, err := time.ParseDuration(raw); err == nil {
+				reconcileCfg.Interval = d
+			}
+		}
+		if raw := strings.TrimSpace(os.Getenv("TALON_METRICS_RECONCILE_WINDOW")); raw != "" {
+			if d, err := time.ParseDuration(raw); err == nil {
+				reconcileCfg.Window = d
+			}
+		}
+		stopReconcile := metricsCollector.StartReconcileLoop(ctx, evidenceStore, reconcileCfg)
+		defer stopReconcile()
 
 		// Wire the collector as the gateway's metrics recorder via adapter
 		if gw, ok := gatewayHandler.(*gateway.Gateway); ok {

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -12,13 +12,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	_ "github.com/mattn/go-sqlite3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dativo-io/talon/internal/explanation"
+	"github.com/dativo-io/talon/internal/health"
 	talonotel "github.com/dativo-io/talon/internal/otel"
 )
 
@@ -26,9 +29,15 @@ var tracer = talonotel.Tracer("github.com/dativo-io/talon/internal/evidence")
 
 // Store persists HMAC-signed evidence records in SQLite.
 type Store struct {
-	db     *sql.DB
-	signer *Signer
+	db *sql.DB
+	// observer receives post-commit notifications for successfully stored evidence.
+	observerMu sync.RWMutex
+	observer   StoreObserver
+	signer     *Signer
 }
+
+// StoreObserver receives post-commit notifications for stored evidence rows.
+type StoreObserver func(ctx context.Context, ev *Evidence)
 
 // Evidence is the full audit record for a single agent invocation.
 type Evidence struct {
@@ -366,6 +375,31 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+// SetStoreObserver updates the optional post-commit observer for Store().
+func (s *Store) SetStoreObserver(fn StoreObserver) {
+	s.observerMu.Lock()
+	defer s.observerMu.Unlock()
+	s.observer = fn
+}
+
+func (s *Store) notifyStored(ctx context.Context, ev *Evidence) {
+	s.observerMu.RLock()
+	observer := s.observer
+	s.observerMu.RUnlock()
+	if observer == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().
+				Str("evidence_id", ev.ID).
+				Interface("panic", r).
+				Msg("evidence_store_observer_panicked")
+		}
+	}()
+	observer(ctx, ev)
+}
+
 // Store saves evidence with an HMAC signature.
 func (s *Store) Store(ctx context.Context, ev *Evidence) error {
 	ctx, span := tracer.Start(ctx, "evidence.store",
@@ -418,10 +452,13 @@ func (s *Store) Store(ctx context.Context, ev *Evidence) error {
 		ev.CandidateIndex, ev.JudgeScore, ev.Selected, ev.PlanID, ev.GraphRunID,
 	)
 	if err != nil {
+		health.MarkEvidenceWriteFailure(time.Now().UTC(), err)
 		return fmt.Errorf("storing evidence: %w", err)
 	}
 
+	health.MarkEvidenceWriteSuccess(time.Now().UTC())
 	RecordEvidenceStored(ctx, ev.InvocationType)
+	s.notifyStored(ctx, ev)
 	return nil
 }
 

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 

--- a/internal/gateway/extract_test.go
+++ b/internal/gateway/extract_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/stretchr/testify/assert"
@@ -208,7 +209,7 @@ func TestGateway_PIIRedactedBeforeForwarding(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"content":"Processed"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`))
 	})
 
-	gw, _, _ := setupOpenClawGateway(t, "redact", handler)
+	gw, _, evStore := setupOpenClawGateway(t, "redact", handler)
 
 	requestBody := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Send report to hans.mueller@example.de with IBAN DE89370400440532013000, phone +34612345678, and VAT ESB12345678"}]}`
 	w := makeGatewayRequest(gw, requestBody)
@@ -223,6 +224,13 @@ func TestGateway_PIIRedactedBeforeForwarding(t *testing.T) {
 
 	assert.Contains(t, forwarded, "Send report to",
 		"non-PII content must be preserved in forwarded request")
+
+	records, err := evStore.List(context.Background(), "test-tenant", "openclaw-main",
+		time.Now().Add(-time.Minute), time.Now().Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	assert.True(t, records[0].Classification.PIIRedacted,
+		"evidence should mark input redaction when pii_action=redact")
 }
 
 func TestGateway_PIIBlockModePreventsForwarding(t *testing.T) {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/explanation"
-	"github.com/dativo-io/talon/internal/health"
 	"github.com/dativo-io/talon/internal/llm"
 	"github.com/dativo-io/talon/internal/metrics"
 	"github.com/dativo-io/talon/internal/secrets"
@@ -894,10 +893,8 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	params.TPOTMS = tpotMS
 	ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, params)
 	if err != nil {
-		health.MarkEvidenceWriteFailure(time.Now().UTC(), err)
 		return nil, err
 	}
-	health.MarkEvidenceWriteSuccess(time.Now().UTC())
 	return ev, nil
 }
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -275,7 +275,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -330,7 +330,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"Request blocked: attachment violates policy")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
 				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, "", false,
-				[]string{"attachment policy block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				[]string{"attachment policy block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -364,7 +364,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -392,7 +392,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -443,7 +443,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -465,7 +465,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusForbidden, reasons[0])
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -500,7 +500,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				WriteProviderError(w, route.Provider, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -518,7 +518,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
 					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -536,11 +536,13 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	inputPIIRedacted := false
 	// Step 7: Redact (if policy says redact and PII found, skip in shadow mode)
 	if !isShadow && piiAction == "redact" && classification.HasPII {
 		redacted, redactErr := RedactRequestBody(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), route.Provider, forwardBody, g.classifier)
 		if redactErr == nil {
 			forwardBody = redacted
+			inputPIIRedacted = true
 		}
 	}
 
@@ -596,7 +598,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -672,7 +674,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -794,7 +796,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if forwardErr != nil {
 		forwardErrStr = forwardErr.Error()
 	}
-	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
@@ -809,7 +811,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -859,7 +861,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 		ShadowViolations:        shadowViolations,
 		InputTier:               classification.Tier,
 		PIIDetected:             piiDetected,
-		PIIRedacted:             false,
+		PIIRedacted:             inputPIIRedacted,
 		OutputPIIDetected:       outputPIIDetected,
 		OutputPIITypes:          outputPIITypes,
 		Cost:                    cost,

--- a/internal/metrics/backfill.go
+++ b/internal/metrics/backfill.go
@@ -13,27 +13,71 @@ type EvidenceLister interface {
 	List(ctx context.Context, tenantID, agentID string, from, to time.Time, limit int) ([]evidence.Evidence, error)
 }
 
+const (
+	defaultReconcileWindow = 24 * time.Hour
+	defaultReconcileLimit  = 10000
+)
+
 // BackfillFromStore replays the last 24 hours of evidence into the collector
 // so that the dashboard has data immediately after a restart.
 func (c *Collector) BackfillFromStore(ctx context.Context, store EvidenceLister) error {
-	now := time.Now().UTC()
-	since := now.Add(-24 * time.Hour)
-
-	records, err := store.List(ctx, "", "", since, now, 10000)
+	_, err := c.ReconcileFromStore(ctx, store, defaultReconcileWindow, defaultReconcileLimit)
 	if err != nil {
 		return fmt.Errorf("backfill list: %w", err)
 	}
+	return nil
+}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for i := range records {
-		ev, ok := MapToGatewayEvent(&records[i])
-		if !ok {
-			continue
-		}
-		c.processEvent(ev)
+// ReconcileFromStore rebuilds the collector from bounded evidence history.
+// It is idempotent and returns the number of recovered events compared to
+// the collector request total before reconciliation.
+func (c *Collector) ReconcileFromStore(ctx context.Context, store EvidenceLister, window time.Duration, limit int) (int, error) {
+	if store == nil {
+		err := fmt.Errorf("evidence store is nil")
+		c.mu.Lock()
+		c.markReconcileFailure(err)
+		c.mu.Unlock()
+		return 0, err
+	}
+	if window <= 0 {
+		window = defaultReconcileWindow
+	}
+	if limit <= 0 {
+		limit = defaultReconcileLimit
 	}
 
-	return nil
+	now := time.Now().UTC()
+	since := now.Add(-window)
+	records, err := store.List(ctx, "", "", since, now, limit)
+	if err != nil {
+		c.mu.Lock()
+		c.markReconcileFailure(err)
+		c.mu.Unlock()
+		return 0, fmt.Errorf("reconcile list: %w", err)
+	}
+
+	var lag time.Duration
+	if len(records) > 0 {
+		latest := records[0].Timestamp
+		for i := 1; i < len(records); i++ {
+			if records[i].Timestamp.After(latest) {
+				latest = records[i].Timestamp
+			}
+		}
+		if latest.Before(now) {
+			lag = now.Sub(latest)
+		}
+	}
+
+	c.mu.Lock()
+	before := c.totalRequests
+	c.rebuildFromEvidence(records)
+	after := c.totalRequests
+	recovered := after - before
+	if recovered < 0 {
+		recovered = 0
+	}
+	c.markReconcileSuccess(recovered, lag)
+	c.mu.Unlock()
+	return recovered, nil
 }

--- a/internal/metrics/backfill.go
+++ b/internal/metrics/backfill.go
@@ -72,6 +72,9 @@ func (c *Collector) ReconcileFromStore(ctx context.Context, store EvidenceLister
 	c.mu.Lock()
 	before := c.totalRequests
 	c.rebuildFromEvidence(records)
+	// Drain queued events: gateway persists evidence before calling Record,
+	// so any buffered events are already included in the rebuild above.
+	c.drainEvents()
 	after := c.totalRequests
 	recovered := after - before
 	if recovered < 0 {

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -174,6 +174,7 @@ type PlanStats struct {
 
 // GatewayEvent is the input from the gateway for real-time dashboard aggregation.
 type GatewayEvent struct {
+	EvidenceID       string
 	Timestamp        time.Time
 	CallerID         string
 	Model            string
@@ -289,6 +290,16 @@ type Collector struct {
 	tenantID       string
 	planStatsFn    func(context.Context, string) (PlanStats, error)
 	droppedEvents  uint64
+	reconcileStats ReconcileStats
+}
+
+// ReconcileStats tracks collector reconciliation health and outcomes.
+type ReconcileStats struct {
+	Runs            uint64    `json:"runs"`
+	RecoveredEvents uint64    `json:"recovered_events"`
+	LastRunAt       time.Time `json:"last_run_at,omitempty"`
+	LastError       string    `json:"last_error,omitempty"`
+	LastLagMS       int64     `json:"last_lag_ms,omitempty"`
 }
 
 // CollectorOption configures a Collector.
@@ -535,6 +546,76 @@ func (c *Collector) Snapshot(ctx context.Context) Snapshot {
 
 	c.fillAggregateMetrics(ctx, &snap)
 	return snap
+}
+
+// ReconcileStatus returns the latest reconciliation counters and health fields.
+func (c *Collector) ReconcileStatus() ReconcileStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.reconcileStats
+}
+
+func (c *Collector) resetInMemoryAggregates() {
+	c.buckets = make(map[string]*bucket)
+	c.callerStats = make(map[string]*callerAccum)
+	c.piiCounts = make(map[string]int)
+	c.toolFiltered = make(map[string]int)
+	c.shadowViolations = make(map[string]*shadowViolationAccum)
+	c.byRiskLevel = make(map[string]*riskLevelAccum)
+	c.anomalousAgents = make(map[string]bool)
+	c.piiRedactions = 0
+	c.toolRequested = 0
+	c.bulkOperations = 0
+	c.irreversibleBlocked = 0
+	c.totalRequests = 0
+	c.blockedRequests = 0
+	c.totalErrors = 0
+	c.totalSuccessful = 0
+	c.totalFailed = 0
+	c.totalTimedOut = 0
+	c.totalDenied = 0
+	c.totalCostEUR = 0
+	c.totalLatencyMS = 0
+	c.totalTTFTMS = 0
+	c.ttftCount = 0
+	c.totalTPOTMS = 0
+	c.tpotCount = 0
+	c.latencyRing = [maxLatencySamples]int64{}
+	c.latencyRingPos = 0
+	c.latencyRingLen = 0
+}
+
+func (c *Collector) rebuildFromEvidence(records []evidence.Evidence) {
+	c.resetInMemoryAggregates()
+	for i := range records {
+		ev := GatewayEventFromEvidence(&records[i])
+		c.processEvent(ev)
+	}
+}
+
+func (c *Collector) markReconcileSuccess(recovered int, lag time.Duration) {
+	c.reconcileStats.Runs++
+	if recovered > 0 {
+		c.reconcileStats.RecoveredEvents += uint64(recovered)
+	}
+	c.reconcileStats.LastRunAt = time.Now().UTC()
+	c.reconcileStats.LastError = ""
+	if lag > 0 {
+		c.reconcileStats.LastLagMS = lag.Milliseconds()
+	} else {
+		c.reconcileStats.LastLagMS = 0
+	}
+	recordCollectorReconcileRun(recovered, lag, false)
+}
+
+func (c *Collector) markReconcileFailure(err error) {
+	c.reconcileStats.Runs++
+	c.reconcileStats.LastRunAt = time.Now().UTC()
+	c.reconcileStats.LastLagMS = 0
+	if err != nil {
+		c.reconcileStats.LastError = err.Error()
+	}
+	recordCollectorReconcileRun(0, 0, true)
 }
 
 func (c *Collector) buildInMemorySnapshot() Snapshot {

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -386,6 +386,18 @@ func (c *Collector) consumeLoop() {
 	}
 }
 
+// drainEvents discards all buffered events from the channel.
+// Must be called while holding c.mu.
+func (c *Collector) drainEvents() {
+	for {
+		select {
+		case <-c.events:
+		default:
+			return
+		}
+	}
+}
+
 func (c *Collector) processEvent(e GatewayEvent) {
 	c.totalRequests++
 	if e.Blocked {

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
 )
 
 // mockQuerier implements evidence.MetricsQuerier for testing.
@@ -330,6 +332,46 @@ func TestCollectorDroppedEventsBackpressure(t *testing.T) {
 	assert.Greater(t, c.DroppedEvents(), uint64(0))
 	snap := c.Snapshot(context.Background())
 	assert.Equal(t, c.DroppedEvents(), snap.DroppedEvents)
+}
+
+func TestCollectorDroppedEvents_ReconcileRestoresParity(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubEvidenceLister{
+		records: []evidence.Evidence{
+			{
+				ID:              "ev-r1",
+				Timestamp:       now.Add(-2 * time.Minute),
+				RequestSourceID: "caller-a",
+				AgentID:         "agent-a",
+				PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+				Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.01, DurationMS: 50},
+			},
+			{
+				ID:              "ev-r2",
+				Timestamp:       now.Add(-1 * time.Minute),
+				RequestSourceID: "caller-a",
+				AgentID:         "agent-a",
+				PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+				Execution:       evidence.Execution{ModelUsed: "gpt-4o-mini", Cost: 0.02, DurationMS: 70},
+			},
+		},
+	}
+	c := newTestCollector("enforce", nil)
+	defer c.Close()
+
+	// Initial drift: only one event is in collector.
+	c.Record(GatewayEventFromEvidence(&store.records[0]))
+	waitForProcessing(c)
+	assert.Equal(t, 1, c.Snapshot(context.Background()).Summary.TotalRequests)
+
+	recovered, err := c.ReconcileFromStore(context.Background(), store, 10*time.Minute, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, 1, recovered)
+
+	snap := c.Snapshot(context.Background())
+	assert.Equal(t, 2, snap.Summary.TotalRequests)
+	assert.InDelta(t, 0.03, snap.Summary.TotalCostEUR, 0.0001)
+	assertSnapshotCrossChecks(t, snap)
 }
 
 func TestPIITimelineAndCostTimeline(t *testing.T) {

--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -12,13 +13,17 @@ import (
 var collectorMeter = otel.Meter("github.com/dativo-io/talon/internal/metrics")
 
 var (
-	mTaskSuccessTotal  metric.Int64Counter
-	mTaskFailedTotal   metric.Int64Counter
-	mTaskTimedOutTotal metric.Int64Counter
-	mTaskDeniedTotal   metric.Int64Counter
-	mCostPerSuccess    metric.Float64Histogram
-	mViolationsDaily   metric.Int64Counter
-	mEventsDropped     metric.Int64Counter
+	mTaskSuccessTotal   metric.Int64Counter
+	mTaskFailedTotal    metric.Int64Counter
+	mTaskTimedOutTotal  metric.Int64Counter
+	mTaskDeniedTotal    metric.Int64Counter
+	mCostPerSuccess     metric.Float64Histogram
+	mViolationsDaily    metric.Int64Counter
+	mEventsDropped      metric.Int64Counter
+	mReconcileRuns      metric.Int64Counter
+	mReconcileRecovered metric.Int64Counter
+	mReconcileErrors    metric.Int64Counter
+	mReconcileLagMS     metric.Int64Histogram
 
 	collectorMetricsOnce       sync.Once
 	collectorMetricsRegistered bool
@@ -72,6 +77,34 @@ func initCollectorMetrics() {
 	mEventsDropped, err = collectorMeter.Int64Counter("talon.metrics.events_dropped.total",
 		metric.WithDescription("Dropped collector events due to backpressure"),
 		metric.WithUnit("{event}"))
+	if err != nil {
+		return
+	}
+
+	mReconcileRuns, err = collectorMeter.Int64Counter("talon.metrics.reconcile_runs.total",
+		metric.WithDescription("Periodic collector reconciliation runs"),
+		metric.WithUnit("{run}"))
+	if err != nil {
+		return
+	}
+
+	mReconcileRecovered, err = collectorMeter.Int64Counter("talon.metrics.reconcile_recovered_events.total",
+		metric.WithDescription("Events recovered by reconciliation"),
+		metric.WithUnit("{event}"))
+	if err != nil {
+		return
+	}
+
+	mReconcileErrors, err = collectorMeter.Int64Counter("talon.metrics.reconcile_errors.total",
+		metric.WithDescription("Reconciliation failures"),
+		metric.WithUnit("{error}"))
+	if err != nil {
+		return
+	}
+
+	mReconcileLagMS, err = collectorMeter.Int64Histogram("talon.metrics.reconcile_lag_ms",
+		metric.WithDescription("Replay lag from latest evidence to reconciliation time"),
+		metric.WithUnit("ms"))
 	if err != nil {
 		return
 	}
@@ -133,4 +166,21 @@ func recordCollectorEventDrop() {
 		return
 	}
 	mEventsDropped.Add(context.Background(), 1)
+}
+
+func recordCollectorReconcileRun(recovered int, lag time.Duration, hadError bool) {
+	ensureCollectorMetrics()
+	if !collectorMetricsRegistered {
+		return
+	}
+	mReconcileRuns.Add(context.Background(), 1)
+	if recovered > 0 {
+		mReconcileRecovered.Add(context.Background(), int64(recovered))
+	}
+	if lag > 0 {
+		mReconcileLagMS.Record(context.Background(), lag.Milliseconds())
+	}
+	if hadError {
+		mReconcileErrors.Add(context.Background(), 1)
+	}
 }

--- a/internal/metrics/projection.go
+++ b/internal/metrics/projection.go
@@ -71,6 +71,7 @@ func mapToGatewayEvent(input interface{}) (GatewayEvent, bool) {
 // dashboard metrics event shape.
 func GatewayEventFromOperationalEvent(ev events.OperationalEvent) GatewayEvent {
 	return GatewayEvent{
+		EvidenceID:    ev.EvidenceID,
 		Timestamp:     ev.Timestamp,
 		CallerID:      firstNonEmpty(ev.Caller, ev.AgentID),
 		Model:         ev.Model,
@@ -94,6 +95,7 @@ func gatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
 	ev.TokensOutput = e.Execution.Tokens.Output
 	ev.TTFTMS = e.Execution.TTFTMS
 	ev.TPOTMS = e.Execution.TPOTMS
+	ev.EvidenceID = e.ID
 	ev.WouldHaveBlocked = e.ObservationModeOverride
 	ev.TimedOut = isTimedOutError(e.Execution.Error)
 
@@ -169,6 +171,9 @@ func mapStringFields(m map[string]interface{}, e *GatewayEvent) {
 	}
 	if v, ok := m["enforcement_mode"].(string); ok {
 		e.EnforcementMode = v
+	}
+	if v, ok := m["evidence_id"].(string); ok {
+		e.EvidenceID = v
 	}
 }
 

--- a/internal/metrics/reconcile.go
+++ b/internal/metrics/reconcile.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ReconcileLoopConfig configures periodic evidence->collector reconciliation.
+type ReconcileLoopConfig struct {
+	Interval time.Duration
+	Window   time.Duration
+	Limit    int
+}
+
+// DefaultReconcileLoopConfig returns conservative default settings.
+func DefaultReconcileLoopConfig() ReconcileLoopConfig {
+	return ReconcileLoopConfig{
+		Interval: 30 * time.Second,
+		Window:   defaultReconcileWindow,
+		Limit:    defaultReconcileLimit,
+	}
+}
+
+// StartReconcileLoop runs periodic idempotent reconciliation until stop is called
+// or ctx is cancelled.
+func (c *Collector) StartReconcileLoop(ctx context.Context, store EvidenceLister, cfg ReconcileLoopConfig) (stop func()) {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = defaultReconcileWindow
+	}
+	if cfg.Limit <= 0 {
+		cfg.Limit = defaultReconcileLimit
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	ticker := time.NewTicker(cfg.Interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				recovered, err := c.ReconcileFromStore(loopCtx, store, cfg.Window, cfg.Limit)
+				if err != nil {
+					log.Warn().Err(err).Msg("metrics_reconcile_failed")
+					continue
+				}
+				if recovered > 0 {
+					log.Info().Int("recovered_events", recovered).Msg("metrics_reconcile_recovered")
+				}
+			}
+		}
+	}()
+	return cancel
+}

--- a/internal/metrics/reconcile_test.go
+++ b/internal/metrics/reconcile_test.go
@@ -1,0 +1,82 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+func makeEvidence(id string, ts time.Time) evidence.Evidence {
+	return evidence.Evidence{
+		ID:              id,
+		Timestamp:       ts,
+		RequestSourceID: "reconcile-caller",
+		AgentID:         "reconcile-agent",
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true},
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.01,
+			DurationMS: 100,
+		},
+	}
+}
+
+func TestReconcileFromStore_ConvergesAfterDrop(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubEvidenceLister{
+		records: []evidence.Evidence{
+			makeEvidence("ev-1", now.Add(-2*time.Minute)),
+			makeEvidence("ev-2", now.Add(-90*time.Second)),
+			makeEvidence("ev-3", now.Add(-30*time.Second)),
+		},
+	}
+	c := NewCollector("enforce", nil)
+	defer c.Close()
+
+	// Simulate drift/missed events: collector only saw the first record.
+	c.Record(GatewayEventFromEvidence(&store.records[0]))
+	waitForProcessing(c)
+	require.Equal(t, 1, c.Snapshot(context.Background()).Summary.TotalRequests)
+
+	recovered, err := c.ReconcileFromStore(context.Background(), store, 10*time.Minute, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, 2, recovered)
+
+	snap := c.Snapshot(context.Background())
+	assert.Equal(t, 3, snap.Summary.TotalRequests)
+	status := c.ReconcileStatus()
+	assert.Equal(t, uint64(1), status.Runs)
+	assert.Equal(t, uint64(2), status.RecoveredEvents)
+	assert.Empty(t, status.LastError)
+}
+
+func TestReconcileFromStore_IsIdempotentAcrossRepeatedRuns(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubEvidenceLister{
+		records: []evidence.Evidence{
+			makeEvidence("ev-a", now.Add(-2*time.Minute)),
+			makeEvidence("ev-b", now.Add(-1*time.Minute)),
+		},
+	}
+	c := NewCollector("enforce", nil)
+	defer c.Close()
+
+	recoveredFirst, err := c.ReconcileFromStore(context.Background(), store, 10*time.Minute, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, 2, recoveredFirst)
+	first := c.Snapshot(context.Background())
+
+	recoveredSecond, err := c.ReconcileFromStore(context.Background(), store, 10*time.Minute, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, 0, recoveredSecond)
+	second := c.Snapshot(context.Background())
+
+	assert.Equal(t, first.Summary.TotalRequests, second.Summary.TotalRequests)
+	assert.InDelta(t, first.Summary.TotalCostEUR, second.Summary.TotalCostEUR, 0.00001)
+	assert.Equal(t, first.Summary.BlockedRequests, second.Summary.BlockedRequests)
+}

--- a/internal/metrics/reconcile_test.go
+++ b/internal/metrics/reconcile_test.go
@@ -80,3 +80,28 @@ func TestReconcileFromStore_IsIdempotentAcrossRepeatedRuns(t *testing.T) {
 	assert.InDelta(t, first.Summary.TotalCostEUR, second.Summary.TotalCostEUR, 0.00001)
 	assert.Equal(t, first.Summary.BlockedRequests, second.Summary.BlockedRequests)
 }
+
+func TestReconcileFromStore_DoesNotDoubleCountObservedEvidence(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubEvidenceLister{
+		records: []evidence.Evidence{
+			makeEvidence("ev-obs-1", now.Add(-1*time.Minute)),
+		},
+	}
+	c := NewCollector("enforce", nil)
+	defer c.Close()
+
+	// Simulate live store observer path before periodic reconciliation.
+	c.Record(GatewayEventFromEvidence(&store.records[0]))
+	waitForProcessing(c)
+	before := c.Snapshot(context.Background())
+	require.Equal(t, 1, before.Summary.TotalRequests)
+
+	recovered, err := c.ReconcileFromStore(context.Background(), store, 10*time.Minute, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, 0, recovered)
+
+	after := c.Snapshot(context.Background())
+	assert.Equal(t, 1, after.Summary.TotalRequests)
+	assert.InDelta(t, before.Summary.TotalCostEUR, after.Summary.TotalCostEUR, 0.00001)
+}

--- a/internal/server/dashboard_api_test.go
+++ b/internal/server/dashboard_api_test.go
@@ -49,10 +49,13 @@ func TestEmbeddedDashboardsContainUnifiedMissionControlMarkers(t *testing.T) {
 	assert.Contains(t, web.DashboardHTML, "Talon Mission Control")
 	assert.Contains(t, web.DashboardHTML, "Session timeline (lifecycle)")
 	assert.Contains(t, web.DashboardHTML, "Compliance report preview")
+	assert.Contains(t, web.DashboardHTML, "runtime-warning-banner")
+	assert.Contains(t, web.DashboardHTML, "renderEventSignalChips")
 
 	assert.Contains(t, web.GatewayDashboardHTML, "Talon <span>Mission Control</span>")
 	assert.Contains(t, web.GatewayDashboardHTML, "Session Timeline (Lifecycle)")
 	assert.Contains(t, web.GatewayDashboardHTML, "Compliance Report Preview")
+	assert.Contains(t, web.GatewayDashboardHTML, "reliability-badge")
 }
 
 func TestHandleMetricsJSON(t *testing.T) {

--- a/internal/server/events_api_test.go
+++ b/internal/server/events_api_test.go
@@ -296,6 +296,52 @@ func TestStatusIncludesEvidenceDegradedFields(t *testing.T) {
 	assert.True(t, hasStreamActive && hasStreamGaps && hasReplayMisses && hasDisconnects && hasBacklogDrops)
 }
 
+func TestEventsRecentIncludesSignalSummaryFields(t *testing.T) {
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	ev := evidence.Evidence{
+		ID:              "ev-signals",
+		CorrelationID:   "corr-signals",
+		Timestamp:       time.Now().UTC(),
+		TenantID:        "default",
+		AgentID:         "agent-signal",
+		InvocationType:  "gateway",
+		RequestSourceID: "agent-signal",
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Classification:  evidence.Classification{PIIDetected: []string{"email"}},
+		ToolGovernance: &evidence.ToolGovernance{
+			ToolsRequested: []string{"read_file", "exec_cmd"},
+			ToolsFiltered:  []string{"exec_cmd"},
+		},
+		CacheHit:  true,
+		CostSaved: 0.02,
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.01,
+			DurationMS: 100,
+		},
+	}
+	require.NoError(t, store.Store(context.Background(), &ev))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/recent?limit=10", nil)
+	req.Header.Set("Authorization", "Bearer k-default")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Events []events.OperationalEvent `json:"events"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	require.NotEmpty(t, out.Events)
+
+	got := out.Events[0]
+	assert.Equal(t, "ev-signals", got.EvidenceID)
+	assert.Equal(t, []string{"email"}, got.PIIDetected)
+	assert.Equal(t, []string{"exec_cmd"}, got.ToolsFiltered)
+	assert.True(t, got.CacheHit)
+	assert.InDelta(t, 0.02, got.CostSaved, 0.0001)
+}
+
 func newEventsTestServer(t *testing.T, tenantKeys map[string]string) (*Server, *evidence.Store) {
 	t.Helper()
 	pol := minimalPolicy()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -613,6 +613,18 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"status": "ok", "evidence_count_today": 0, "cost_today": 0.0, "monthly": 0.0, "active_runs": 0,
 		"pending_memory_reviews": 0, "blocked_count": 0, "error_rate": 0.0, "enforcement_mode": "", "tenant_id": tenantID,
 	}
+	applyEvidenceHealthStatus(resp)
+	applyEventStreamStatus(resp)
+	s.applyEvidenceStoreStatus(r.Context(), resp, tenantID, dayStart, dayEnd, monthStart, monthEnd)
+	s.applyMemoryStoreStatus(r.Context(), resp, tenantID)
+	s.applyMetricsCollectorStatus(r.Context(), resp)
+	if s.activeRunTracker != nil {
+		resp["active_runs"] = s.activeRunTracker.Count(tenantID)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func applyEvidenceHealthStatus(resp map[string]interface{}) {
 	evHealth := health.GetEvidenceWriteStatus()
 	resp["evidence_ok"] = evHealth.OK
 	if !evHealth.LastGoodWrite.IsZero() {
@@ -625,40 +637,70 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		resp["evidence_error"] = evHealth.LastError
 		resp["status"] = "degraded"
 	}
+}
+
+func applyEventStreamStatus(resp map[string]interface{}) {
 	resp["events_stream_active"] = health.ActiveEventStreams()
 	resp["events_stream_gaps"] = health.EventStreamGaps()
 	resp["events_replay_misses"] = health.EventReplayMisses()
 	resp["events_stream_disconnects"] = health.EventStreamDisconnects()
 	resp["events_backlog_drops"] = health.EventBacklogDrops()
-	if s.evidenceStore != nil {
-		if n, err := s.evidenceStore.CountInRange(r.Context(), tenantID, "", dayStart, dayEnd); err == nil {
-			resp["evidence_count_today"] = n
-		}
-		if cost, err := s.evidenceStore.CostTotal(r.Context(), tenantID, "", dayStart, dayEnd); err == nil {
-			resp["cost_today"] = cost
-		}
-		if cost, err := s.evidenceStore.CostTotal(r.Context(), tenantID, "", monthStart, monthEnd); err == nil {
-			resp["monthly"] = cost
-		}
-		if blocked, err := s.evidenceStore.CountDeniedInRange(r.Context(), tenantID, "", dayStart, dayEnd); err == nil {
-			resp["blocked_count"] = blocked
-		}
+}
+
+func (s *Server) applyEvidenceStoreStatus(
+	ctx context.Context,
+	resp map[string]interface{},
+	tenantID string,
+	dayStart time.Time,
+	dayEnd time.Time,
+	monthStart time.Time,
+	monthEnd time.Time,
+) {
+	if s.evidenceStore == nil {
+		return
 	}
-	if s.memoryStore != nil {
-		if n, err := s.memoryStore.CountPendingReviewForTenant(r.Context(), tenantID); err == nil {
-			resp["pending_memory_reviews"] = n
-		}
+	if n, err := s.evidenceStore.CountInRange(ctx, tenantID, "", dayStart, dayEnd); err == nil {
+		resp["evidence_count_today"] = n
 	}
-	if s.metricsCollector != nil {
-		snap := s.metricsCollector.Snapshot(r.Context())
-		resp["error_rate"] = snap.Summary.ErrorRate
-		resp["enforcement_mode"] = snap.EnforcementMode
-		resp["metrics_events_dropped"] = s.metricsCollector.DroppedEvents()
+	if cost, err := s.evidenceStore.CostTotal(ctx, tenantID, "", dayStart, dayEnd); err == nil {
+		resp["cost_today"] = cost
 	}
-	if s.activeRunTracker != nil {
-		resp["active_runs"] = s.activeRunTracker.Count(tenantID)
+	if cost, err := s.evidenceStore.CostTotal(ctx, tenantID, "", monthStart, monthEnd); err == nil {
+		resp["monthly"] = cost
 	}
-	writeJSON(w, http.StatusOK, resp)
+	if blocked, err := s.evidenceStore.CountDeniedInRange(ctx, tenantID, "", dayStart, dayEnd); err == nil {
+		resp["blocked_count"] = blocked
+	}
+}
+
+func (s *Server) applyMemoryStoreStatus(ctx context.Context, resp map[string]interface{}, tenantID string) {
+	if s.memoryStore == nil {
+		return
+	}
+	if n, err := s.memoryStore.CountPendingReviewForTenant(ctx, tenantID); err == nil {
+		resp["pending_memory_reviews"] = n
+	}
+}
+
+func (s *Server) applyMetricsCollectorStatus(ctx context.Context, resp map[string]interface{}) {
+	if s.metricsCollector == nil {
+		return
+	}
+	snap := s.metricsCollector.Snapshot(ctx)
+	resp["error_rate"] = snap.Summary.ErrorRate
+	resp["enforcement_mode"] = snap.EnforcementMode
+	resp["metrics_events_dropped"] = s.metricsCollector.DroppedEvents()
+	reconcile := s.metricsCollector.ReconcileStatus()
+	resp["metrics_reconcile_runs"] = reconcile.Runs
+	resp["metrics_recovered_events"] = reconcile.RecoveredEvents
+	resp["metrics_reconcile_lag_ms"] = reconcile.LastLagMS
+	if !reconcile.LastRunAt.IsZero() {
+		resp["metrics_reconcile_last_run"] = reconcile.LastRunAt.UTC().Format(time.RFC3339)
+	}
+	if reconcile.LastError != "" {
+		resp["metrics_reconcile_error"] = reconcile.LastError
+		resp["status"] = "degraded"
+	}
 }
 
 func (s *Server) handleCosts(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/ssot_gate_test.go
+++ b/internal/server/ssot_gate_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dativo-io/talon/internal/events"
+	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/health"
+	"github.com/dativo-io/talon/internal/metrics"
 )
 
 // SSOT gate: ordering and core-field parity across evidence and events API.
@@ -83,4 +86,79 @@ func TestSSOTGate_DegradedStatusContract(t *testing.T) {
 	assert.Equal(t, false, out["evidence_ok"])
 	_, hasReason := out["evidence_error"]
 	assert.True(t, hasReason)
+}
+
+// SSOT gate: non-gateway evidence updates both events API and metrics totals live.
+func TestSSOTGate_NonGatewayEvidenceFeedsEventsAndMetrics(t *testing.T) {
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	collector := metrics.NewCollector("enforce", nil)
+	defer collector.Close()
+	store.SetStoreObserver(func(_ context.Context, ev *evidence.Evidence) {
+		collector.Record(metrics.GatewayEventFromEvidence(ev))
+	})
+
+	now := time.Now().UTC()
+	agentEv := evidence.Evidence{
+		ID:              "ev-agent-1",
+		CorrelationID:   "corr-agent-1",
+		Timestamp:       now.Add(-1 * time.Second),
+		TenantID:        "default",
+		AgentID:         "agent-a",
+		InvocationType:  "agent",
+		RequestSourceID: "agent-a",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"policy denied"},
+		},
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.0,
+			DurationMS: 80,
+		},
+	}
+	require.NoError(t, store.Store(context.Background(), &agentEv))
+
+	gatewayEv := evidence.Evidence{
+		ID:              "ev-gateway-1",
+		CorrelationID:   "corr-gateway-1",
+		Timestamp:       now,
+		TenantID:        "default",
+		AgentID:         "agent-a",
+		InvocationType:  "gateway",
+		RequestSourceID: "agent-a",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: true,
+			Action:  "allow",
+		},
+		Execution: evidence.Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.02,
+			DurationMS: 120,
+		},
+	}
+	require.NoError(t, store.Store(context.Background(), &gatewayEv))
+
+	time.Sleep(50 * time.Millisecond)
+	snap := collector.Snapshot(context.Background())
+	assert.Equal(t, 2, snap.Summary.TotalRequests)
+	assert.Equal(t, 1, snap.Summary.BlockedRequests)
+	assert.InDelta(t, 0.02, snap.Summary.TotalCostEUR, 0.0001)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/recent?limit=10", nil)
+	req.Header.Set("Authorization", "Bearer k-default")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Events []events.OperationalEvent `json:"events"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	require.Len(t, out.Events, 2)
+	assert.Equal(t, "ev-gateway-1", out.Events[0].EvidenceID)
+	assert.Equal(t, "gateway", out.Events[0].InvocationType)
+	assert.Equal(t, "ev-agent-1", out.Events[1].EvidenceID)
+	assert.Equal(t, "agent", out.Events[1].InvocationType)
+	assert.Equal(t, "blocked", out.Events[1].Decision)
 }

--- a/internal/server/ssot_gate_test.go
+++ b/internal/server/ssot_gate_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/health"
+)
+
+// SSOT gate: ordering and core-field parity across evidence and events API.
+func TestSSOTGate_RecentEventsParityOrdering(t *testing.T) {
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	now := time.Now().UTC()
+	insertEvidence(t, store, "ev-g1", "default", "agent-a", now.Add(-2*time.Second), true, 0.01)
+	insertEvidence(t, store, "ev-g2", "default", "agent-a", now.Add(-1*time.Second), false, 0.00)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/recent?limit=10", nil)
+	req.Header.Set("Authorization", "Bearer k-default")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		Events []map[string]interface{} `json:"events"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	require.Len(t, out.Events, 2)
+	assert.Equal(t, "ev-g2", out.Events[0]["evidence_id"])
+	assert.Equal(t, "ev-g1", out.Events[1]["evidence_id"])
+	require.NotEmpty(t, out.Events[0]["event_id"])
+	require.NotEmpty(t, out.Events[0]["tenant_id"])
+	require.NotEmpty(t, out.Events[0]["agent_id"])
+}
+
+// SSOT gate: reconnect path emits gap contract when replay window is exceeded.
+func TestSSOTGate_StreamReconnectGapContract(t *testing.T) {
+	health.ResetEventStreamStatsForTest()
+	t.Cleanup(health.ResetEventStreamStatsForTest)
+
+	srv, store := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	srv.eventsReplayBacklog = 1
+	now := time.Now().UTC()
+	insertEvidence(t, store, "ev-r1", "default", "agent-a", now.Add(-3*time.Second), true, 0.01)
+	insertEvidence(t, store, "ev-r2", "default", "agent-a", now.Add(-2*time.Second), true, 0.01)
+	insertEvidence(t, store, "ev-r3", "default", "agent-a", now.Add(-1*time.Second), true, 0.01)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/events/stream", nil)
+	req.Header.Set("Authorization", "Bearer k-default")
+	req.Header.Set("Last-Event-ID", eventsIDForTest(now.Add(-3*time.Second), "ev-r1"))
+	rec := httptest.NewRecorder()
+	ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+	srv.Routes().ServeHTTP(rec, req)
+
+	assert.Contains(t, rec.Body.String(), "event: gap")
+	assert.GreaterOrEqual(t, health.EventStreamGaps(), int64(1))
+}
+
+// SSOT gate: degraded-mode contract is surfaced via /v1/status.
+func TestSSOTGate_DegradedStatusContract(t *testing.T) {
+	health.ResetEvidenceWriteStatusForTest()
+	t.Cleanup(health.ResetEvidenceWriteStatusForTest)
+	health.MarkEvidenceWriteFailure(time.Now().UTC(), assert.AnError)
+
+	srv, _ := newEventsTestServer(t, map[string]string{"k-default": "default"})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer k-default")
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	assert.Equal(t, "degraded", out["status"])
+	assert.Equal(t, false, out["evidence_ok"])
+	_, hasReason := out["evidence_error"]
+	assert.True(t, hasReason)
+}

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -200,6 +200,7 @@ CACHEEOF
   assert_pass "dashboard HTML contains Mission Control marker" grep -q "Talon <span>Mission Control</span>" <<< "$dash_html"
   assert_pass "dashboard HTML contains Session Timeline marker" grep -q "Session Timeline (Lifecycle)" <<< "$dash_html"
   assert_pass "dashboard HTML contains Compliance Report Preview marker" grep -q "Compliance Report Preview" <<< "$dash_html"
+  assert_pass "dashboard HTML contains reliability badge marker" grep -q "reliability-badge" <<< "$dash_html"
   assert_pass "dashboard HTML contains <script>" grep -qi "<script" <<< "$dash_html"
   assert_pass "dashboard HTML contains Success Rate KPI" grep -qi "Success Rate" <<< "$dash_html"
   assert_pass "dashboard HTML contains Timeouts KPI" grep -qi "Timeouts" <<< "$dash_html"
@@ -1047,6 +1048,10 @@ CACHEEOF
       jq -e 'has("events_replay_misses")' <<< "$status_json" &>/dev/null
     assert_pass "status exposes events_backlog_drops" \
       jq -e 'has("events_backlog_drops")' <<< "$status_json" &>/dev/null
+    assert_pass "status exposes metrics_reconcile_runs" \
+      jq -e 'has("metrics_reconcile_runs")' <<< "$status_json" &>/dev/null
+    assert_pass "status exposes metrics_recovered_events" \
+      jq -e 'has("metrics_recovered_events")' <<< "$status_json" &>/dev/null
   else
     log_failure "status endpoint not reachable for SSOT checks" "url=${dashboard_base_url}${SMOKE_PATH_STATUS}"
     dump_diag_json "status_json" "$status_json"

--- a/tests/smoke_sections/30_graph_events.sh
+++ b/tests/smoke_sections/30_graph_events.sh
@@ -497,13 +497,13 @@ GWEOF
   local ev_body ev_code
   ev_body="$(mktemp)"
   ev_code="$(curl -s -o "$ev_body" -w '%{http_code}' -H "$admin_hdr" \
-    "${ge_base}/v1/evidence?limit=20" 2>/dev/null)"
+    "${ge_base}/v1/evidence?limit=200" 2>/dev/null)"
   if [[ "$ev_code" == "200" ]]; then
     local has_graph_run
     local denied_run_recorded denied_run_policy_denied
     has_graph_run="$(jq -r "[.entries[]? | select(.correlation_id == \"${lifecycle_id}\")] | length" "$ev_body" 2>/dev/null)"
     denied_run_recorded="$(jq -r "[.entries[]? | select(.correlation_id == \"${denied_run_id}\")] | length" "$ev_body" 2>/dev/null)"
-    denied_run_policy_denied="$(jq -r "[.entries[]? | select(.correlation_id == \"${denied_run_id}\" and .policy_decision.allowed == false)] | length" "$ev_body" 2>/dev/null)"
+    denied_run_policy_denied="$(jq -r "[.entries[]? | select(.correlation_id == \"${denied_run_id}\" and ((.policy_decision.allowed == false) or (.allowed == false)))] | length" "$ev_body" 2>/dev/null)"
     if [[ "$has_graph_run" =~ ^[1-9] ]] && [[ "$denied_run_recorded" =~ ^[1-9] ]] && [[ "$denied_run_policy_denied" =~ ^[1-9] ]]; then
       echo "  ✓  graph_events_evidence_recorded (found lifecycle + denied-run evidence with policy_decision.allowed=false)"
       record_pass

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -75,6 +75,11 @@
     .mission-feed-list { list-style: none; margin: 0.5rem 0 0; padding: 0; }
     .mission-feed-list li { border-bottom: 1px solid var(--border); padding: 0.45rem 0; font-size: 0.82rem; }
     .mission-feed-list li:last-child { border-bottom: none; }
+    .runtime-warning { margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; border-radius: 6px; border: 1px solid rgba(248,113,113,0.4); color: var(--risk); background: rgba(248,113,113,0.1); font-size: 0.8rem; display: none; }
+    .signal-chip { display: inline-block; margin: 0.15rem 0.2rem 0 0; padding: 0.1rem 0.35rem; border-radius: 999px; border: 1px solid var(--border); font-size: 0.65rem; color: var(--text-dim); }
+    .signal-chip.warn { color: var(--warn); border-color: rgba(250,204,21,0.45); }
+    .signal-chip.risk { color: var(--risk); border-color: rgba(248,113,113,0.45); }
+    .signal-chip.ok { color: var(--ok); border-color: rgba(74,222,128,0.45); }
     @media (max-width: 980px) {
       .split-grid { grid-template-columns: 1fr; }
     }
@@ -87,6 +92,7 @@
       <span class="dashboard-badge" id="header-badge" title="Enforcement mode and tenant scope"></span>
       <nav class="dashboard-nav"><a id="gateway-nav-link" href="/gateway/dashboard">Gateway telemetry &rarr;</a></nav>
     </header>
+    <div class="runtime-warning" id="runtime-warning-banner"></div>
     <div class="cards">
     <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Visible requests</div><div class="value" id="card-requests">—</div></div>
     <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Visible cost</div><div class="value" id="card-daily">— &euro;</div></div>
@@ -299,6 +305,21 @@
 
       function renderCards() {
         get('/v1/status').then(function(d) {
+          var warnings = [];
+          if (d.evidence_ok === false) warnings.push('evidence writes are degraded');
+          if (Number(d.events_backlog_drops || 0) > 0 || Number(d.metrics_events_dropped || 0) > 0) warnings.push('collector dropped events');
+          if (Number(d.events_stream_gaps || 0) > 0 || Number(d.events_replay_misses || 0) > 0) warnings.push('event stream gaps/replay misses');
+          if (d.metrics_reconcile_error) warnings.push('metrics reconciliation errors');
+          var warningBanner = document.getElementById('runtime-warning-banner');
+          if (warningBanner) {
+            if (warnings.length > 0) {
+              warningBanner.style.display = 'block';
+              warningBanner.textContent = 'Reliability warning: ' + warnings.join(' · ');
+            } else {
+              warningBanner.style.display = 'none';
+              warningBanner.textContent = '';
+            }
+          }
           var el = document.getElementById('card-requests');
           if (el) el.textContent = d.evidence_count_today != null ? d.evidence_count_today : '—';
           el = document.getElementById('card-daily');
@@ -432,6 +453,22 @@
         if (recentEvents.length > 0) recentEventCursor = String(recentEvents[0].event_id || recentEventCursor);
       }
 
+      function renderEventSignalChips(ev) {
+        if (!ev) return '';
+        var chips = [];
+        var pii = Array.isArray(ev.pii_detected) ? ev.pii_detected.length : 0;
+        var tools = Array.isArray(ev.tools_filtered) ? ev.tools_filtered.length : 0;
+        if (pii > 0) chips.push('<span class="signal-chip risk">PII: ' + pii + '</span>');
+        if (tools > 0) chips.push('<span class="signal-chip warn">Tools filtered: ' + tools + '</span>');
+        if (ev.cache_hit === true) chips.push('<span class="signal-chip ok">Cache hit</span>');
+        if (ev.cost_saved != null && !isNaN(Number(ev.cost_saved)) && Number(ev.cost_saved) > 0) {
+          chips.push('<span class="signal-chip ok">Saved €' + Number(ev.cost_saved).toFixed(4) + '</span>');
+        }
+        if (chips.length > 3) chips = chips.slice(0, 3);
+        if (chips.length === 0) return '';
+        return '<div>' + chips.join('') + '</div>';
+      }
+
       function renderRecentEventsList() {
         var timeline = document.getElementById('session-timeline-list');
         if (!timeline) return;
@@ -447,6 +484,7 @@
           var actor = ev.caller || ev.agent_id || 'agent';
           var tenant = ev.tenant_id || '—';
           var reason = ev.reason_text || ev.reason_code || '—';
+          var reasonCell = escapeHtml(reason) + renderEventSignalChips(ev);
           var model = ev.model || '—';
           var cost = (ev.cost_eur != null && !isNaN(Number(ev.cost_eur))) ? Number(ev.cost_eur).toFixed(4) : '0.0000';
           var evidenceId = ev.evidence_id || '—';
@@ -456,7 +494,7 @@
             '<td>' + escapeHtml(tenant) + '</td>' +
             '<td>' + escapeHtml(actor) + '</td>' +
             '<td>' + escapeHtml(outcome) + '</td>' +
-            '<td>' + escapeHtml(reason) + '</td>' +
+            '<td>' + reasonCell + '</td>' +
             '<td>' + escapeHtml(cost) + '</td>' +
             '<td>' + escapeHtml(model) + '</td>' +
             '<td>' + escapeHtml(evidenceId) + '</td>' +

--- a/web/gateway_dashboard.html
+++ b/web/gateway_dashboard.html
@@ -93,6 +93,7 @@
   <nav class="header-nav"><a href="/dashboard">← Governance dashboard</a></nav>
   <div class="header-meta">
     <span id="mode-badge" class="badge">--</span>
+    <span id="reliability-badge" class="badge">--</span>
     <span>Uptime: <strong id="uptime">--</strong></span>
     <span id="last-updated">--</span>
   </div>
@@ -372,6 +373,20 @@
     document.getElementById('last-updated').textContent = 'Updated: ' + new Date(d.generated_at).toLocaleTimeString();
 
     var s = d.summary || {};
+    var reliabilityBadge = document.getElementById('reliability-badge');
+    if (reliabilityBadge) {
+      var reliabilityIssues = [];
+      if ((d.dropped_events || 0) > 0) reliabilityIssues.push('drops');
+      if ((s.total_timed_out || 0) > 0) reliabilityIssues.push('timeouts');
+      if ((s.error_rate || 0) > 0.1) reliabilityIssues.push('errors');
+      if (reliabilityIssues.length > 0) {
+        reliabilityBadge.textContent = 'degraded: ' + reliabilityIssues.join(',');
+        reliabilityBadge.className = 'badge badge-risk';
+      } else {
+        reliabilityBadge.textContent = 'reliability: healthy';
+        reliabilityBadge.className = 'badge badge-ok';
+      }
+    }
     document.getElementById('kpi-requests').textContent = fmt(s.total_requests);
     document.getElementById('kpi-blocked').textContent = fmt(s.blocked_requests);
     document.getElementById('kpi-pii').textContent = fmt(s.pii_detections);


### PR DESCRIPTION
## Summary
- add periodic bounded/idempotent collector reconciliation with OTel/status telemetry and startup/serve integration
- surface degraded and backpressure signals in normal dashboard and CLI flows, plus compact recent-event signal chips
- add consolidated SSOT parity/resilience gate tests, Make target wiring, smoke updates, and final docs/changelog lock updates

## Test plan
- [x] `go test ./internal/metrics ./internal/cmd ./internal/server -run 'Reconcile|Degraded|Signal|SSOTGate|EventsRecentIncludesSignalSummaryFields|EmbeddedDashboardsContainUnifiedMissionControlMarkers'`
- [x] `make test-ssot-gate`
- [x] `make lint`
- [x] `make check`
- [x] `make test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live metrics aggregation, `/v1/status` degraded semantics, and serve startup behavior; mitigated by idempotent reconciliation, tests, and smoke coverage, but operators may see new warnings or status flips after upgrade.
> 
> **Overview**
> This PR hardens **v1.5.0 runtime SSOT parity** by reconciling in-memory metrics with persisted evidence, surfacing reliability problems in normal operator paths, and locking behavior with release gates and docs.
> 
> **Metrics reconciliation:** `BackfillFromStore` now delegates to **`ReconcileFromStore`**, which rebuilds collector aggregates from a bounded evidence window (idempotent; reports recovered events). **`StartReconcileLoop`** runs on a ticker at serve startup (interval/window overridable via `TALON_METRICS_RECONCILE_*`). Reconcile health and OTel counters are exposed; **`/v1/status`** adds `metrics_reconcile_*` fields and marks **`degraded`** when reconciliation fails.
> 
> **Operator UX:** Governance and gateway dashboards show **runtime warning / reliability badges** and compact **signal chips** (PII, filtered tools, cache) on recent events. **`talon metrics`** and **`talon events tail`** (non-JSON) preflight **`/v1/status`** and print a degraded warning when evidence, drops, stream gaps, or reconcile errors are present.
> 
> **Quality / contract:** New **`make test-ssot-gate`** (`SSOTGate` tests) is wired into **`make check`**. Docs and smoke tests document locked scopes for metrics vs events and validate reconcile status fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f9fdfd0d3c29ac3734525de40fa26c7d46f656. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->