### PR TITLE
fix(build): bump Go patch versions to 1.25.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.8']
+        go-version: ['1.25.10']
 
     steps:
       - uses: actions/checkout@v4
@@ -79,10 +79,10 @@ jobs:
           path: coverage-${{ matrix.go-version }}.out
 
       - name: Upload to Codecov
-        if: matrix.go-version == '1.25.8'
+        if: matrix.go-version == '1.25.10'
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage-1.25.8.out
+          file: ./coverage-1.25.10.out
           fail_ci_if_error: false
 
   lint:
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.10'
           cache: true
 
       - name: golangci-lint
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.10'
           cache: true
 
       - name: Install cross-compilation tools

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.10'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for minimal image size (<50MB target)
 
 # Stage 1: Build
-FROM golang:1.25.8-alpine AS builder
+FROM golang:1.25.10-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache gcc musl-dev sqlite-dev git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dativo-io/talon
 
-go 1.25.8
+go 1.25.10
 
 require (
 	// HTTP Router (Prompt 6)


### PR DESCRIPTION
## Summary
- Upgrade Go patch pin in `go.mod` from `1.25.8` to `1.25.10` to pick up stdlib security fixes.
- Update CI/security workflow Go versions to `1.25.10` so govulncheck and CI run on patched stdlib.
- Update Docker builder image to `golang:1.25.10-alpine` for secure release builds.

## Test plan
- [x] `go build ./...`
- [x] `GOTOOLCHAIN=go1.25.10 govulncheck ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin only across build/CI/Docker; no runtime or application logic changes.
> 
> **Overview**
> Pins the toolchain from **Go 1.25.8** to **1.25.10** everywhere the project declares or runs Go: `go.mod`, CI test/lint/build (including Codecov artifact paths), the security workflow’s `govulncheck` job, and the Docker builder image (`golang:1.25.10-alpine`).
> 
> No application source changes—this is a patch-level stdlib/toolchain upgrade for security fixes, with CI and release builds aligned on the same version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf63c76ec9348c6164c8b507bb9ac7e9c4e2da0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->