### PR TITLE
chore(release): cut v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Release Note Quality Bar
+
+For user-facing entries, include:
+
+- why this change matters (problem solved),
+- who should care (operator/developer persona),
+- how to verify quickly (command or path),
+- any upgrade/migration impact,
+- at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
+
+## [1.5.0] - 2026-06-01
+
 ### Added
 
 - **feat(serve): OpenAI-compatible quickstart proxy mode.** Added `talon serve --proxy-quickstart` for dev/local host-root compatibility (`POST /v1/chat/completions`, `POST /v1/responses`) without gateway YAML, while keeping policy, PII redaction, and evidence active.
@@ -35,16 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **fix(events): expand stream reliability telemetry.** Event stream handling now increments disconnect and backlog-drop counters (in addition to gap/replay signals) and exposes them in status output for faster operator diagnosis.
 - **fix(gateway/metrics): no metrics emission without persisted evidence.** Gateway collector events are now emitted only after successful evidence persistence, preventing runtime telemetry drift when evidence writes fail.
 - **fix(metrics): surface collector backpressure drops.** Collector channel overflow drops now increment `dropped_events`, emit OTel counter `talon.metrics.events_dropped.total`, and appear in `/v1/status` as `metrics_events_dropped`.
-
-### Release Note Quality Bar
-
-For user-facing entries, include:
-
-- why this change matters (problem solved),
-- who should care (operator/developer persona),
-- how to verify quickly (command or path),
-- any upgrade/migration impact,
-- at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
 ## [1.4.6] - 2026-04-14
 
@@ -474,7 +476,8 @@ For user-facing entries, include:
 - EU AI Act: risk management, transparency, human oversight (Art. 9, 13, 14).
 - Data residency: tier-based EU model routing.
 
-[Unreleased]: https://github.com/dativo-io/talon/compare/v1.4.6...HEAD
+[Unreleased]: https://github.com/dativo-io/talon/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/dativo-io/talon/compare/v1.4.6...v1.5.0
 [1.4.6]: https://github.com/dativo-io/talon/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/dativo-io/talon/compare/v1.4.0...v1.4.5
 [1.4.0]: https://github.com/dativo-io/talon/compare/v1.3.0...v1.4.0


### PR DESCRIPTION
## Summary

- Promote the `Unreleased` runtime/SSOT hardening, OpenAI-compatible quickstart proxy, upstream-auth, and evidence-first parity work into a dated `## [1.5.0] - 2026-06-01` section.
- Reset the `Unreleased` template (retaining the Release Note Quality Bar guidance).
- Refresh changelog comparison links (`Unreleased` → `v1.5.0...HEAD`, add `v1.4.6...v1.5.0`).

Version is derived from git tags via ldflags/VCS metadata, so no source constant changes are required; the `v1.5.0` tag will be cut on `main` after merge.

## Test plan

- [ ] CHANGELOG renders correctly (Unreleased empty + 1.5.0 section populated)
- [ ] After merge, tag `v1.5.0` on `main` and push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog reorganization with no runtime or security behavior changes in this diff.
> 
> **Overview**
> This PR **cuts release v1.5.0** in `CHANGELOG.md` only: everything that was under **`[Unreleased]`** is now documented under **`## [1.5.0] - 2026-06-01`** (Added/Changed/Fixed bullets for quickstart proxy, upstream auth, evidence/metrics/events SSOT work, session migration, audit logging, etc.).
> 
> **`[Unreleased]`** is reset to an empty section that keeps the **Release Note Quality Bar** guidance at the top (moved out of the bottom of the file). Footer compare links are updated so **`[Unreleased]`** points at `v1.5.0...HEAD` and **`[1.5.0]`** links `v1.4.6...v1.5.0`.
> 
> No application source changes; version still comes from git tags/ldflags after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fef13a53042b596ff1cdade40a5d813d4293a7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->