### PR TITLE
feat(evidence): add signed export integrity UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+### Added
+
+- **feat(evidence): signed export and offline file verification.** Added `talon audit export --format signed-json|signed-ndjson` and `talon audit verify --file <path>` so operators and compliance teams can verify evidence integrity outside the running instance. This matters for GDPR/NIS2 handoffs where auditors request portable, tamper-evident artifacts. Verify quickly with `talon audit export --format signed-json --output signed.json && talon audit verify --file signed.json`.
+- **feat(dashboard): persistent evidence integrity UX.** Evidence rows now expose explicit integrity states (`Verified`, `Invalid`, `Not checked`, `Unable to verify`), with a persistent detail/signature block that shows signed fields and trust/spend context in one view. This makes integrity obvious to CTO/DPO users without requiring CLI-first workflows.
+
+### Docs
+
+- **docs(evidence): add 5-minute tamper-proof demo and signed export runbook updates.** Added `docs/tutorials/evidence-integrity-demo.md`, updated the 60-second demo and compliance export runbook to distinguish reduced reporting exports from signed integrity exports, and documented `/v1/evidence/{id}/verify` response shape in the evidence store reference.
+
 ## [1.5.0] - 2026-06-01
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Choose the shortest path for your situation:
 | Doc | Description |
 |-----|-------------|
 | [60-Second Demo (no API key)](tutorials/quickstart-demo.md) | Docker Compose demo with mock provider — see governance in action in 60 seconds. |
+| [Evidence integrity 5-minute proof](tutorials/evidence-integrity-demo.md) | End-to-end tamper-proof demo: verify in dashboard, export signed evidence, tamper one field, verify failure with CLI. |
 | [Your first governed agent](tutorials/first-governed-agent.md) | Install → init → run → see evidence. Native Talon (requires Go + API key). |
 
 ### How-to guides (goal-oriented)
@@ -92,6 +93,7 @@ Choose the shortest path for your situation:
 | [What Talon does to your request](explanation/what-talon-does-to-your-request.md) | Pipeline, latency, threat boundaries, and reproducible checks. |
 | [Why not just a PII proxy?](explanation/why-not-a-pii-proxy.md) | Control-plane vs scrubber differentiation with proof commands. |
 | [Evidence store](explanation/evidence-store.md) | HMAC integrity model and verification flow. |
+| [Evidence integrity 5-minute proof](tutorials/evidence-integrity-demo.md) | Fast proof moment for auditors/operators, including offline signed-export verification. |
 | [Security policy](../SECURITY.md) | Vulnerability reporting process and security scope. |
 | [Docker Compose demo](../examples/docker-compose/README.md) | Fastest no-key proof loop. |
 

--- a/docs/explanation/evidence-store.md
+++ b/docs/explanation/evidence-store.md
@@ -71,6 +71,14 @@ $ talon audit verify req_tampered
 ✗ Evidence req_tampered: signature INVALID
 ```
 
+You can also verify signed export files offline:
+
+```bash
+talon audit verify --file march-signed-evidence.json
+```
+
+The file verifier reports total/valid/invalid/malformed/unsupported counts and exits non-zero if any record is invalid or unverifiable.
+
 **What this proves:** The signing key never leaves the server. If the signature
 is valid, the record has not been modified since Talon created it. This provides
 ISO 27001 A.8.15 compliance (tamper-proof logging) without requiring external
@@ -125,9 +133,45 @@ talon audit export --format csv --from 2026-03-01 --to 2026-03-31 > march-audit.
 
 # JSON for programmatic access
 talon audit export --format json --from 2026-03-01 > march-audit.json
+
+# Signed JSON for offline integrity verification
+talon audit export --format signed-json --from 2026-03-01 > march-signed-audit.json
+
+# Signed NDJSON for line-oriented pipelines
+talon audit export --format signed-ndjson --from 2026-03-01 > march-signed-audit.ndjson
 ```
 
 CSV columns: `id`, `session_id`, `timestamp`, `tenant_id`, `agent_id`, `invocation_type`, `allowed`, `cost`, `model_used`, `duration_ms`, `has_error`, `input_tier`, `output_tier`, `pii_detected`, `pii_redacted`, `policy_reasons`, `tools_called`, `input_hash`, `output_hash`, `primary_explanation_code`, `primary_explanation_reason`, `primary_version_identity`, plus shadow/cache fields when applicable. JSON and NDJSON export include the same fields; `session_id` links evidence to a lifecycle session (e.g. plan-gated run and its dispatch).
+
+Signed exports include full `Evidence` records with per-record `signature` fields, so integrity can be verified later with `talon audit verify --file`.
+
+Practical split:
+
+- Use reduced `csv/json/ndjson` export for reporting and spreadsheet workflows.
+- Use `signed-json/signed-ndjson` when you need cryptographic integrity verification.
+
+## Evidence Verify API
+
+The dashboard and API expose record-level verification:
+
+```http
+GET /v1/evidence/{id}/verify
+```
+
+Response:
+
+```json
+{
+  "id": "req_a1b2c3d4",
+  "valid": true
+}
+```
+
+Tenant scoping applies: callers can only verify evidence in their own tenant scope.
+
+Buyer-facing wording:
+
+> Talon evidence can be independently verified. If a record is changed after creation, verification fails.
 
 ## OpenTelemetry Export
 

--- a/docs/guides/compliance-export-runbook.md
+++ b/docs/guides/compliance-export-runbook.md
@@ -6,7 +6,12 @@ Use this runbook to export Talon evidence for auditors or regulators (e.g. GDPR 
 
 ## 1. Export evidence
 
-**CLI:** Export a date range or limit. Formats: `csv` or `json`.
+Choose the export type based on your goal:
+
+- **Reporting export (reduced fields):** `--format csv|json|ndjson` for spreadsheet/report tooling.
+- **Integrity export (full signed records):** `--format signed-json|signed-ndjson` for offline verification.
+
+**CLI:** Export a date range or limit.
 
 ```bash
 # CSV for a date range (e.g. last month)
@@ -14,6 +19,9 @@ talon audit export --format csv --from 2026-02-01 --to 2026-02-28
 
 # JSON with a limit
 talon audit export --format json --limit 1000
+
+# Full signed JSON for offline integrity verification
+talon audit export --format signed-json --from 2026-02-01 --to 2026-02-28 --output feb-signed-evidence.json
 ```
 
 **API:** Authenticate with `Authorization: Bearer <tenant-key>` (or admin key for operator workflows) and call:
@@ -25,26 +33,37 @@ Content-Type: application/json
 {"tenant_id": "default", "format": "json", "limit": 1000}
 ```
 
-Exports include evidence ID, session_id (lifecycle session linking), timestamp, tenant_id, agent_id, policy decision, cost, and (when configured) PII flags and data tier. For the full column list see [Evidence store — Export](../explanation/evidence-store.md#export) or the CSV header row.
+Reduced exports include evidence ID, session_id (lifecycle session linking), timestamp, tenant_id, agent_id, policy decision, cost, and (when configured) PII flags and data tier. For the full reduced column list see [Evidence store — Export](../explanation/evidence-store.md#export) or the CSV header row.
+
+Signed exports include full evidence records with per-record `signature`, policy decision, hashes, model, token usage, and cost fields, suitable for offline verification.
 
 **Scope:** Use `tenant_id` (in API body or CLI context) so the export is scoped to the tenant you are responsible for. For GDPR Art. 30 you typically export processing records for a defined period and scope.
 
 ---
 
-## 2. Verify integrity (optional but recommended)
+## 2. Verify integrity (recommended)
 
-Evidence records are signed with HMAC-SHA256. To prove integrity, verify a sample or the full set:
+Evidence records are signed with HMAC-SHA256. To prove integrity:
 
 ```bash
-# Verify a single record
+# Verify a single record from the store
 talon audit verify <evidence-id>
 
-# List IDs from your export, then verify each (or a sample)
-talon audit list --limit 100
-talon audit verify req_xxxxxxxx
+# Verify a signed export file (offline workflow)
+talon audit verify --file feb-signed-evidence.json
 ```
 
-Document the verification (e.g. "Verified N evidence IDs; signature VALID"). If you need to verify in bulk, script `talon audit verify` over the IDs from your export.
+`talon audit verify --file` prints:
+
+- total records
+- valid records
+- invalid records
+- records that could not be parsed
+- unsupported records
+
+Exit code is non-zero when any record is invalid, malformed, missing signature, or unsupported.
+
+For ad-hoc checks from the live store, `talon audit verify <evidence-id>` remains available.
 
 ---
 
@@ -52,8 +71,9 @@ Document the verification (e.g. "Verified N evidence IDs; signature VALID"). If 
 
 Suggested package for auditors:
 
-- **Export file(s):** CSV or JSON from step 1, named with tenant and date range (e.g. `talon-evidence-default-2026-02.csv`).
-- **Verification log:** Short note or log listing evidence IDs verified and result (e.g. "signature VALID").
+- **Reporting file(s):** CSV/JSON reduced export from step 1, named with tenant and date range (e.g. `talon-evidence-default-2026-02.csv`).
+- **Integrity file:** signed JSON export (e.g. `talon-evidence-default-2026-02-signed.json`).
+- **Verification log:** Output of `talon audit verify --file ...` showing validity counts.
 - **Scope description:** One-line summary (e.g. "Talon evidence for tenant default, 2026-02-01 to 2026-02-28, GDPR Art. 30 processing records").
 
 Store the package in a secure location and hand off according to your audit process.
@@ -72,7 +92,7 @@ For incident response, use the same export and verification steps. Use timeline 
 
 ## You're done
 
-You now know how to export evidence, verify signatures, and package records for auditors. Talon evidence is HMAC-signed and can be handed off with a verification log.
+You now know how to export evidence for reporting and integrity, verify signatures offline, and package records for auditors. Talon evidence is HMAC-signed and independently verifiable.
 
 **Next steps:**
 

--- a/docs/tutorials/evidence-integrity-demo.md
+++ b/docs/tutorials/evidence-integrity-demo.md
@@ -1,0 +1,85 @@
+# Evidence Integrity: 5-Minute Proof Demo
+
+This walkthrough gives you a fast auditor-ready proof:
+
+1. run a request,
+2. verify evidence in the dashboard,
+3. export signed evidence,
+4. tamper one field,
+5. show CLI verification failure.
+
+Core message:
+
+> Evidence-grade, not just logs. Talon signs every evidence record at creation time. If any signed field changes later, verification fails.
+
+## Prerequisites
+
+- Talon running locally (for example via `examples/docker-compose`)
+- `talon` CLI available in the environment where you run verification
+
+## 1) Run one request
+
+```bash
+curl -X POST http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Summarize this support ticket and include next actions."}]
+  }'
+```
+
+## 2) Open dashboard evidence and verify
+
+- Open [http://localhost:8080/dashboard](http://localhost:8080/dashboard).
+- Go to the **Evidence** tab.
+- Click **Verify** for your latest row (or **Verify visible records**).
+- Confirm integrity state shows `✓ Verified`.
+- Click **Detail** and confirm the signature block + trust/spend details (cost, tokens, model, provider).
+
+## 3) Export signed evidence
+
+```bash
+talon audit export --format signed-json --limit 20 --output signed-evidence.json
+```
+
+## 4) Verify the file (expected success)
+
+```bash
+talon audit verify --file signed-evidence.json
+```
+
+Expected outcome:
+
+- valid records > 0
+- invalid/malformed/unsupported = 0
+- exit code 0
+
+## 5) Modify one signed field
+
+Edit `signed-evidence.json` and change one value in a record, for example:
+
+- `policy_decision.allowed`
+- `execution.cost`
+- `audit_trail.input_hash`
+- `timestamp`
+
+Do not update `signature`.
+
+## 6) Verify again (expected failure)
+
+```bash
+talon audit verify --file signed-evidence.json
+```
+
+Expected outcome:
+
+- invalid records > 0
+- non-zero exit code
+
+This is the proof moment: Talon detects post-creation tampering.
+
+## 7) One-paragraph compliance statement
+
+Use this during audits or buyer calls:
+
+> Talon signs every evidence record at creation time with HMAC-SHA256 and stores the signature with policy decision, hashes, model, and cost metadata. Teams can verify records later from dashboard or CLI (`talon audit verify` / `talon audit verify --file`). If a signed field is modified after creation, verification fails.

--- a/docs/tutorials/quickstart-demo.md
+++ b/docs/tutorials/quickstart-demo.md
@@ -84,6 +84,12 @@ The HMAC-SHA256 signature proves no field has been modified since creation.
 Visit [http://localhost:8080/dashboard](http://localhost:8080/dashboard) to see
 evidence records, costs, and PII findings in the browser.
 
+Use the Evidence tab to:
+
+- check the per-row integrity state (`Not checked`, `Verified`, `Invalid`, `Unable to verify`),
+- open the persistent signature block from **Detail**,
+- verify that governance decision and spend attribution are visible beside signature status.
+
 ## What you just proved
 
 The demo showed three things a PII-only proxy cannot:

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -29,6 +29,7 @@ var (
 	auditCaller         string
 	auditViolationsOnly bool
 	auditOutputFile     string
+	auditVerifyFile     string
 )
 
 var auditCmd = &cobra.Command{
@@ -52,13 +53,13 @@ var auditShowCmd = &cobra.Command{
 var auditVerifyCmd = &cobra.Command{
 	Use:   "verify [evidence-id]",
 	Short: "Verify HMAC signature of an evidence record",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	RunE:  auditVerify,
 }
 
 var auditExportCmd = &cobra.Command{
 	Use:   "export",
-	Short: "Export evidence records as CSV, JSON, NDJSON, or HTML for compliance",
+	Short: "Export evidence records as CSV, JSON, NDJSON, signed JSON, signed NDJSON, or HTML",
 	RunE:  auditExport,
 }
 
@@ -67,7 +68,8 @@ func init() {
 	auditListCmd.Flags().StringVar(&auditAgent, "agent", "", "Filter by agent ID")
 	auditListCmd.Flags().IntVar(&auditLimit, "limit", 20, "Maximum records to show")
 
-	auditExportCmd.Flags().StringVar(&auditExportFmt, "format", "csv", "Output format: csv, json, ndjson, or html")
+	auditVerifyCmd.Flags().StringVar(&auditVerifyFile, "file", "", "Verify all records from a signed export file")
+	auditExportCmd.Flags().StringVar(&auditExportFmt, "format", "csv", "Output format: csv, json, ndjson, signed-json, signed-ndjson, or html")
 	auditExportCmd.Flags().StringVar(&auditFrom, "from", "", "Start date (YYYY-MM-DD)")
 	auditExportCmd.Flags().StringVar(&auditTo, "to", "", "End date (YYYY-MM-DD)")
 	auditExportCmd.Flags().StringVar(&auditTenant, "tenant", "", "Filter by tenant ID")
@@ -158,13 +160,37 @@ func auditVerify(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
-	evidenceID := args[0]
-
 	store, err := openEvidenceStore()
 	if err != nil {
 		return fmt.Errorf("initializing evidence store: %w", err)
 	}
 	defer store.Close()
+
+	if auditVerifyFile != "" {
+		if len(args) > 0 {
+			return fmt.Errorf("use either evidence ID or --file, not both")
+		}
+		data, err := os.ReadFile(auditVerifyFile)
+		if err != nil {
+			return fmt.Errorf("reading verify file: %w", err)
+		}
+		report, verifyErr := store.VerifyExport(data)
+		renderVerifyFileReport(os.Stdout, auditVerifyFile, report)
+		if report.HasFailures() {
+			if verifyErr != nil {
+				return fmt.Errorf("file verification failed: %w", verifyErr)
+			}
+			return fmt.Errorf("file verification failed")
+		}
+		if verifyErr != nil {
+			return fmt.Errorf("verifying file: %w", verifyErr)
+		}
+		return nil
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("evidence id is required when --file is not provided")
+	}
+	evidenceID := args[0]
 
 	ev, err := store.Get(ctx, evidenceID)
 	if err != nil {
@@ -198,7 +224,8 @@ func auditExport(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("querying evidence: %w", err)
 	}
-	records := filterExportRecords(list, auditViolationsOnly)
+	filteredEvidence := filterEvidenceForExport(list, auditViolationsOnly)
+	records := toExportRecords(filteredEvidence)
 
 	out, cleanup, err := resolveExportOutput(cmd, auditOutputFile)
 	if err != nil {
@@ -215,10 +242,14 @@ func auditExport(cmd *cobra.Command, _ []string) error {
 		return renderAuditExportJSONWrapped(out, records)
 	case "ndjson":
 		return renderAuditExportNDJSON(out, records)
+	case "signed-json":
+		return renderAuditExportSignedJSON(out, filteredEvidence)
+	case "signed-ndjson":
+		return renderAuditExportSignedNDJSON(out, filteredEvidence)
 	case "html":
 		return renderAuditExportHTML(out, records)
 	default:
-		return fmt.Errorf("unsupported --format %q; use csv, json, ndjson, or html", auditExportFmt)
+		return fmt.Errorf("unsupported --format %q; use csv, json, ndjson, signed-json, signed-ndjson, or html", auditExportFmt)
 	}
 }
 
@@ -248,14 +279,25 @@ func resolveAgentFilter(agent, caller string) string {
 	return caller
 }
 
-func filterExportRecords(list []evidence.Evidence, violationsOnly bool) []evidence.ExportRecord {
-	records := make([]evidence.ExportRecord, 0, len(list))
+func filterEvidenceForExport(list []evidence.Evidence, violationsOnly bool) []evidence.Evidence {
+	if !violationsOnly {
+		return append([]evidence.Evidence(nil), list...)
+	}
+	filtered := make([]evidence.Evidence, 0, len(list))
 	for i := range list {
-		rec := evidence.ToExportRecord(&list[i])
-		if violationsOnly && !rec.ObservationModeOverride && rec.Allowed {
+		ev := list[i]
+		if !ev.ObservationModeOverride && ev.PolicyDecision.Allowed {
 			continue
 		}
-		records = append(records, rec)
+		filtered = append(filtered, ev)
+	}
+	return filtered
+}
+
+func toExportRecords(list []evidence.Evidence) []evidence.ExportRecord {
+	records := make([]evidence.ExportRecord, 0, len(list))
+	for i := range list {
+		records = append(records, evidence.ToExportRecord(&list[i]))
 	}
 	return records
 }
@@ -346,6 +388,39 @@ func renderAuditExportJSONWrapped(w io.Writer, records []evidence.ExportRecord) 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(envelope)
+}
+
+func renderAuditExportSignedJSON(w io.Writer, records []evidence.Evidence) error {
+	envelope := evidence.SignedExportEnvelope{
+		ExportMetadata: evidence.ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: resolvedVersion(),
+			Filter: evidence.ExportFilter{
+				From:   auditFrom,
+				To:     auditTo,
+				Tenant: auditTenant,
+				Agent:  auditAgent,
+				Caller: auditCaller,
+			},
+			TotalRecords: len(records),
+			Algorithm:    evidence.SignedExportAlgorithm,
+			Signed:       true,
+		},
+		Records: records,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(envelope)
+}
+
+func renderAuditExportSignedNDJSON(w io.Writer, records []evidence.Evidence) error {
+	enc := json.NewEncoder(w)
+	for i := range records {
+		if err := enc.Encode(&records[i]); err != nil {
+			return fmt.Errorf("encoding record %s: %w", records[i].ID, err)
+		}
+	}
+	return nil
 }
 
 func renderAuditExportNDJSON(w io.Writer, records []evidence.ExportRecord) error {
@@ -525,6 +600,35 @@ func renderVerifyResult(w io.Writer, evidenceID string, valid bool, ev *evidence
 			piiStr,
 			ev.Classification.PIIRedacted,
 		)
+	}
+}
+
+func renderVerifyFileReport(w io.Writer, path string, report evidence.FileVerifyReport) {
+	fmt.Fprintf(w, "File: %s\n", path)
+	fmt.Fprintf(w, "Total records: %d\n", report.Total)
+	fmt.Fprintf(w, "Valid records: %d\n", report.Valid)
+	fmt.Fprintf(w, "Invalid records: %d\n", report.Invalid)
+	fmt.Fprintf(w, "Missing signature: %d\n", report.MissingSignature)
+	fmt.Fprintf(w, "Could not parse: %d\n", report.Unparseable)
+	fmt.Fprintf(w, "Unsupported: %d\n", report.Unsupported)
+	if report.Hint != "" {
+		fmt.Fprintf(w, "Hint: %s\n", report.Hint)
+	}
+	if len(report.Records) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Record results:")
+	for i := range report.Records {
+		rec := report.Records[i]
+		id := rec.ID
+		if id == "" {
+			id = "(unknown)"
+		}
+		detail := rec.Detail
+		if detail == "" {
+			detail = "-"
+		}
+		fmt.Fprintf(w, "  - %s: %s (%s)\n", id, rec.Status, detail)
 	}
 }
 

--- a/internal/cmd/audit_test.go
+++ b/internal/cmd/audit_test.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,12 +28,14 @@ func TestAuditCmd_HasSubcommands(t *testing.T) {
 	}
 }
 
-func TestAuditVerifyCmd_RequiresOneArg(t *testing.T) {
+func TestAuditVerifyCmd_AcceptsZeroOrOneArg(t *testing.T) {
 	assert.NotNil(t, auditVerifyCmd.Args)
 	err := auditVerifyCmd.Args(auditVerifyCmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	err = auditVerifyCmd.Args(auditVerifyCmd, []string{"ev_123"})
 	assert.NoError(t, err)
+	err = auditVerifyCmd.Args(auditVerifyCmd, []string{"ev_1", "ev_2"})
+	assert.Error(t, err)
 }
 
 func TestAuditListCmd_Flags(t *testing.T) {
@@ -337,4 +342,103 @@ func TestAuditShowCmd_ZeroArgs_EmptyStore_PrintsNoRecords(t *testing.T) {
 	w.Close()
 	<-done
 	assert.Contains(t, string(out), "No evidence records found.")
+}
+
+func TestAuditExportSignedJSON_IncludesSignatures(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SIGNING_KEY", "test-signing-key-1234567890123456")
+
+	store, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	defer store.Close()
+	gen := evidence.NewGenerator(store)
+	_, err = gen.Generate(context.Background(), evidence.GenerateParams{
+		CorrelationID:  "corr_signed_export",
+		TenantID:       "default",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "signed.json")
+	rootCmd.SetArgs([]string{"audit", "export", "--format", "signed-json", "--output", outPath})
+	require.NoError(t, rootCmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "\"signed\": true")
+	assert.Contains(t, string(data), "\"algorithm\": \"HMAC-SHA256\"")
+
+	var envelope evidence.SignedExportEnvelope
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	require.Len(t, envelope.Records, 1)
+	assert.NotEmpty(t, envelope.Records[0].Signature)
+}
+
+func TestAuditVerifyFile_SucceedsForValidSignedExport(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SIGNING_KEY", "test-signing-key-1234567890123456")
+
+	store, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	defer store.Close()
+	gen := evidence.NewGenerator(store)
+	_, err = gen.Generate(context.Background(), evidence.GenerateParams{
+		CorrelationID:  "corr_verify_file_ok",
+		TenantID:       "default",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "signed.json")
+	rootCmd.SetArgs([]string{"audit", "export", "--format", "signed-json", "--output", outPath})
+	require.NoError(t, rootCmd.Execute())
+
+	rootCmd.SetArgs([]string{"audit", "verify", "--file", outPath})
+	err = rootCmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestAuditVerifyFile_FailsForTamperedSignedExport(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SIGNING_KEY", "test-signing-key-1234567890123456")
+
+	store, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	defer store.Close()
+	gen := evidence.NewGenerator(store)
+	_, err = gen.Generate(context.Background(), evidence.GenerateParams{
+		CorrelationID:  "corr_verify_file_bad",
+		TenantID:       "default",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "signed.json")
+	rootCmd.SetArgs([]string{"audit", "export", "--format", "signed-json", "--output", outPath})
+	require.NoError(t, rootCmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	tampered := strings.Replace(string(data), "\"tenant_id\": \"default\"", "\"tenant_id\": \"tampered\"", 1)
+	require.NoError(t, os.WriteFile(outPath, []byte(tampered), 0o644))
+
+	rootCmd.SetArgs([]string{"audit", "verify", "--file", outPath})
+	err = rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file verification failed")
 }

--- a/internal/evidence/export.go
+++ b/internal/evidence/export.go
@@ -57,6 +57,8 @@ type ExportMetadata struct {
 	TalonVersion string       `json:"talon_version"`
 	Filter       ExportFilter `json:"filter"`
 	TotalRecords int          `json:"total_records"`
+	Algorithm    string       `json:"algorithm,omitempty"`
+	Signed       bool         `json:"signed,omitempty"`
 }
 
 // ExportFilter describes the filter criteria used during export.

--- a/internal/evidence/signed_export.go
+++ b/internal/evidence/signed_export.go
@@ -1,0 +1,253 @@
+package evidence
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	// SignedExportAlgorithm is the algorithm label emitted by signed exports.
+	SignedExportAlgorithm = "HMAC-SHA256"
+
+	// Verify statuses for exported evidence records.
+	VerifyStatusValid            = "valid"
+	VerifyStatusInvalidSignature = "invalid_signature"
+	VerifyStatusMissingSignature = "missing_signature"
+	VerifyStatusMalformed        = "malformed_record"
+	VerifyStatusUnsupported      = "unsupported_record"
+)
+
+// SignedExportEnvelope wraps full signed evidence records with export metadata.
+type SignedExportEnvelope struct {
+	ExportMetadata ExportMetadata `json:"export_metadata"`
+	Records        []Evidence     `json:"records"`
+}
+
+// RecordVerifyResult is the verification outcome for one exported record.
+type RecordVerifyResult struct {
+	ID     string `json:"id,omitempty"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// FileVerifyReport summarizes verification outcomes for an exported evidence file.
+type FileVerifyReport struct {
+	Total            int                  `json:"total_records"`
+	Valid            int                  `json:"valid_records"`
+	Invalid          int                  `json:"invalid_records"`
+	MissingSignature int                  `json:"missing_signature_records"`
+	Unparseable      int                  `json:"unparseable_records"`
+	Unsupported      int                  `json:"unsupported_records"`
+	Records          []RecordVerifyResult `json:"records,omitempty"`
+	Hint             string               `json:"hint,omitempty"`
+}
+
+// HasFailures returns true when any record is invalid, malformed, missing signature, or unsupported.
+func (r FileVerifyReport) HasFailures() bool {
+	return r.Invalid > 0 || r.MissingSignature > 0 || r.Unparseable > 0 || r.Unsupported > 0
+}
+
+// VerifyExport verifies signed evidence files in signed-json and signed-ndjson formats.
+// It can also process a bare JSON array of Evidence records.
+func (s *Store) VerifyExport(data []byte) (FileVerifyReport, error) {
+	var report FileVerifyReport
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		report.Unsupported = 1
+		report.Records = append(report.Records, RecordVerifyResult{
+			Status: VerifyStatusUnsupported,
+			Detail: "empty file",
+		})
+		return report, fmt.Errorf("unsupported export format: empty file")
+	}
+
+	switch trimmed[0] {
+	case '{':
+		report, err := s.verifySignedJSON(trimmed)
+		if report.Total == 0 && bytes.Contains(trimmed, []byte("\n")) {
+			ndReport, ndErr := s.verifyNDJSON(trimmed)
+			if ndReport.Total > 0 || ndErr == nil {
+				return ndReport, ndErr
+			}
+		}
+		return report, err
+	case '[':
+		return s.verifyJSONArray(trimmed)
+	default:
+		return s.verifyNDJSON(trimmed)
+	}
+}
+
+func (s *Store) verifySignedJSON(data []byte) (FileVerifyReport, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return FileVerifyReport{
+			Unparseable: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusMalformed,
+				Detail: "malformed JSON envelope",
+			}},
+		}, nil
+	}
+
+	recordsRaw, hasRecords := payload["records"]
+	if !hasRecords {
+		return FileVerifyReport{
+			Unsupported: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusUnsupported,
+				Detail: "missing records field",
+			}},
+		}, fmt.Errorf("unsupported export format: missing records field")
+	}
+
+	var meta ExportMetadata
+	if metaRaw, ok := payload["export_metadata"]; ok {
+		_ = json.Unmarshal(metaRaw, &meta)
+	}
+	if !meta.Signed {
+		return FileVerifyReport{
+			Unsupported: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusUnsupported,
+				Detail: "export_metadata.signed is false or missing",
+			}},
+		}, fmt.Errorf("unsupported export format: signed metadata missing")
+	}
+
+	var rawRecords []json.RawMessage
+	if err := json.Unmarshal(recordsRaw, &rawRecords); err != nil {
+		return FileVerifyReport{
+			Unparseable: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusMalformed,
+				Detail: "records field is not a JSON array",
+			}},
+		}, nil
+	}
+	report := s.verifyRawRecords(rawRecords)
+	report.Total = len(rawRecords)
+	report.Hint = verificationHint(report)
+	return report, nil
+}
+
+func (s *Store) verifyJSONArray(data []byte) (FileVerifyReport, error) {
+	var rawRecords []json.RawMessage
+	if err := json.Unmarshal(data, &rawRecords); err != nil {
+		return FileVerifyReport{
+			Unparseable: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusMalformed,
+				Detail: "malformed JSON array",
+			}},
+		}, nil
+	}
+	report := s.verifyRawRecords(rawRecords)
+	report.Total = len(rawRecords)
+	report.Hint = verificationHint(report)
+	return report, nil
+}
+
+func (s *Store) verifyNDJSON(data []byte) (FileVerifyReport, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var rawRecords []json.RawMessage
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		rawRecords = append(rawRecords, json.RawMessage(line))
+	}
+	if err := scanner.Err(); err != nil {
+		return FileVerifyReport{}, fmt.Errorf("reading file: %w", err)
+	}
+	if len(rawRecords) == 0 {
+		return FileVerifyReport{
+			Unsupported: 1,
+			Records: []RecordVerifyResult{{
+				Status: VerifyStatusUnsupported,
+				Detail: "no parseable NDJSON lines",
+			}},
+		}, fmt.Errorf("unsupported export format: empty ndjson")
+	}
+	report := s.verifyRawRecords(rawRecords)
+	report.Total = len(rawRecords)
+	report.Hint = verificationHint(report)
+	return report, nil
+}
+
+func (s *Store) verifyRawRecords(rawRecords []json.RawMessage) FileVerifyReport {
+	report := FileVerifyReport{
+		Records: make([]RecordVerifyResult, 0, len(rawRecords)),
+	}
+	for i := range rawRecords {
+		ev, status, detail := parseEvidenceRecord(rawRecords[i])
+		result := RecordVerifyResult{
+			Status: status,
+			Detail: detail,
+		}
+
+		if ev != nil {
+			result.ID = ev.ID
+			switch {
+			case ev.Signature == "":
+				result.Status = VerifyStatusMissingSignature
+				result.Detail = "missing signature field"
+				report.MissingSignature++
+			case s.VerifyRecord(ev):
+				result.Status = VerifyStatusValid
+				result.Detail = "signature valid"
+				report.Valid++
+			default:
+				result.Status = VerifyStatusInvalidSignature
+				result.Detail = "signature does not match record contents"
+				report.Invalid++
+			}
+			report.Records = append(report.Records, result)
+			continue
+		}
+
+		switch status {
+		case VerifyStatusMalformed:
+			report.Unparseable++
+		case VerifyStatusUnsupported:
+			report.Unsupported++
+		}
+		report.Records = append(report.Records, result)
+	}
+	return report
+}
+
+func parseEvidenceRecord(raw json.RawMessage) (*Evidence, string, string) {
+	var shape map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &shape); err != nil {
+		return nil, VerifyStatusMalformed, "malformed evidence record JSON"
+	}
+
+	if !looksLikeEvidence(shape) {
+		return nil, VerifyStatusUnsupported, "record does not match signed evidence schema"
+	}
+
+	var ev Evidence
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return nil, VerifyStatusMalformed, "could not parse evidence record"
+	}
+	return &ev, VerifyStatusValid, ""
+}
+
+func looksLikeEvidence(shape map[string]json.RawMessage) bool {
+	_, hasPolicy := shape["policy_decision"]
+	_, hasExecution := shape["execution"]
+	_, hasTimestamp := shape["timestamp"]
+	return hasPolicy && hasExecution && hasTimestamp
+}
+
+func verificationHint(report FileVerifyReport) string {
+	if report.Total > 0 && report.Valid == 0 && report.Invalid > 0 && report.MissingSignature == 0 && report.Unparseable == 0 && report.Unsupported == 0 {
+		return "all signatures failed; check TALON_SIGNING_KEY"
+	}
+	return ""
+}

--- a/internal/evidence/signed_export.go
+++ b/internal/evidence/signed_export.go
@@ -67,7 +67,7 @@ func (s *Store) VerifyExport(data []byte) (FileVerifyReport, error) {
 	switch trimmed[0] {
 	case '{':
 		report, err := s.verifySignedJSON(trimmed)
-		if report.Total == 0 && bytes.Contains(trimmed, []byte("\n")) {
+		if report.Total == 0 && report.HasFailures() && bytes.Contains(trimmed, []byte("\n")) {
 			ndReport, ndErr := s.verifyNDJSON(trimmed)
 			if ndReport.Total > 0 || ndErr == nil {
 				return ndReport, ndErr

--- a/internal/evidence/signed_export.go
+++ b/internal/evidence/signed_export.go
@@ -221,7 +221,7 @@ func (s *Store) verifyRawRecords(rawRecords []json.RawMessage) FileVerifyReport 
 	return report
 }
 
-func parseEvidenceRecord(raw json.RawMessage) (*Evidence, string, string) {
+func parseEvidenceRecord(raw json.RawMessage) (ev *Evidence, status string, detail string) {
 	var shape map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &shape); err != nil {
 		return nil, VerifyStatusMalformed, "malformed evidence record JSON"
@@ -231,11 +231,11 @@ func parseEvidenceRecord(raw json.RawMessage) (*Evidence, string, string) {
 		return nil, VerifyStatusUnsupported, "record does not match signed evidence schema"
 	}
 
-	var ev Evidence
-	if err := json.Unmarshal(raw, &ev); err != nil {
+	var record Evidence
+	if err := json.Unmarshal(raw, &record); err != nil {
 		return nil, VerifyStatusMalformed, "could not parse evidence record"
 	}
-	return &ev, VerifyStatusValid, ""
+	return &record, VerifyStatusValid, ""
 }
 
 func looksLikeEvidence(shape map[string]json.RawMessage) bool {

--- a/internal/evidence/signed_export_test.go
+++ b/internal/evidence/signed_export_test.go
@@ -1,0 +1,193 @@
+package evidence
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyExport_ValidSignedJSON(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	gen := NewGenerator(store)
+
+	ev, err := gen.Generate(ctx, GenerateParams{
+		CorrelationID:  "corr_signed_ok",
+		TenantID:       "acme",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+
+	envelope := SignedExportEnvelope{
+		ExportMetadata: ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: "test",
+			TotalRecords: 1,
+			Algorithm:    SignedExportAlgorithm,
+			Signed:       true,
+		},
+		Records: []Evidence{*ev},
+	}
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	report, verifyErr := store.VerifyExport(payload)
+	require.NoError(t, verifyErr)
+	assert.Equal(t, 1, report.Total)
+	assert.Equal(t, 1, report.Valid)
+	assert.False(t, report.HasFailures())
+}
+
+func TestVerifyExport_TamperedRecordFails(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	gen := NewGenerator(store)
+
+	ev, err := gen.Generate(ctx, GenerateParams{
+		CorrelationID:  "corr_signed_tamper",
+		TenantID:       "acme",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+		Cost:           0.1,
+	})
+	require.NoError(t, err)
+
+	tampered := *ev
+	tampered.Execution.Cost = 42.0
+	envelope := SignedExportEnvelope{
+		ExportMetadata: ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: "test",
+			TotalRecords: 1,
+			Algorithm:    SignedExportAlgorithm,
+			Signed:       true,
+		},
+		Records: []Evidence{tampered},
+	}
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	report, verifyErr := store.VerifyExport(payload)
+	require.NoError(t, verifyErr)
+	assert.Equal(t, 1, report.Total)
+	assert.Equal(t, 1, report.Invalid)
+	assert.True(t, report.HasFailures())
+	assert.Equal(t, "all signatures failed; check TALON_SIGNING_KEY", report.Hint)
+}
+
+func TestVerifyExport_MissingSignature(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	gen := NewGenerator(store)
+
+	ev, err := gen.Generate(ctx, GenerateParams{
+		CorrelationID:  "corr_signed_missing",
+		TenantID:       "acme",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+	ev.Signature = ""
+
+	envelope := SignedExportEnvelope{
+		ExportMetadata: ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: "test",
+			TotalRecords: 1,
+			Algorithm:    SignedExportAlgorithm,
+			Signed:       true,
+		},
+		Records: []Evidence{*ev},
+	}
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	report, verifyErr := store.VerifyExport(payload)
+	require.NoError(t, verifyErr)
+	assert.Equal(t, 1, report.Total)
+	assert.Equal(t, 1, report.MissingSignature)
+	assert.True(t, report.HasFailures())
+}
+
+func TestVerifyExport_UnsupportedReducedEnvelope(t *testing.T) {
+	store := newTestStore(t)
+	envelope := ExportEnvelope{
+		ExportMetadata: ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: "test",
+			TotalRecords: 1,
+		},
+		Records: []ExportRecord{{ID: "rec_1"}},
+	}
+	payload, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	report, verifyErr := store.VerifyExport(payload)
+	require.Error(t, verifyErr)
+	assert.Equal(t, 1, report.Unsupported)
+	assert.True(t, report.HasFailures())
+}
+
+func TestVerifyExport_SignedNDJSONMixed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	gen := NewGenerator(store)
+
+	ev, err := gen.Generate(ctx, GenerateParams{
+		CorrelationID:  "corr_signed_ndjson",
+		TenantID:       "acme",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+	validLine, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	payload := append(validLine, []byte("\n{bad json}\n")...)
+	report, verifyErr := store.VerifyExport(payload)
+	require.NoError(t, verifyErr)
+	assert.Equal(t, 2, report.Total)
+	assert.Equal(t, 1, report.Valid)
+	assert.Equal(t, 1, report.Unparseable)
+	assert.True(t, report.HasFailures())
+}
+
+func TestSignedExportEnvelope_ContainsSignatures(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	gen := NewGenerator(store)
+	_, err := gen.Generate(ctx, GenerateParams{
+		CorrelationID:  "corr_signed_export_contains_sig",
+		TenantID:       "acme",
+		AgentID:        "agent",
+		InvocationType: "manual",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "hello",
+		OutputResponse: "world",
+	})
+	require.NoError(t, err)
+
+	list, err := store.List(ctx, "acme", "agent", time.Time{}, time.Time{}, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, list)
+	for i := range list {
+		assert.NotEmpty(t, list[i].Signature)
+	}
+}

--- a/internal/evidence/signed_export_test.go
+++ b/internal/evidence/signed_export_test.go
@@ -142,6 +142,29 @@ func TestVerifyExport_UnsupportedReducedEnvelope(t *testing.T) {
 	assert.True(t, report.HasFailures())
 }
 
+func TestVerifyExport_EmptySignedJSON(t *testing.T) {
+	store := newTestStore(t)
+
+	envelope := SignedExportEnvelope{
+		ExportMetadata: ExportMetadata{
+			GeneratedAt:  time.Now().UTC(),
+			TalonVersion: "test",
+			TotalRecords: 0,
+			Algorithm:    SignedExportAlgorithm,
+			Signed:       true,
+		},
+		Records: []Evidence{},
+	}
+	payload, err := json.MarshalIndent(envelope, "", "  ")
+	require.NoError(t, err)
+
+	report, verifyErr := store.VerifyExport(payload)
+	require.NoError(t, verifyErr)
+	assert.Equal(t, 0, report.Total)
+	assert.Equal(t, 0, report.Valid)
+	assert.False(t, report.HasFailures(), "empty signed export should not report failures")
+}
+
 func TestVerifyExport_SignedNDJSONMixed(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/evidence/signed_export_test.go
+++ b/internal/evidence/signed_export_test.go
@@ -183,7 +183,8 @@ func TestVerifyExport_SignedNDJSONMixed(t *testing.T) {
 	validLine, err := json.Marshal(ev)
 	require.NoError(t, err)
 
-	payload := append(validLine, []byte("\n{bad json}\n")...)
+	validLine = append(validLine, []byte("\n{bad json}\n")...)
+	payload := validLine
 	report, verifyErr := store.VerifyExport(payload)
 	require.NoError(t, verifyErr)
 	assert.Equal(t, 2, report.Total)

--- a/internal/gateway/blocked_metrics_test.go
+++ b/internal/gateway/blocked_metrics_test.go
@@ -508,7 +508,7 @@ func TestGatewayMetrics_RuntimeEventMatchesEvidenceProjection(t *testing.T) {
 
 type budgetDenyPolicy struct{}
 
-func (p *budgetDenyPolicy) EvaluateGateway(_ context.Context, _ map[string]interface{}) (bool, []string, error) {
+func (p *budgetDenyPolicy) EvaluateGateway(_ context.Context, _ map[string]interface{}) (allowed bool, reasons []string, err error) {
 	return false, []string{"budget exceeded: daily limit"}, nil
 }
 

--- a/internal/gateway/blocked_metrics_test.go
+++ b/internal/gateway/blocked_metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -503,4 +504,40 @@ func TestGatewayMetrics_RuntimeEventMatchesEvidenceProjection(t *testing.T) {
 	assert.Equal(t, projected.CallerID, observed["caller_id"])
 	assert.Equal(t, projected.Model, observed["model"])
 	assert.Equal(t, projected.CostEUR, observed["cost_eur"])
+}
+
+type budgetDenyPolicy struct{}
+
+func (p *budgetDenyPolicy) EvaluateGateway(_ context.Context, _ map[string]interface{}) (bool, []string, error) {
+	return false, []string{"budget exceeded: daily limit"}, nil
+}
+
+func TestBudgetDeniedRequest_RecordsSignedEvidence(t *testing.T) {
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "http://localhost:1"},
+		},
+		Callers: []CallerConfig{
+			{Name: "test-caller", TenantKey: "talon-gw-test-001", TenantID: "default"},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		Timeouts:       TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+
+	gw, _, evStore := setupGatewayWithSpy(t, cfg, &budgetDenyPolicy{})
+	w := postGateway(gw, "/v1/proxy/openai/v1/chat/completions", "talon-gw-test-001",
+		`{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}`)
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	list, err := evStore.List(context.Background(), "default", "test-caller", time.Time{}, time.Time{}, 5)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	ev := list[0]
+	assert.False(t, ev.PolicyDecision.Allowed)
+	require.NotEmpty(t, ev.Signature)
+	assert.True(t, evStore.VerifyRecord(&ev), "budget-denied evidence must remain signature-verifiable")
+	assert.Contains(t, strings.Join(ev.PolicyDecision.Reasons, ","), "budget")
 }

--- a/internal/server/dashboard_html_test.go
+++ b/internal/server/dashboard_html_test.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dativo-io/talon/web"
+)
+
+func TestDashboardHTML_ContainsEvidenceIntegritySurface(t *testing.T) {
+	html := web.DashboardHTML
+	assert.NotEmpty(t, html)
+	assert.True(t, strings.Contains(html, "evidence-verify-visible"))
+	assert.True(t, strings.Contains(html, "evidence-integrity-state"))
+	assert.True(t, strings.Contains(html, "evidence-signature-grid"))
+	assert.True(t, strings.Contains(html, "evidence-spend-grid"))
+	assert.True(t, strings.Contains(html, "Evidence-grade, not just logs"))
+}
+
+func TestGatewayDashboardHTML_ContainsEvidenceReviewLink(t *testing.T) {
+	html := web.GatewayDashboardHTML
+	assert.NotEmpty(t, html)
+	assert.True(t, strings.Contains(html, "#evidence-gateway"))
+	assert.True(t, strings.Contains(html, "Open approvals and evidence review"))
+}

--- a/tests/smoke_sections/10_audit.sh
+++ b/tests/smoke_sections/10_audit.sh
@@ -26,21 +26,6 @@ test_section_10_audit() {
     grep -qiE 'policy_decision|Policy' <<< "$show_out"
   assert_pass "talon audit verify <id> exits 0 and contains valid: true or VALID" \
     grep -qi valid <<< "$(run_talon audit verify "$ev_id" 2>/dev/null)" && run_talon audit verify "$ev_id" &>/dev/null
-  # Tamper: corrupt evidence_json so HMAC verification fails (Verify reads from JSON blob)
-  local db_path="$TALON_DATA_DIR/evidence.db"
-  if [[ -f "$db_path" ]] && command -v sqlite3 &>/dev/null; then
-    sqlite3 "$db_path" "UPDATE evidence SET evidence_json = REPLACE(evidence_json, '\"default\"', '\"tampered\"') WHERE id = '$ev_id';" 2>/dev/null || true
-    local verify_out; verify_out="$(run_talon audit verify "$ev_id" 2>&1)"
-    local verify_code=$?
-    if [[ $verify_code -eq 0 ]] && grep -q VALID <<< "$verify_out"; then
-      log_failure "talon audit verify tampered record should exit non-zero or output invalid" "$verify_out"
-    else
-      echo "  ✓  talon audit verify tampered record exits non-zero or outputs invalid"
-      record_pass
-    fi
-  else
-    echo "  -  (skip tamper test: evidence.db or sqlite3 not found)"
-  fi
   assert_pass "talon audit export --format csv exits 0" run_talon audit export --format csv --from 2020-01-01 --to 2099-12-31
   local csv_out; csv_out="$(run_talon audit export --format csv --from 2020-01-01 --to 2099-12-31 2>/dev/null)"; true
   assert_pass "CSV has header with id, timestamp, tenant_id, pii_detected" \
@@ -87,6 +72,22 @@ PY
     record_pass
   else
     log_failure "talon audit verify --file tampered export should fail with integrity diagnostics" "$verify_file_out"
+  fi
+  # Tamper store record only after signed-export verification checks above.
+  # This keeps the signed export "happy path" deterministic in smoke runs.
+  local db_path="$TALON_DATA_DIR/evidence.db"
+  if [[ -f "$db_path" ]] && command -v sqlite3 &>/dev/null; then
+    sqlite3 "$db_path" "UPDATE evidence SET evidence_json = REPLACE(evidence_json, '\"default\"', '\"tampered\"') WHERE id = '$ev_id';" 2>/dev/null || true
+    local verify_out; verify_out="$(run_talon audit verify "$ev_id" 2>&1)"
+    local verify_code=$?
+    if [[ $verify_code -eq 0 ]] && grep -q VALID <<< "$verify_out"; then
+      log_failure "talon audit verify tampered record should exit non-zero or output invalid" "$verify_out"
+    else
+      echo "  ✓  talon audit verify tampered record exits non-zero or outputs invalid"
+      record_pass
+    fi
+  else
+    echo "  -  (skip tamper test: evidence.db or sqlite3 not found)"
   fi
   assert_pass "talon audit export --from --to exits 0" \
     run_talon audit export --format json --from 2020-01-01 --to 2099-12-31

--- a/tests/smoke_sections/10_audit.sh
+++ b/tests/smoke_sections/10_audit.sh
@@ -48,6 +48,46 @@ test_section_10_audit() {
   assert_pass "talon audit export --format json exits 0" run_talon audit export --format json --from 2020-01-01 --to 2099-12-31
   local json_out; json_out="$(run_talon audit export --format json --from 2020-01-01 --to 2099-12-31 2>/dev/null)"; true
   assert_pass "audit export JSON is valid (jq)" jq . <<< "$json_out"
+  # Signed export + file verification path (integrity export for auditors)
+  local signed_json_path="$dir/smoke-signed-evidence.json"
+  assert_pass "talon audit export --format signed-json exits 0" \
+    run_talon audit export --format signed-json --from 2020-01-01 --to 2099-12-31 --output "$signed_json_path"
+  assert_pass "signed-json export metadata marks signed=true" \
+    jq -e '.export_metadata.signed == true' < "$signed_json_path" &>/dev/null
+  assert_pass "signed-json export includes algorithm HMAC-SHA256" \
+    jq -e '.export_metadata.algorithm == "HMAC-SHA256"' < "$signed_json_path" &>/dev/null
+  assert_pass "signed-json export includes non-empty record signatures" \
+    jq -e '(.records | length) > 0 and all(.records[]; (.signature | type=="string" and length > 0))' < "$signed_json_path" &>/dev/null
+  assert_pass "talon audit verify --file signed export exits 0" \
+    run_talon audit verify --file "$signed_json_path"
+  # Tamper signed file; verify --file must fail and report invalid/unverifiable records.
+  local tampered_signed_json_path="$dir/smoke-signed-evidence-tampered.json"
+  if command -v python3 &>/dev/null; then
+    python3 - "$signed_json_path" "$tampered_signed_json_path" <<'PY'
+import json, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src, "r", encoding="utf-8") as f:
+    data = json.load(f)
+if data.get("records"):
+    rec = data["records"][0]
+    rec["tenant_id"] = "tampered-tenant"
+with open(dst, "w", encoding="utf-8") as f:
+    json.dump(data, f)
+PY
+  elif command -v jq &>/dev/null; then
+    jq '.records[0].tenant_id = "tampered-tenant"' "$signed_json_path" > "$tampered_signed_json_path"
+  else
+    cp "$signed_json_path" "$tampered_signed_json_path"
+  fi
+  local verify_file_out verify_file_code
+  verify_file_out="$(run_talon audit verify --file "$tampered_signed_json_path" 2>&1)"
+  verify_file_code=$?
+  if [[ $verify_file_code -ne 0 ]] && grep -qiE 'invalid|missing signature|unsupported|could not parse' <<< "$verify_file_out"; then
+    echo "  ✓  talon audit verify --file tampered export fails with integrity diagnostics"
+    record_pass
+  else
+    log_failure "talon audit verify --file tampered export should fail with integrity diagnostics" "$verify_file_out"
+  fi
   assert_pass "talon audit export --from --to exits 0" \
     run_talon audit export --format json --from 2020-01-01 --to 2099-12-31
   cd "$REPO_ROOT" || true

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -200,6 +200,7 @@ CACHEEOF
   assert_pass "dashboard HTML contains Mission Control marker" grep -q "Talon <span>Mission Control</span>" <<< "$dash_html"
   assert_pass "dashboard HTML contains Session Timeline marker" grep -q "Session Timeline (Lifecycle)" <<< "$dash_html"
   assert_pass "dashboard HTML contains Compliance Report Preview marker" grep -q "Compliance Report Preview" <<< "$dash_html"
+  assert_pass "dashboard HTML links governance evidence review with gateway hash" grep -q "/dashboard#evidence-gateway" <<< "$dash_html"
   assert_pass "dashboard HTML contains reliability badge marker" grep -q "reliability-badge" <<< "$dash_html"
   assert_pass "dashboard HTML contains <script>" grep -qi "<script" <<< "$dash_html"
   assert_pass "dashboard HTML contains Success Rate KPI" grep -qi "Success Rate" <<< "$dash_html"

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -54,6 +54,14 @@
     .evidence-filters { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; margin-bottom: 0.75rem; }
     .evidence-filters label { display: flex; align-items: center; gap: 0.25rem; font-size: 0.875rem; color: var(--text-dim); }
     .evidence-filters input, .evidence-filters select { background: var(--surface-2); color: var(--text); border: 1px solid var(--border); padding: 0.25rem 0.5rem; border-radius: 4px; }
+    .integrity-state { font-size: 0.85rem; font-weight: 600; white-space: nowrap; }
+    .integrity-state.pending { color: #cbd5e1; }
+    .integrity-state.error { color: #fca5a5; }
+    .detail-card { margin-top: 0.75rem; border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem; background: #0b1222; }
+    .detail-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); gap: 0.5rem 1rem; }
+    .detail-label { color: var(--text-dim); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.02em; }
+    .detail-value { font-size: 0.9rem; }
+    .detail-empty { color: var(--text-dim); font-size: 0.9rem; }
     .compliance-overlay { font-size: 0.75rem; color: var(--text-dim); margin-bottom: 0.5rem; }
     .governance-widget { margin-bottom: 1rem; padding: 0.75rem; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
     .denials-summary { font-size: 0.875rem; color: var(--text); margin: 0; }
@@ -158,6 +166,8 @@
 
   <div id="panel-evidence" class="panel active">
     <p class="compliance-overlay">Evidence supports: GDPR Art. 30, EU AI Act documentation (when present in metadata).</p>
+    <p class="refresh">Evidence-grade, not just logs. Talon signs every evidence record at creation time; if a signed field changes later, verification fails.</p>
+    <p class="refresh" id="evidence-scope-note">Verified evidence proves both governance decisions and cost attribution.</p>
     <div class="evidence-filters">
       <label>Tenant <input type="text" id="filter-tenant" placeholder="optional" /></label>
       <label>Agent <input type="text" id="filter-agent" placeholder="optional" /></label>
@@ -166,12 +176,25 @@
       <label>From <input type="datetime-local" id="filter-from" /></label>
       <label>To <input type="datetime-local" id="filter-to" /></label>
       <button type="button" id="evidence-apply-filters" class="btn">Apply</button>
+      <button type="button" id="evidence-verify-visible" class="btn">Verify visible records</button>
     </div>
     <p><button type="button" id="evidence-export-btn" class="btn">Export (CSV)</button> <button type="button" id="audit-pack-btn" class="btn">Audit pack (JSON)</button></p>
     <table>
-      <thead><tr><th>Time</th><th>Agent</th><th>Status</th><th>Cost (€)</th><th>ID</th><th>Trace</th><th>Verify</th></tr></thead>
+      <thead><tr><th>Time</th><th>Agent</th><th>Status</th><th>Integrity</th><th>Cost (€)</th><th>ID</th><th>Detail</th><th>Verify</th></tr></thead>
       <tbody id="evidence-tbody"></tbody>
     </table>
+    <div id="evidence-detail" class="detail-card">
+      <h3 style="margin:0 0 0.5rem;">Evidence detail</h3>
+      <p id="evidence-detail-empty" class="detail-empty">Select a record with <strong>Detail</strong> to inspect signed fields, trust state, and spend attribution.</p>
+      <div id="evidence-detail-content" style="display:none;">
+        <h4 style="margin:0.5rem 0;">Signature block</h4>
+        <div id="evidence-signature-grid" class="detail-grid"></div>
+        <h4 style="margin:0.75rem 0 0.5rem;">Trust &amp; spend</h4>
+        <div id="evidence-spend-grid" class="detail-grid"></div>
+        <h4 style="margin:0.75rem 0 0.5rem;">Step trace</h4>
+        <div id="evidence-steps" class="detail-value"></div>
+      </div>
+    </div>
   </div>
   <div id="panel-plans" class="panel">
     <h3 style="margin-top:0">Pending</h3>
@@ -274,6 +297,8 @@
       setGatewayLinksToken(window.TALON_ADMIN_KEY || '');
       var base = window.TALON_BASE_URL || '';
       var key = window.TALON_ADMIN_KEY || '';
+      var evidenceIntegrityState = {};
+      var evidenceInvocationTypeFilter = window.location.hash === '#evidence-gateway' ? 'gateway' : '';
       function headers() {
         var h = { 'Content-Type': 'application/json' };
         var k = window.TALON_ADMIN_KEY || '';
@@ -295,6 +320,103 @@
           .replace(/>/g, '&gt;')
           .replace(/"/g, '&quot;')
           .replace(/'/g, '&#39;');
+      }
+      function integrityStateLabel(state) {
+        if (state === 'verified') return '✓ Verified';
+        if (state === 'invalid') return '✗ Invalid';
+        if (state === 'unable') return '⚠ Unable to verify';
+        return '— Not checked';
+      }
+      function integrityStateClass(state) {
+        if (state === 'verified') return 'status-ok';
+        if (state === 'invalid') return 'status-deny';
+        if (state === 'unable') return 'integrity-state error';
+        return 'integrity-state pending';
+      }
+      function renderIntegrityCellState(cell, state) {
+        if (!cell) return;
+        var text = integrityStateLabel(state);
+        if (state === 'verified' || state === 'invalid') {
+          cell.innerHTML = '<span class="' + integrityStateClass(state) + '">' + escapeHtml(text) + '</span>';
+          return;
+        }
+        cell.innerHTML = '<span class="' + integrityStateClass(state) + '">' + escapeHtml(text) + '</span>';
+      }
+      function writeDetailGrid(targetID, rows) {
+        var target = document.getElementById(targetID);
+        if (!target) return;
+        target.innerHTML = '';
+        rows.forEach(function(row) {
+          var block = document.createElement('div');
+          block.innerHTML = '<div class="detail-label">' + escapeHtml(row.label) + '</div><div class="detail-value">' + escapeHtml(row.value) + '</div>';
+          target.appendChild(block);
+        });
+      }
+      function setEvidenceDetailVisible(visible) {
+        var empty = document.getElementById('evidence-detail-empty');
+        var content = document.getElementById('evidence-detail-content');
+        if (empty) empty.style.display = visible ? 'none' : 'block';
+        if (content) content.style.display = visible ? 'block' : 'none';
+      }
+      function renderEvidenceDetail(ev, trace, verifyResult) {
+        if (!ev) {
+          setEvidenceDetailVisible(false);
+          return;
+        }
+        var decision = (ev.policy_decision && ev.policy_decision.allowed) ? 'Allowed' : 'Denied';
+        var provider = (ev.routing_decision && ev.routing_decision.selected_provider) ? ev.routing_decision.selected_provider : '—';
+        var signatureRows = [
+          { label: 'Evidence ID', value: ev.id || '—' },
+          { label: 'Tenant ID', value: ev.tenant_id || '—' },
+          { label: 'Agent / caller ID', value: ev.agent_id || '—' },
+          { label: 'Timestamp', value: ev.timestamp ? new Date(ev.timestamp).toISOString() : '—' },
+          { label: 'Algorithm', value: 'HMAC-SHA256' },
+          { label: 'Input hash', value: (ev.audit_trail && ev.audit_trail.input_hash) ? ev.audit_trail.input_hash : '—' },
+          { label: 'Output hash', value: (ev.audit_trail && ev.audit_trail.output_hash) ? ev.audit_trail.output_hash : '—' },
+          { label: 'Policy decision', value: decision + (ev.policy_decision && ev.policy_decision.action ? ' (' + ev.policy_decision.action + ')' : '') },
+          { label: 'Verification result', value: verifyResult && verifyResult.valid ? '✓ Verified' : '✗ Invalid' }
+        ];
+        var spendRows = [
+          { label: 'Execution cost', value: ev.execution && ev.execution.cost != null ? String(ev.execution.cost) : '—' },
+          { label: 'Tokens (in/out)', value: ev.execution && ev.execution.tokens ? String(ev.execution.tokens.input || 0) + ' / ' + String(ev.execution.tokens.output || 0) : '—' },
+          { label: 'Model', value: ev.execution && ev.execution.model_used ? ev.execution.model_used : '—' },
+          { label: 'Provider', value: provider },
+          { label: 'Tenant', value: ev.tenant_id || '—' },
+          { label: 'Caller source', value: ev.request_source_id || ev.agent_id || '—' }
+        ];
+        writeDetailGrid('evidence-signature-grid', signatureRows);
+        writeDetailGrid('evidence-spend-grid', spendRows);
+        var stepsEl = document.getElementById('evidence-steps');
+        if (stepsEl) {
+          var steps = trace && trace.steps ? trace.steps : [];
+          if (!steps.length) {
+            stepsEl.textContent = 'No step evidence recorded for this invocation.';
+          } else {
+            stepsEl.innerHTML = steps.map(function(step, idx) {
+              var label = (step.step_type || step.type || 'step') + (step.tool_name ? ' ' + step.tool_name : '');
+              return '<div>' + (idx + 1) + '. ' + escapeHtml(label) + '</div>';
+            }).join('');
+          }
+        }
+        setEvidenceDetailVisible(true);
+      }
+      function verifyEvidenceByID(id) {
+        return get('/v1/evidence/' + encodeURIComponent(id) + '/verify').then(function(res) {
+          evidenceIntegrityState[id] = res.valid ? 'verified' : 'invalid';
+          return res;
+        }).catch(function(err) {
+          evidenceIntegrityState[id] = 'unable';
+          throw err;
+        });
+      }
+      function updateEvidenceScopeLabel() {
+        var note = document.getElementById('evidence-scope-note');
+        if (!note) return;
+        if (evidenceInvocationTypeFilter === 'gateway') {
+          note.textContent = 'Showing gateway evidence only. Verified evidence proves both governance decisions and cost attribution.';
+          return;
+        }
+        note.textContent = 'Verified evidence proves both governance decisions and cost attribution.';
       }
       function post(url, body) {
         return fetch(base + url, { method: 'POST', headers: headers(), body: JSON.stringify(body || {}) }).then(function(r) {
@@ -558,6 +680,9 @@
           var toDate = new Date(toEl.value);
           if (!isNaN(toDate.getTime())) params.push('to=' + encodeURIComponent(toDate.toISOString()));
         }
+        if (evidenceInvocationTypeFilter) {
+          params.push('invocation_type=' + encodeURIComponent(evidenceInvocationTypeFilter));
+        }
         return params.join('&');
       }
       function syncCardsFromEvidence(entries) {
@@ -608,9 +733,15 @@
         get('/v1/evidence?' + q).then(function(d) {
           var tbody = document.getElementById('evidence-tbody');
           if (!tbody) return;
+          updateEvidenceScopeLabel();
           syncCardsFromEvidence(d.entries || []);
           syncPolicyOutcomeFromEvidence(d.entries || []);
           tbody.innerHTML = '';
+          if (!(d.entries || []).length) {
+            tbody.innerHTML = '<tr><td colspan="8" class="refresh">No evidence yet. Run a request (CLI or proxy) to generate signed records, then verify integrity inline from this table.</td></tr>';
+            setEvidenceDetailVisible(false);
+            return;
+          }
           (d.entries || []).forEach(function(ev) {
             var tr = document.createElement('tr');
             var time = ev.timestamp ? new Date(ev.timestamp).toLocaleString() : '—';
@@ -621,14 +752,16 @@
             var cost = ev.cost != null ? ev.cost.toFixed(4) : '—';
             var id = ev.id || '';
             var idEsc = escapeHtml(id || '—');
+            if (!evidenceIntegrityState[id]) evidenceIntegrityState[id] = 'not_checked';
             var verifyBtn = '<button type="button" class="btn evidence-verify" data-id="' + String(id).replace(/"/g, '&quot;') + '">Verify</button>';
-            var traceBtn = '<button type="button" class="btn evidence-trace" data-id="' + String(id).replace(/"/g, '&quot;') + '">Trace</button>';
+            var traceBtn = '<button type="button" class="btn evidence-trace" data-id="' + String(id).replace(/"/g, '&quot;') + '">Detail</button>';
             var complianceTip = '';
             if (ev.compliance && ev.compliance.frameworks && ev.compliance.frameworks.length) {
               complianceTip = ' title="Frameworks: ' + escapeHtml(ev.compliance.frameworks.join(', ')) + (ev.compliance.data_location ? '; Location: ' + ev.compliance.data_location : '') + '"';
             }
-            tr.innerHTML = '<td>' + escapeHtml(time) + '</td><td>' + escapeHtml(ev.agent_id || '—') + '</td><td>' + status + '</td><td>' + escapeHtml(cost) + '</td><td' + complianceTip + '>' + idEsc + '</td><td>' + traceBtn + '</td><td>' + verifyBtn + '</td>';
+            tr.innerHTML = '<td>' + escapeHtml(time) + '</td><td>' + escapeHtml(ev.agent_id || '—') + '</td><td>' + status + '</td><td class="evidence-integrity-state" data-id="' + String(id).replace(/"/g, '&quot;') + '"></td><td>' + escapeHtml(cost) + '</td><td' + complianceTip + '>' + idEsc + '</td><td>' + traceBtn + '</td><td>' + verifyBtn + '</td>';
             tbody.appendChild(tr);
+            renderIntegrityCellState(tr.querySelector('.evidence-integrity-state'), evidenceIntegrityState[id]);
           });
           var complianceSummary = document.getElementById('compliance-preview-summary');
           if (complianceSummary) {
@@ -643,17 +776,12 @@
             btn.addEventListener('click', function() {
               var id = btn.getAttribute('data-id');
               if (!id || id === '—') return;
-              get('/v1/evidence/' + encodeURIComponent(id) + '/verify').then(function(res) {
-                var msg = res.valid ? 'Signature valid' : 'Signature invalid';
-                var span = document.createElement('span');
-                span.className = res.valid ? 'status-ok' : 'status-deny';
-                span.textContent = msg;
-                btn.parentNode.replaceChild(span, btn);
-              }).catch(function(e) {
-                var span = document.createElement('span');
-                span.className = 'error';
-                span.textContent = e.message || 'Error';
-                btn.parentNode.replaceChild(span, btn);
+              var row = btn.closest('tr');
+              var stateCell = row ? row.querySelector('.evidence-integrity-state') : null;
+              verifyEvidenceByID(id).then(function() {
+                renderIntegrityCellState(stateCell, evidenceIntegrityState[id]);
+              }).catch(function() {
+                renderIntegrityCellState(stateCell, evidenceIntegrityState[id]);
               });
             });
           });
@@ -661,28 +789,30 @@
             btn.addEventListener('click', function() {
               var id = btn.getAttribute('data-id');
               if (!id || id === '—') return;
-              get('/v1/evidence/' + encodeURIComponent(id) + '/trace').then(function(trace) {
-                var ev = trace.evidence || trace;
-                var steps = trace.steps || [];
-                var lines = ['Evidence: ' + (ev.id || id), 'Correlation: ' + (ev.correlation_id || '—'), 'Model: ' + (ev.execution && ev.execution.model_used ? ev.execution.model_used : '—'), 'Cost: ' + (ev.execution && ev.execution.cost != null ? ev.execution.cost : '—'), 'Steps: ' + steps.length];
-                var explanations = Array.isArray(ev.explanations) ? ev.explanations : [];
-                if (explanations.length > 0) {
-                  var primary = explanations[0];
-                  lines.push('Primary explanation: ' + (primary.code || '—') + ' - ' + (primary.reason || '—'));
-                  if (primary.stage) lines.push('Stage: ' + primary.stage);
-                  if (primary.trigger) lines.push('Trigger: ' + primary.trigger);
-                  if (primary.policy_ref) lines.push('Policy ref: ' + primary.policy_ref);
-                  if (primary.version_identity) lines.push('Version: ' + primary.version_identity);
-                  if (primary.fix) lines.push('Fix: ' + primary.fix);
-                }
-                steps.forEach(function(s, i) { lines.push('  ' + (i+1) + '. ' + (s.step_type || s.type || 'step') + (s.tool_name ? ' ' + s.tool_name : '')); });
-                alert(lines.join('\n'));
-              }).catch(function(e) { alert('Trace failed: ' + (e.message || e)); });
+              Promise.all([
+                get('/v1/evidence/' + encodeURIComponent(id)),
+                get('/v1/evidence/' + encodeURIComponent(id) + '/verify'),
+                get('/v1/evidence/' + encodeURIComponent(id) + '/trace')
+              ]).then(function(results) {
+                var detail = results[0];
+                var verifyRes = results[1];
+                var trace = results[2];
+                evidenceIntegrityState[id] = verifyRes.valid ? 'verified' : 'invalid';
+                var row = btn.closest('tr');
+                var stateCell = row ? row.querySelector('.evidence-integrity-state') : null;
+                renderIntegrityCellState(stateCell, evidenceIntegrityState[id]);
+                renderEvidenceDetail(detail, trace, verifyRes);
+              }).catch(function(e) {
+                renderEvidenceDetail(null, null, null);
+                var stepsEl = document.getElementById('evidence-steps');
+                if (stepsEl) stepsEl.textContent = 'Unable to load detail: ' + (e.message || e);
+                setEvidenceDetailVisible(true);
+              });
             });
           });
         }).catch(function(e) {
           var tbody = document.getElementById('evidence-tbody');
-          if (tbody) tbody.innerHTML = '<tr><td colspan="7" class="error">' + escapeHtml(e.message) + '</td></tr>';
+          if (tbody) tbody.innerHTML = '<tr><td colspan="8" class="error">' + escapeHtml(e.message) + '</td></tr>';
         });
       }
 
@@ -911,6 +1041,22 @@
       });
       var applyFiltersBtn = document.getElementById('evidence-apply-filters');
       if (applyFiltersBtn) applyFiltersBtn.addEventListener('click', renderEvidence);
+      var verifyVisibleBtn = document.getElementById('evidence-verify-visible');
+      if (verifyVisibleBtn) verifyVisibleBtn.addEventListener('click', function() {
+        var rows = Array.prototype.slice.call(document.querySelectorAll('#evidence-tbody tr'));
+        var checks = rows.map(function(row) {
+          var verifyBtn = row.querySelector('.evidence-verify');
+          var id = verifyBtn ? verifyBtn.getAttribute('data-id') : '';
+          var stateCell = row.querySelector('.evidence-integrity-state');
+          if (!id) return Promise.resolve();
+          return verifyEvidenceByID(id).catch(function() {
+            return null;
+          }).then(function() {
+            renderIntegrityCellState(stateCell, evidenceIntegrityState[id] || 'unable');
+          });
+        });
+        Promise.all(checks).then(function() {});
+      });
       var stakeholderView = document.getElementById('stakeholder-view');
       if (stakeholderView) stakeholderView.addEventListener('click', function(e) {
         e.preventDefault();
@@ -1006,6 +1152,8 @@
         if (document.getElementById('panel-memory').classList.contains('active')) renderMemory();
         if (document.getElementById('panel-finops').classList.contains('active')) renderFinops();
       }
+      setEvidenceDetailVisible(false);
+      updateEvidenceScopeLabel();
       refresh();
       startRecentEventsStream();
       setInterval(refresh, 30000);

--- a/web/gateway_dashboard.html
+++ b/web/gateway_dashboard.html
@@ -90,7 +90,7 @@
 <section class="mission-band band-1">
 <div class="header">
   <h1>Talon <span>Mission Control</span></h1>
-  <nav class="header-nav"><a href="/dashboard">← Governance dashboard</a></nav>
+  <nav class="header-nav"><a id="gw-evidence-link-header" href="/dashboard#evidence-gateway">← Governance dashboard</a></nav>
   <div class="header-meta">
     <span id="mode-badge" class="badge">--</span>
     <span id="reliability-badge" class="badge">--</span>
@@ -272,7 +272,7 @@
     <div class="card" style="margin-top:12px;">
       <div class="kpi-label">Plan Review Workflow</div>
       <div class="kpi-sub">Review approvals are available in Governance dashboard.</div>
-      <div class="kpi-sub"><a href="/dashboard" style="color: var(--brand-light); text-decoration:none;">Open approvals and evidence review →</a></div>
+      <div class="kpi-sub"><a id="gw-evidence-link-panel" href="/dashboard#evidence-gateway" style="color: var(--brand-light); text-decoration:none;">Open approvals and evidence review →</a></div>
     </div>
   </aside>
 </div>
@@ -298,6 +298,15 @@
   } else if (!window.TALON_ADMIN_KEY && tokenFromStorage) {
     window.TALON_ADMIN_KEY = tokenFromStorage;
   }
+  function setGovernanceLinksToken(token) {
+    if (!token) return;
+    var href = '/dashboard?talon_admin_key=' + encodeURIComponent(token) + '#evidence-gateway';
+    var header = document.getElementById('gw-evidence-link-header');
+    var panel = document.getElementById('gw-evidence-link-panel');
+    if (header) header.href = href;
+    if (panel) panel.href = href;
+  }
+  setGovernanceLinksToken(window.TALON_ADMIN_KEY || '');
 
   var eventSource = null;
   var pollTimer = null;


### PR DESCRIPTION
## Summary
- add signed evidence export formats (`signed-json` and `signed-ndjson`) and CLI file verification via `talon audit verify --file`
- upgrade dashboard evidence UX with explicit integrity states, persistent signature/trust detail panel, gateway-to-evidence parity link, and buyer-facing integrity copy
- extend docs and smoke coverage with a 5-minute integrity proof flow, signed export runbook guidance, and tamper-detection smoke checks

## Test plan
- [x] `go test ./internal/evidence ./internal/cmd ./internal/gateway ./internal/server`
- [x] `bash -n tests/smoke_sections/10_audit.sh tests/smoke_sections/23_dashboard_metrics.sh`
- [x] `make test`
- [x] `make check`
- [x] `make lint`
- [x] `make test-smoke`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compliance-critical audit export and HMAC verification paths; risk is mitigated by broad unit/CLI/smoke tests but wrong verification behavior could mislead auditors.
> 
> **Overview**
> This PR extends **evidence integrity** for auditors and operators: portable signed exports, offline verification, and clearer dashboard UX—without changing how records are signed at write time.
> 
> **CLI & evidence store:** `talon audit export` gains **`signed-json`** and **`signed-ndjson`**, emitting full `Evidence` objects (including HMAC signatures) via `SignedExportEnvelope` and metadata (`signed`, `algorithm`). **`talon audit verify --file`** parses those formats (plus NDJSON lines / JSON arrays), returns per-record counts (valid, invalid, missing signature, unparseable, unsupported), and exits non-zero on any failure. Single-ID verify remains; `--file` and an ID are mutually exclusive.
> 
> **Dashboard:** The Evidence tab adds an **Integrity** column (`Not checked` / `Verified` / `Invalid` / `Unable to verify`), **Verify visible records**, and a persistent **Detail** panel (signature block, trust/spend, step trace) driven by `/v1/evidence/{id}`, `/verify`, and `/trace`. Gateway Mission Control links to **`/dashboard#evidence-gateway`**, which filters list queries with `invocation_type=gateway`.
> 
> **Docs & tests:** Changelog, compliance runbook, evidence-store reference, a **5-minute integrity demo** tutorial, and smoke checks for signed export + tampered-file verify. Regression tests cover signed export, file verify, budget-denied signed evidence, and dashboard HTML markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dd0aeda974c26f3cbadae503ba8b8771cf7be0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->