### PR TITLE
feat(cost): add hard caller caps and evidence-backed spend visibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Choose the shortest path for your situation:
 | [Docker primer: OpenClaw + Talon (cloud-ready)](guides/openclaw-talon-primer/docker-openclaw-talon-primer.md) | Predefined Docker setup to run Talon gateway for OpenClaw; deploy in the cloud. |
 | [How to add compliance to your Slack bot](guides/slack-bot-integration.md) | Route your Slack bot's LLM calls through Talon. |
 | [How to govern ChatGPT/Claude Desktop (enterprise)](guides/desktop-app-governance.md) | Route desktop app traffic via DNS/TLS and gateway. |
-| [How to cap daily spend per team or application](guides/cost-governance-by-caller.md) | Gateway callers and policy overrides for cost limits. |
+| [Cap AI spend for a Slack/support bot in 10 minutes](guides/cost-governance-by-caller.md) | Fast path to caller-level daily/monthly hard caps, budget-deny proof, and evidence-backed cost attribution. |
 | [How to export evidence for auditors](guides/compliance-export-runbook.md) | Export, verify, and hand off audit evidence. |
 | [How to run governed LLM calls in CI/CD](guides/cicd-pipeline-governance.md) | Use Talon from GitHub Actions or GitLab CI. |
 | [How to run a first-line support agent with Talon](guides/internal-support-agent.md) | Ticket summarization with PII and cost controls. |

--- a/docs/guides/cost-governance-by-caller.md
+++ b/docs/guides/cost-governance-by-caller.md
@@ -1,82 +1,136 @@
-# How to cap daily spend per team or application
+# Cap AI spend for a Slack/support bot in 10 minutes
 
-Use the LLM API gateway to cap daily (and optionally monthly) spend per caller (team or application). Each caller is identified by tenant key or source IP and can have its own limits. You can then monitor usage via the costs API or CLI.
+Talon gives EMEA SMB operators a simple promise:
+
+> You can cap AI spend before it runs away, and prove every allow/deny decision with signed evidence.
+
+This guide shows the fastest path to that outcome for a support bot caller.
 
 ---
 
-## 1. Define callers with cost overrides
+## What this guide covers
 
-In your gateway config (e.g. `talon.config.yaml` with a `gateway` block), define one or more callers and set `policy_overrides.max_daily_cost` and optionally `max_monthly_cost`.
+- Hard daily/monthly spend caps for one caller (`support-slack-bot`)
+- Deny **before** any upstream provider call when the next request would exceed cap
+- Signed evidence for both allowed and denied decisions
+- Dashboard + CLI visibility for today/month, by caller/model/provider
 
-Example (excerpt from [examples/gateway/talon.config.gateway.yaml](../../examples/gateway/talon.config.gateway.yaml)):
+---
+
+## 1. Add a caller with hard EUR caps
+
+Use a gateway config like this (from [examples/gateway/talon.config.gateway.yaml](../../examples/gateway/talon.config.gateway.yaml)):
 
 ```yaml
 gateway:
   enabled: true
   listen_prefix: "/v1/proxy"
-  providers:
-    openai:
-      enabled: true
-      base_url: "https://api.openai.com"
-    ollama:
-      enabled: true
-      base_url: "http://localhost:11434"
+  mode: "enforce"
 
   callers:
-    - name: "slack-bot"
-      tenant_key: "talon-gw-slack-abc"
+    - name: "support-slack-bot"
+      tenant_key: "talon-gw-support-xyz"
       tenant_id: "default"
       policy_overrides:
-        max_daily_cost: 15.00
-        max_monthly_cost: 300.00
-
-    - name: "desktop-engineering"
-      tenant_key: "talon-gw-eng-xyz"
-      tenant_id: "default"
-      policy_overrides:
-        max_daily_cost: 25.00
-
-    - name: "ci-openai"
-      tenant_key: "talon-gw-ci-123"
-      tenant_id: "default"
-      policy_overrides:
-        max_daily_cost: 5.00
+        max_daily_cost: 10.00
+        max_monthly_cost: 200.00
+        pii_action: "warn"
+        allowed_models: ["gpt-4o-mini"]
 ```
 
-When a caller exceeds their daily or monthly limit, the gateway returns a policy denial and records evidence. Costs are still attributed to the caller for visibility.
+For a demo, temporarily lower `max_daily_cost` (for example `0.01`) so you can trigger a denial quickly.
 
 ---
 
-## 2. Start the gateway
+## 2. Start Talon gateway
 
 ```bash
-talon serve --gateway --gateway-config=path/to/your/talon.config.yaml
+talon serve --gateway --gateway-config=path/to/talon.config.yaml
 ```
 
-Ensure the real provider API keys are in the vault (e.g. `talon secrets set openai-api-key "sk-..."`). Callers only use their own gateway tenant keys; they never see the provider key.
+Ensure provider keys are in vault (for example `talon secrets set openai-api-key "sk-..."`).
 
 ---
 
-## 3. Monitor costs
+## 3. Run the 6-step demo flow
 
-**Via API (per tenant):**
+1. Configure very low `max_daily_cost` for `support-slack-bot`
+2. Send one request that is allowed
+3. Send a second request that would exceed budget
+4. Verify Talon denies **before** provider call
+5. Verify signed evidence exists for the denial
+6. Verify dashboard budget utilization reflects the event
 
-- `GET /v1/costs` with `Authorization: Bearer <tenant-key>` returns `daily` and `monthly` totals for the authenticated tenant. Gateway traffic is recorded under that tenant, so the totals include all callers in the tenant.
-- `GET /v1/costs/budget` returns usage and optional limits (when set in policy).
-
-**Via CLI:**
+Example calls:
 
 ```bash
-talon audit list --limit 50
+# Allowed request (first call)
+curl -sS "http://localhost:8080/v1/proxy/openai/v1/chat/completions" \
+  -H "Authorization: Bearer talon-gw-support-xyz" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Summarize ticket #123"}]}'
+
+# Denied request (second call, over cap)
+curl -sS "http://localhost:8080/v1/proxy/openai/v1/chat/completions" \
+  -H "Authorization: Bearer talon-gw-support-xyz" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Summarize ticket #124"}]}'
 ```
 
-Evidence records include cost per request. For per-caller breakdown you would filter or aggregate by the caller name stored in evidence (e.g. `agent_id` or request metadata, depending on how gateway evidence is tagged).
+Expected deny characteristics:
+
+- HTTP 403
+- Machine-readable error code/reason contains `budget_exceeded`
+- No upstream provider execution for denied call
+- Signed evidence row recorded with denial reason and estimated pre-call cost
+
+---
+
+## 4. Verify with CLI and dashboard
+
+CLI:
+
+```bash
+talon costs --tenant default
+talon costs --caller support-slack-bot --json
+talon costs --by-provider --tenant default
+```
+
+Export cost rows (joinable to signed evidence by `evidence_id`):
+
+```bash
+talon costs export --tenant default --caller support-slack-bot --format csv
+talon audit export --tenant default --caller support-slack-bot --format signed-json
+```
+
+HTTP/API equivalents:
+
+- `GET /v1/costs`
+- `GET /v1/costs/budget`
+- `POST /v1/costs/export`
+
+Dashboard:
+
+- `/gateway/dashboard` for real-time caller/model/provider operational view
+- `/dashboard` for evidence-backed governance view and drill-down
+
+---
+
+## Cost visibility vs caps vs evidence attribution
+
+- **Cost visibility**: today/month totals and breakdowns by tenant/caller/model/provider
+- **Hard budget caps**: deny requests that would exceed daily/monthly cap before provider call
+- **Evidence-backed attribution**: every allow/deny is signed and traceable by evidence ID, including budget-denied rows with zero provider cost and denial reason
+
+This is the launch narrative connection to evidence integrity:
+
+> Verified evidence proves both governance decisions and cost attribution.
 
 ---
 
 ## Native agents (no gateway)
 
-For agents run via `talon run` or `POST /v1/chat/completions`, cost limits are set in `.talon.yaml`:
+If you run `talon run` directly, use `.talon.yaml`:
 
 ```yaml
 policies:
@@ -86,19 +140,13 @@ policies:
     monthly: 400.00
 ```
 
-See [Policy cookbook](policy-cookbook.md) for more snippets.
-
 ---
 
-## You're done
-
-You now have per-caller cost caps (daily and optionally monthly) in your gateway config. Talon is denying or allowing requests based on those limits before the LLM call is made.
-
-**Next steps:**
+## Next steps
 
 | I want to… | Doc |
 |------------|-----|
-| Export evidence or verify records | [How to export evidence for auditors](compliance-export-runbook.md) |
-| Add more callers or restrict models | [Configuration and environment](../reference/configuration.md) |
-| Route another app through the gateway | [Add Talon to your existing app](add-talon-to-existing-app.md) |
-| Copy more policy snippets | [Policy cookbook](policy-cookbook.md) |
+| Verify signed exports and tamper checks | [How to export evidence for auditors](compliance-export-runbook.md) |
+| Understand dashboard metrics schema | [Gateway dashboard](../reference/gateway-dashboard.md) |
+| Add more callers/models | [Configuration and environment](../reference/configuration.md) |
+| Apply additional governance snippets | [Policy cookbook](policy-cookbook.md) |

--- a/docs/reference/gateway-dashboard.md
+++ b/docs/reference/gateway-dashboard.md
@@ -116,6 +116,9 @@ curl -s -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" http://localhost:8080/api/v1/me
   "model_breakdown": [
     {"model": "gpt-4o-mini", "requests": 900, "cost_eur": 2.1}
   ],
+  "provider_breakdown": [
+    {"provider": "openai", "requests": 900, "cost_eur": 2.1}
+  ],
   "tool_governance": {
     "total_requested": 150,
     "total_filtered": 12,
@@ -245,6 +248,10 @@ Detection counts per PII type (e.g. `email`, `iban`, `phone`, `ssn`, `passport`)
 
 Per-model request counts and cost. One entry per distinct model seen.
 
+### `provider_breakdown`
+
+Per-provider request counts and cost. One entry per selected provider in evidence routing decisions.
+
 ### `tool_governance`
 
 | Field | Type | Description |
@@ -303,8 +310,16 @@ Plan lifecycle counters (same values surfaced in `summary.*_plans` fields).
 The dashboard metrics and CLI commands (`talon costs`, `talon audit list`, `talon report`) share the same underlying `MetricsQuerier` interface against the evidence store. This ensures:
 
 - `talon costs --tenant default` reports the same daily/monthly totals as `budget_status` in the dashboard.
+- `talon costs --by-provider` aligns with `provider_breakdown` in `/api/v1/metrics`.
 - `talon report` counts match `summary.total_requests` and `summary.pii_detections`.
 - Evidence records shown by `talon audit list` are the same records that feed the dashboard timelines.
+
+Cost export surfaces:
+
+- CLI: `talon costs export --format csv|json --tenant <id> [--agent <id>|--caller <id>]`
+- API: `POST /v1/costs/export` with `{tenant_id, agent_id|caller, from, to, format}`
+
+Both export surfaces include evidence ID, tenant/agent, timestamp, model/provider, cost, token counts, and policy decision/reason so rows can be joined to signed evidence exports by evidence ID.
 
 The in-memory collector adds real-time aggregation (5-minute buckets, latency percentiles) on top of the querier, so the dashboard may reflect very recent events slightly sooner than CLI queries that read directly from SQLite.
 

--- a/examples/gateway/talon.config.gateway.yaml
+++ b/examples/gateway/talon.config.gateway.yaml
@@ -41,14 +41,15 @@ gateway:
         pii_action: "redact"
         allowed_models: ["gpt-4o", "gpt-4o-mini"]
 
-    - name: "support-bot"
-      tenant_key: "talon-gw-support-xyz789"
+    - name: "support-slack-bot"
+      tenant_key: "talon-gw-support-xyz"
       tenant_id: "default"
       team: "support"
       allowed_providers: ["openai"]
       policy_overrides:
         max_daily_cost: 10.00
-        pii_action: "block"
+        max_monthly_cost: 200.00
+        pii_action: "warn"
         allowed_models: ["gpt-4o-mini"]
 
   default_policy:

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -316,7 +316,7 @@ func resolveExportOutput(cmd *cobra.Command, outputFile string) (io.Writer, func
 func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 	writer := csv.NewWriter(w)
 	header := []string{
-		"id", "session_id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "cost", "model_used", "duration_ms", "has_error",
+		"id", "session_id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "policy_action", "cost", "model_used", "provider", "input_tokens", "output_tokens", "duration_ms", "has_error",
 		"input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash",
 		"observation_mode_override", "shadow_violation_types",
 		"cache_hit", "cache_entry_id", "cost_saved",
@@ -336,8 +336,12 @@ func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 			r.AgentID,
 			r.InvocationType,
 			strconv.FormatBool(r.Allowed),
+			r.PolicyAction,
 			formatCostNumeric(r.Cost),
 			r.ModelUsed,
+			r.Provider,
+			strconv.Itoa(r.InputTokens),
+			strconv.Itoa(r.OutputTokens),
 			strconv.FormatInt(r.DurationMS, 10),
 			strconv.FormatBool(r.HasError),
 			strconv.Itoa(r.InputTier),

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -221,7 +221,6 @@ var costsCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("cost by agent (monthly): %w", err)
 		}
-		renderCostReportAllAgents(out, tenantID, byAgentDaily, byAgentMonthly)
 		dailyTotal, _ := store.CostTotal(ctx, tenantID, "", dayStart, dayEnd)
 		monthlyTotal, _ := store.CostTotal(ctx, tenantID, "", monthStart, monthEnd)
 		weekTotal, _ := store.CostTotal(ctx, tenantID, "", weekStart, dayEnd)
@@ -240,6 +239,7 @@ var costsCmd = &cobra.Command{
 				CacheMonth:     cache30d,
 			})
 		}
+		renderCostReportAllAgents(out, tenantID, byAgentDaily, byAgentMonthly)
 		fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
 		printBudgetUtilization(out, dailyBudget, monthlyBudget)
 		printCacheSavings(out, cache7d, cache30d)

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -336,22 +336,24 @@ func getCacheUsage(
 		return nil, nil
 	}
 	total7d, _ := store.CountInRange(ctx, tenantID, "", weekStart, dayEnd)
+	sevenDays = &cacheUsage{
+		Hits:      hits7d,
+		SavedEUR:  saved7d,
+		HitRate:   percentage(int(hits7d), total7d),
+		TotalSeen: total7d,
+	}
 	hits30d, saved30d, err := store.CacheSavings(ctx, tenantID, monthStart, monthEnd)
 	if err != nil {
-		return nil, nil
+		return sevenDays, nil
 	}
 	total30d, _ := store.CountInRange(ctx, tenantID, "", monthStart, monthEnd)
-	return &cacheUsage{
-			Hits:      hits7d,
-			SavedEUR:  saved7d,
-			HitRate:   percentage(int(hits7d), total7d),
-			TotalSeen: total7d,
-		}, &cacheUsage{
-			Hits:      hits30d,
-			SavedEUR:  saved30d,
-			HitRate:   percentage(int(hits30d), total30d),
-			TotalSeen: total30d,
-		}
+	month = &cacheUsage{
+		Hits:      hits30d,
+		SavedEUR:  saved30d,
+		HitRate:   percentage(int(hits30d), total30d),
+		TotalSeen: total30d,
+	}
+	return sevenDays, month
 }
 
 func percentage(hits, total int) float64 {

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -2,24 +2,77 @@ package cmd
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
 	"github.com/dativo-io/talon/internal/policy"
 )
 
 var (
-	costsAgent   string
-	costsTenant  string
-	costsByModel bool
-	costsByTeam  bool
+	costsAgent        string
+	costsCaller       string
+	costsTenant       string
+	costsByModel      bool
+	costsByProvider   bool
+	costsByTeam       bool
+	costsJSON         bool
+	costsExportFmt    string
+	costsExportFrom   string
+	costsExportTo     string
+	costsExportTenant string
+	costsExportAgent  string
+	costsExportCaller string
+	costsExportOutput string
+	costsExportLimit  int
 )
+
+var costsExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export cost evidence rows",
+	RunE:  costsExport,
+}
+
+type costsPayload struct {
+	TenantID       string             `json:"tenant_id"`
+	AgentID        string             `json:"agent_id,omitempty"`
+	TodayEUR       float64            `json:"today_eur"`
+	MonthEUR       float64            `json:"month_eur"`
+	SevenDaysEUR   float64            `json:"seven_days_eur"`
+	ByAgentEUR     map[string]float64 `json:"by_agent_eur,omitempty"`
+	ByModelEUR     map[string]float64 `json:"by_model_eur,omitempty"`
+	ByProviderEUR  map[string]float64 `json:"by_provider_eur,omitempty"`
+	ByTeamEUR      map[string]float64 `json:"by_team_eur,omitempty"`
+	DailyBudget    *budgetUsage       `json:"daily_budget,omitempty"`
+	MonthlyBudget  *budgetUsage       `json:"monthly_budget,omitempty"`
+	CacheSevenDays *cacheUsage        `json:"cache_7d,omitempty"`
+	CacheMonth     *cacheUsage        `json:"cache_30d,omitempty"`
+}
+
+type budgetUsage struct {
+	UsedEUR  float64 `json:"used_eur"`
+	LimitEUR float64 `json:"limit_eur"`
+	Percent  float64 `json:"percent"`
+	Source   string  `json:"source"`
+}
+
+type cacheUsage struct {
+	Hits      int64   `json:"hits"`
+	SavedEUR  float64 `json:"saved_eur"`
+	HitRate   float64 `json:"hit_rate_percent"`
+	TotalSeen int     `json:"total_seen"`
+}
 
 var costsCmd = &cobra.Command{
 	Use:   "costs",
@@ -43,6 +96,12 @@ var costsCmd = &cobra.Command{
 		if tenantID == "" {
 			tenantID = "default"
 		}
+		if costsCaller != "" {
+			if costsAgent != "" && costsAgent != costsCaller {
+				return fmt.Errorf("--agent (%s) and --caller (%s) refer to different values", costsAgent, costsCaller)
+			}
+			costsAgent = costsCaller
+		}
 
 		now := time.Now().UTC()
 		dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
@@ -62,9 +121,43 @@ var costsCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("cost by model (monthly): %w", err)
 			}
+			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
+			if costsJSON {
+				return writeCostsJSON(out, costsPayload{
+					TenantID:     tenantID,
+					AgentID:      costsAgent,
+					TodayEUR:     sumValues(byModelDaily),
+					MonthEUR:     sumValues(byModelMonthly),
+					SevenDaysEUR: weekTotal,
+					ByModelEUR:   byModelDaily,
+				})
+			}
 			renderCostByModel(out, tenantID, costsAgent, byModelDaily, byModelMonthly)
 			// Optional: 7d trend (same agent filter when --agent is set)
+			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
+			return nil
+		}
+		if costsByProvider {
+			byProviderDaily, err := store.CostByProvider(ctx, tenantID, costsAgent, dayStart, dayEnd)
+			if err != nil {
+				return fmt.Errorf("cost by provider (daily): %w", err)
+			}
+			byProviderMonthly, err := store.CostByProvider(ctx, tenantID, costsAgent, monthStart, monthEnd)
+			if err != nil {
+				return fmt.Errorf("cost by provider (monthly): %w", err)
+			}
 			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
+			if costsJSON {
+				return writeCostsJSON(out, costsPayload{
+					TenantID:      tenantID,
+					AgentID:       costsAgent,
+					TodayEUR:      sumValues(byProviderDaily),
+					MonthEUR:      sumValues(byProviderMonthly),
+					SevenDaysEUR:  weekTotal,
+					ByProviderEUR: byProviderDaily,
+				})
+			}
+			renderCostByProvider(out, tenantID, costsAgent, byProviderDaily, byProviderMonthly)
 			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
 			return nil
 		}
@@ -76,6 +169,16 @@ var costsCmd = &cobra.Command{
 			byTeamMonthly, err := store.CostByTeam(ctx, tenantID, monthStart, monthEnd)
 			if err != nil {
 				return fmt.Errorf("cost by team (monthly): %w", err)
+			}
+			if costsJSON {
+				weekTotal, _ := store.CostTotal(ctx, tenantID, "", weekStart, dayEnd)
+				return writeCostsJSON(out, costsPayload{
+					TenantID:     tenantID,
+					TodayEUR:     sumValues(byTeamDaily),
+					MonthEUR:     sumValues(byTeamMonthly),
+					SevenDaysEUR: weekTotal,
+					ByTeamEUR:    byTeamDaily,
+				})
 			}
 			renderCostByTeam(out, tenantID, byTeamDaily, byTeamMonthly)
 			return nil
@@ -90,10 +193,23 @@ var costsCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("cost total monthly: %w", err)
 			}
+			dailyBudget, monthlyBudget := resolveBudgetUsage(ctx, cfg, tenantID, costsAgent, daily, monthly)
+			if costsJSON {
+				weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
+				return writeCostsJSON(out, costsPayload{
+					TenantID:      tenantID,
+					AgentID:       costsAgent,
+					TodayEUR:      daily,
+					MonthEUR:      monthly,
+					SevenDaysEUR:  weekTotal,
+					DailyBudget:   dailyBudget,
+					MonthlyBudget: monthlyBudget,
+				})
+			}
 			renderCostReportSingleAgent(out, tenantID, costsAgent, daily, monthly)
 			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
 			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
-			printBudgetUtilization(out, ctx, cfg, tenantID, daily, monthly)
+			printBudgetUtilization(out, dailyBudget, monthlyBudget)
 			return nil
 		}
 
@@ -109,54 +225,252 @@ var costsCmd = &cobra.Command{
 		dailyTotal, _ := store.CostTotal(ctx, tenantID, "", dayStart, dayEnd)
 		monthlyTotal, _ := store.CostTotal(ctx, tenantID, "", monthStart, monthEnd)
 		weekTotal, _ := store.CostTotal(ctx, tenantID, "", weekStart, dayEnd)
+		dailyBudget, monthlyBudget := resolveBudgetUsage(ctx, cfg, tenantID, "", dailyTotal, monthlyTotal)
+		cache7d, cache30d := getCacheUsage(ctx, store, tenantID, weekStart, dayEnd, monthStart, monthEnd)
+		if costsJSON {
+			return writeCostsJSON(out, costsPayload{
+				TenantID:       tenantID,
+				TodayEUR:       dailyTotal,
+				MonthEUR:       monthlyTotal,
+				SevenDaysEUR:   weekTotal,
+				ByAgentEUR:     byAgentDaily,
+				DailyBudget:    dailyBudget,
+				MonthlyBudget:  monthlyBudget,
+				CacheSevenDays: cache7d,
+				CacheMonth:     cache30d,
+			})
+		}
 		fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
-		printBudgetUtilization(out, ctx, cfg, tenantID, dailyTotal, monthlyTotal)
-		printCacheSavings(out, ctx, store, tenantID, weekStart, dayEnd, monthStart, monthEnd)
+		printBudgetUtilization(out, dailyBudget, monthlyBudget)
+		printCacheSavings(out, cache7d, cache30d)
 		return nil
 	},
 }
 
-func printCacheSavings(w io.Writer, ctx context.Context, store *evidence.Store, tenantID string, weekStart, dayEnd, monthStart, monthEnd time.Time) {
-	hits7d, saved7d, err := store.CacheSavings(ctx, tenantID, weekStart, dayEnd)
-	if err != nil {
-		return
+func printCacheSavings(w io.Writer, cache7d, cache30d *cacheUsage) {
+	if cache7d != nil && (cache7d.Hits > 0 || cache7d.SavedEUR > 0) {
+		fmt.Fprintf(w, "  Cache (7d):   %d requests from cache, €%s saved, %.1f%% hit rate\n", cache7d.Hits, formatCost(cache7d.SavedEUR), cache7d.HitRate)
 	}
-	total7d, _ := store.CountInRange(ctx, tenantID, "", weekStart, dayEnd)
-	hitRate7d := 0.0
-	if total7d > 0 {
-		hitRate7d = 100 * float64(hits7d) / float64(total7d)
-	}
-	if hits7d > 0 || saved7d > 0 {
-		fmt.Fprintf(w, "  Cache (7d):   %d requests from cache, €%s saved, %.1f%% hit rate\n", hits7d, formatCost(saved7d), hitRate7d)
-	}
-	hits30d, saved30d, err := store.CacheSavings(ctx, tenantID, monthStart, monthEnd)
-	if err != nil {
-		return
-	}
-	total30d, _ := store.CountInRange(ctx, tenantID, "", monthStart, monthEnd)
-	hitRate30d := 0.0
-	if total30d > 0 {
-		hitRate30d = 100 * float64(hits30d) / float64(total30d)
-	}
-	if hits30d > 0 || saved30d > 0 {
-		fmt.Fprintf(w, "  Cache (30d):  %d requests from cache, €%s saved, %.1f%% hit rate\n", hits30d, formatCost(saved30d), hitRate30d)
+	if cache30d != nil && (cache30d.Hits > 0 || cache30d.SavedEUR > 0) {
+		fmt.Fprintf(w, "  Cache (30d):  %d requests from cache, €%s saved, %.1f%% hit rate\n", cache30d.Hits, formatCost(cache30d.SavedEUR), cache30d.HitRate)
 	}
 }
 
-func printBudgetUtilization(w io.Writer, ctx context.Context, cfg *config.Config, tenantID string, daily, monthly float64) {
+func printBudgetUtilization(w io.Writer, dailyBudget, monthlyBudget *budgetUsage) {
+	if dailyBudget != nil && dailyBudget.LimitEUR > 0 {
+		fmt.Fprintf(w, "  Daily budget:   %.1f%% (€%s / €%.2f)\n", dailyBudget.Percent, formatCost(dailyBudget.UsedEUR), dailyBudget.LimitEUR)
+	}
+	if monthlyBudget != nil && monthlyBudget.LimitEUR > 0 {
+		fmt.Fprintf(w, "  Monthly budget: %.1f%% (€%s / €%.2f)\n", monthlyBudget.Percent, formatCost(monthlyBudget.UsedEUR), monthlyBudget.LimitEUR)
+	}
+}
+
+func resolveBudgetUsage(
+	ctx context.Context,
+	cfg *config.Config,
+	tenantID, agentID string,
+	daily, monthly float64,
+) (dailyBudget *budgetUsage, monthlyBudget *budgetUsage) {
+	if agentID != "" {
+		if dailyLimit, monthlyLimit, ok := loadGatewayCallerBudgetCaps(tenantID, agentID); ok {
+			return toBudgetUsage(daily, dailyLimit, "gateway_caller_cap"), toBudgetUsage(monthly, monthlyLimit, "gateway_caller_cap")
+		}
+	}
 	pol, err := policy.LoadPolicy(ctx, cfg.DefaultPolicy, false, ".")
 	if err != nil || pol == nil || pol.Policies.CostLimits == nil {
-		return
+		return nil, nil
 	}
 	cl := pol.Policies.CostLimits
-	if cl.Daily > 0 {
-		pct := 100 * daily / cl.Daily
-		fmt.Fprintf(w, "  Daily budget:   %.1f%% (€%s / €%.2f)\n", pct, formatCost(daily), cl.Daily)
+	return toBudgetUsage(daily, cl.Daily, "policy_cost_limits"), toBudgetUsage(monthly, cl.Monthly, "policy_cost_limits")
+}
+
+func loadGatewayCallerBudgetCaps(tenantID, callerID string) (dailyLimit float64, monthlyLimit float64, ok bool) {
+	path := strings.TrimSpace(os.Getenv("TALON_GATEWAY_CONFIG"))
+	if path == "" {
+		path = "talon.config.yaml"
 	}
-	if cl.Monthly > 0 {
-		pct := 100 * monthly / cl.Monthly
-		fmt.Fprintf(w, "  Monthly budget: %.1f%% (€%s / €%.2f)\n", pct, formatCost(monthly), cl.Monthly)
+	cfg, err := gateway.LoadGatewayConfig(path)
+	if err != nil {
+		return 0, 0, false
 	}
+	for i := range cfg.Callers {
+		caller := cfg.Callers[i]
+		if caller.Name != callerID || caller.TenantID != tenantID {
+			continue
+		}
+		daily := cfg.ServerDefaults.MaxDailyCost
+		monthly := cfg.ServerDefaults.MaxMonthlyCost
+		if caller.PolicyOverrides != nil {
+			if caller.PolicyOverrides.MaxDailyCost > 0 {
+				daily = caller.PolicyOverrides.MaxDailyCost
+			}
+			if caller.PolicyOverrides.MaxMonthlyCost > 0 {
+				monthly = caller.PolicyOverrides.MaxMonthlyCost
+			}
+		}
+		return daily, monthly, daily > 0 || monthly > 0
+	}
+	return 0, 0, false
+}
+
+func toBudgetUsage(used, limit float64, source string) *budgetUsage {
+	if limit <= 0 {
+		return nil
+	}
+	return &budgetUsage{
+		UsedEUR:  used,
+		LimitEUR: limit,
+		Percent:  100 * used / limit,
+		Source:   source,
+	}
+}
+
+func getCacheUsage(
+	ctx context.Context,
+	store *evidence.Store,
+	tenantID string,
+	weekStart, dayEnd, monthStart, monthEnd time.Time,
+) (sevenDays *cacheUsage, month *cacheUsage) {
+	hits7d, saved7d, err := store.CacheSavings(ctx, tenantID, weekStart, dayEnd)
+	if err != nil {
+		return nil, nil
+	}
+	total7d, _ := store.CountInRange(ctx, tenantID, "", weekStart, dayEnd)
+	hits30d, saved30d, err := store.CacheSavings(ctx, tenantID, monthStart, monthEnd)
+	if err != nil {
+		return nil, nil
+	}
+	total30d, _ := store.CountInRange(ctx, tenantID, "", monthStart, monthEnd)
+	return &cacheUsage{
+			Hits:      hits7d,
+			SavedEUR:  saved7d,
+			HitRate:   percentage(int(hits7d), total7d),
+			TotalSeen: total7d,
+		}, &cacheUsage{
+			Hits:      hits30d,
+			SavedEUR:  saved30d,
+			HitRate:   percentage(int(hits30d), total30d),
+			TotalSeen: total30d,
+		}
+}
+
+func percentage(hits, total int) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return 100 * float64(hits) / float64(total)
+}
+
+func sumValues(m map[string]float64) float64 {
+	total := 0.0
+	for _, v := range m {
+		total += v
+	}
+	return total
+}
+
+func writeCostsJSON(w io.Writer, payload costsPayload) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("encoding costs json: %w", err)
+	}
+	return nil
+}
+
+func costsExport(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	defer cancel()
+
+	store, err := openEvidenceStore()
+	if err != nil {
+		return fmt.Errorf("initializing evidence store: %w", err)
+	}
+	defer store.Close()
+
+	from, to, err := parseAuditDateRange(costsExportFrom, costsExportTo)
+	if err != nil {
+		return err
+	}
+	agentID := strings.TrimSpace(costsExportAgent)
+	if caller := strings.TrimSpace(costsExportCaller); caller != "" {
+		if agentID != "" && agentID != caller {
+			return fmt.Errorf("--agent (%s) and --caller (%s) refer to different values", agentID, caller)
+		}
+		agentID = caller
+	}
+	tenantID := strings.TrimSpace(costsExportTenant)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	limit := costsExportLimit
+	if limit <= 0 {
+		limit = 10000
+	}
+	list, err := store.List(ctx, tenantID, agentID, from, to, limit)
+	if err != nil {
+		return fmt.Errorf("querying evidence: %w", err)
+	}
+	records := toExportRecords(list)
+
+	out, cleanup, err := resolveExportOutput(cmd, costsExportOutput)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	switch costsExportFmt {
+	case "csv":
+		return renderCostsExportCSV(out, records)
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(records)
+	default:
+		return fmt.Errorf("unsupported --format %q; use csv or json", costsExportFmt)
+	}
+}
+
+func renderCostsExportCSV(w io.Writer, records []evidence.ExportRecord) error {
+	writer := csv.NewWriter(w)
+	header := []string{
+		"evidence_id", "tenant_id", "agent_id", "timestamp", "model", "provider",
+		"cost_eur", "input_tokens", "output_tokens", "policy_decision", "policy_reason",
+	}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+	for i := range records {
+		rec := &records[i]
+		decision := rec.PolicyAction
+		if decision == "" {
+			if rec.Allowed {
+				decision = "allow"
+			} else {
+				decision = "deny"
+			}
+		}
+		row := []string{
+			rec.ID,
+			rec.TenantID,
+			rec.AgentID,
+			rec.Timestamp.Format(time.RFC3339),
+			rec.ModelUsed,
+			rec.Provider,
+			formatCostNumeric(rec.Cost),
+			strconv.Itoa(rec.InputTokens),
+			strconv.Itoa(rec.OutputTokens),
+			decision,
+			rec.PolicyReasonsCSV(),
+		}
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
 }
 
 // renderCostReportSingleAgent writes single-agent cost output to w (testable).
@@ -201,6 +515,43 @@ func renderCostByModel(w io.Writer, tenantID, agentID string, byModelDaily, byMo
 		fmt.Fprintf(w, "%-32s %14s %14s\n", "-----", "-----", "-----")
 	}
 	fmt.Fprintf(w, "%-32s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
+}
+
+// renderCostByProvider writes per-provider cost table to w.
+//
+//nolint:dupl // parallel to model/team renderers by design for readability in CLI output
+func renderCostByProvider(w io.Writer, tenantID, agentID string, byProviderDaily, byProviderMonthly map[string]float64) {
+	providers := make(map[string]bool)
+	for p := range byProviderDaily {
+		providers[p] = true
+	}
+	for p := range byProviderMonthly {
+		providers[p] = true
+	}
+	var list []string
+	for p := range providers {
+		list = append(list, p)
+	}
+	sort.Strings(list)
+	if agentID != "" {
+		fmt.Fprintf(w, "Tenant: %s | Agent: %s (by provider)\n", tenantID, agentID)
+	} else {
+		fmt.Fprintf(w, "Tenant: %s (by provider)\n", tenantID)
+	}
+	fmt.Fprintf(w, "%-20s %14s %14s\n", "Provider", "Today", "Month")
+	fmt.Fprintf(w, "%-20s %14s %14s\n", "--------", "-----", "-----")
+	var dailyTotal, monthlyTotal float64
+	for _, provider := range list {
+		d := byProviderDaily[provider]
+		m := byProviderMonthly[provider]
+		dailyTotal += d
+		monthlyTotal += m
+		fmt.Fprintf(w, "%-20s €%13s €%13s\n", provider, formatCost(d), formatCost(m))
+	}
+	if len(list) > 0 {
+		fmt.Fprintf(w, "%-20s %14s %14s\n", "--------", "-----", "-----")
+	}
+	fmt.Fprintf(w, "%-20s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
 }
 
 // renderCostByTeam writes per-team cost table to w (testable).
@@ -271,8 +622,20 @@ func renderCostReportAllAgents(w io.Writer, tenantID string, byAgentDaily, byAge
 
 func init() {
 	rootCmd.AddCommand(costsCmd)
+	costsCmd.AddCommand(costsExportCmd)
 	costsCmd.Flags().StringVar(&costsAgent, "agent", "", "filter by agent name")
+	costsCmd.Flags().StringVar(&costsCaller, "caller", "", "filter by caller name (alias for --agent)")
 	costsCmd.Flags().StringVar(&costsTenant, "tenant", "", "tenant ID (default: default)")
 	costsCmd.Flags().BoolVar(&costsByModel, "by-model", false, "group output by model")
+	costsCmd.Flags().BoolVar(&costsByProvider, "by-provider", false, "group output by provider")
 	costsCmd.Flags().BoolVar(&costsByTeam, "by-team", false, "group output by caller team")
+	costsCmd.Flags().BoolVar(&costsJSON, "json", false, "output results as JSON")
+	costsExportCmd.Flags().StringVar(&costsExportFmt, "format", "csv", "output format: csv or json")
+	costsExportCmd.Flags().StringVar(&costsExportFrom, "from", "", "start date (YYYY-MM-DD)")
+	costsExportCmd.Flags().StringVar(&costsExportTo, "to", "", "end date (YYYY-MM-DD)")
+	costsExportCmd.Flags().StringVar(&costsExportTenant, "tenant", "", "tenant ID (default: default)")
+	costsExportCmd.Flags().StringVar(&costsExportAgent, "agent", "", "filter by agent name")
+	costsExportCmd.Flags().StringVar(&costsExportCaller, "caller", "", "filter by caller name (alias for --agent)")
+	costsExportCmd.Flags().StringVar(&costsExportOutput, "output", "", "write to file instead of stdout")
+	costsExportCmd.Flags().IntVar(&costsExportLimit, "limit", 10000, "maximum records to export")
 }

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -2,10 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,4 +158,88 @@ metadata: { owner: "", tags: [] }
 	require.Contains(t, out, "Daily budget:")
 	require.Contains(t, out, "Monthly budget:")
 	require.Contains(t, out, "0.0%") // no spend yet
+}
+
+func TestRenderCostsExportCSV_IncludesProviderAndDeniedReason(t *testing.T) {
+	var buf bytes.Buffer
+	records := []evidence.ExportRecord{
+		{
+			ID:           "gw_1",
+			TenantID:     "default",
+			AgentID:      "support-slack-bot",
+			Timestamp:    time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+			ModelUsed:    "gpt-4o-mini",
+			Provider:     "openai",
+			Cost:         0,
+			InputTokens:  0,
+			OutputTokens: 0,
+			Allowed:      false,
+			PolicyAction: "deny",
+			PolicyReasons: []string{
+				"budget_exceeded: daily limit",
+			},
+		},
+	}
+
+	err := renderCostsExportCSV(&buf, records)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "evidence_id,tenant_id,agent_id")
+	assert.Contains(t, out, "openai")
+	assert.Contains(t, out, "budget_exceeded")
+	assert.Contains(t, out, ",0.000000,")
+}
+
+func TestCostsExportCmd_JSONIncludesProviderAndDeniedRow(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	store, err := evidence.NewStore(cfg.EvidenceDBPath(), cfg.SigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	ev := &evidence.Evidence{
+		ID:             "gw_export_1",
+		CorrelationID:  "corr-export-1",
+		Timestamp:      time.Now().UTC(),
+		TenantID:       "default",
+		AgentID:        "support-slack-bot",
+		InvocationType: "gateway",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"budget_exceeded: daily limit"},
+		},
+		Classification: evidence.Classification{},
+		Execution: evidence.Execution{
+			ModelUsed:     "gpt-4o-mini",
+			Cost:          0,
+			EstimatedCost: 0.02,
+			Tokens:        evidence.TokenUsage{},
+		},
+		RoutingDecision: &evidence.RoutingDecision{
+			SelectedProvider: "openai",
+			SelectedModel:    "gpt-4o-mini",
+		},
+		AuditTrail: evidence.AuditTrail{},
+		Compliance: evidence.Compliance{},
+	}
+	require.NoError(t, store.Store(ctx, ev))
+
+	var buf bytes.Buffer
+	costsCmd.SetOut(&buf)
+	costsCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"costs", "export", "--tenant", "default", "--caller", "support-slack-bot", "--format", "json"})
+	require.NoError(t, rootCmd.Execute())
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "gw_export_1", rows[0]["id"])
+	assert.Equal(t, "openai", rows[0]["provider"])
+	assert.Equal(t, "deny", rows[0]["policy_action"])
+	assert.EqualValues(t, 0, rows[0]["cost"])
 }

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -111,6 +111,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, policyBaseDir)
 	injectPricingInProviders(providers, pricingTable)
+	gatewayEstimator := gatewayCostEstimator(providers)
 	routing, costLimits := loadRoutingAndCostLimits(ctx, policyPath, policyBaseDir)
 	router := llm.NewRouter(routing, providers, costLimits)
 
@@ -349,7 +350,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("gateway policy engine: %w", err)
 			}
-			gw, err := gateway.NewGateway(gatewayCfg, cls, evidenceStore, secretsStore, gatewayPolicy, nil)
+			gw, err := gateway.NewGateway(gatewayCfg, cls, evidenceStore, secretsStore, gatewayPolicy, gatewayEstimator)
 			if err != nil {
 				return fmt.Errorf("initializing gateway: %w", err)
 			}
@@ -372,7 +373,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("gateway policy engine: %w", err)
 		}
-		gw, err := gateway.NewGateway(quickstartCfg, cls, evidenceStore, secretsStore, gatewayPolicy, nil)
+		gw, err := gateway.NewGateway(quickstartCfg, cls, evidenceStore, secretsStore, gatewayPolicy, gatewayEstimator)
 		if err != nil {
 			return fmt.Errorf("initializing quickstart gateway: %w", err)
 		}
@@ -561,6 +562,27 @@ func isLoopbackHost(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func gatewayCostEstimator(providers map[string]llm.Provider) gateway.CostEstimator {
+	return func(model string, inputTokens, outputTokens int) float64 {
+		// Use the highest known estimate across configured providers so pre-call budget checks
+		// stay conservative even when only model is known at this stage.
+		maxEstimate := 0.0
+		for _, provider := range providers {
+			if provider == nil {
+				continue
+			}
+			if estimate := provider.EstimateCost(model, inputTokens, outputTokens); estimate > maxEstimate {
+				maxEstimate = estimate
+			}
+		}
+		if maxEstimate > 0 {
+			return maxEstimate
+		}
+		// Fallback when pricing is unavailable/unknown.
+		return 0.01
+	}
 }
 
 // validateServeModeFlags enforces mutual exclusivity between the quickstart

--- a/internal/evidence/export.go
+++ b/internal/evidence/export.go
@@ -22,6 +22,10 @@ type ExportRecord struct {
 	Allowed        bool      `json:"allowed"`
 	Cost           float64   `json:"cost"`
 	ModelUsed      string    `json:"model_used"`
+	Provider       string    `json:"provider,omitempty"`
+	InputTokens    int       `json:"input_tokens,omitempty"`
+	OutputTokens   int       `json:"output_tokens,omitempty"`
+	PolicyAction   string    `json:"policy_action,omitempty"`
 	DurationMS     int64     `json:"duration_ms"`
 	HasError       bool      `json:"has_error"`
 	// Classification (enriched export)
@@ -89,6 +93,9 @@ func ToExportRecord(e *Evidence) ExportRecord {
 		Allowed:                 e.PolicyDecision.Allowed,
 		Cost:                    e.Execution.Cost,
 		ModelUsed:               e.Execution.ModelUsed,
+		InputTokens:             e.Execution.Tokens.Input,
+		OutputTokens:            e.Execution.Tokens.Output,
+		PolicyAction:            e.PolicyDecision.Action,
 		DurationMS:              e.Execution.DurationMS,
 		HasError:                e.Execution.Error != "",
 		InputTier:               e.Classification.InputTier,
@@ -110,6 +117,9 @@ func ToExportRecord(e *Evidence) ExportRecord {
 	}
 	if len(e.PolicyDecision.Reasons) > 0 {
 		rec.PolicyReasons = append([]string(nil), e.PolicyDecision.Reasons...)
+	}
+	if e.RoutingDecision != nil {
+		rec.Provider = e.RoutingDecision.SelectedProvider
 	}
 	if len(e.Execution.ToolsCalled) > 0 {
 		rec.ToolsCalled = append([]string(nil), e.Execution.ToolsCalled...)

--- a/internal/evidence/interfaces.go
+++ b/internal/evidence/interfaces.go
@@ -13,6 +13,7 @@ type MetricsQuerier interface {
 	CostTotal(ctx context.Context, tenantID, agentID string, from, to time.Time) (float64, error)
 	CostByAgent(ctx context.Context, tenantID string, from, to time.Time) (map[string]float64, error)
 	CostByModel(ctx context.Context, tenantID, agentID string, from, to time.Time) (map[string]float64, error)
+	CostByProvider(ctx context.Context, tenantID, agentID string, from, to time.Time) (map[string]float64, error)
 	CountInRange(ctx context.Context, tenantID, agentID string, from, to time.Time) (int, error)
 	CacheSavings(ctx context.Context, tenantID string, from, to time.Time) (hits int64, costSaved float64, err error)
 	// AvgTTFT returns average time to first token (ms) for streaming requests in the range; 0 if none.

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -175,6 +175,7 @@ type Execution struct {
 	Degraded      bool       `json:"degraded,omitempty"`
 	ToolsCalled   []string   `json:"tools_called,omitempty"`
 	Cost          float64    `json:"cost"`
+	EstimatedCost float64    `json:"estimated_cost,omitempty"`
 	Tokens        TokenUsage `json:"tokens"`
 	MemoryTokens  int        `json:"memory_tokens,omitempty"` // tokens injected from memory context
 	DurationMS    int64      `json:"duration_ms"`
@@ -1204,6 +1205,8 @@ func (s *Store) CostByAgent(ctx context.Context, tenantID string, from, to time.
 
 // CostByModel returns cost per model for the tenant in the half-open time range [from, to).
 // If agentID is non-empty, results are limited to that agent. Uses json_extract on execution.model_used and execution.cost.
+//
+//nolint:dupl // intentionally mirrored with CostByProvider for explicit query readability
 func (s *Store) CostByModel(ctx context.Context, tenantID, agentID string, from, to time.Time) (map[string]float64, error) {
 	ctx, span := tracer.Start(ctx, "evidence.cost_by_model",
 		trace.WithAttributes(
@@ -1253,6 +1256,61 @@ func (s *Store) CostByModel(ctx context.Context, tenantID, agentID string, from,
 	}
 	span.SetAttributes(attribute.Int("model_count", len(byModel)))
 	return byModel, nil
+}
+
+// CostByProvider returns cost per selected provider for the tenant in [from, to).
+// If agentID is non-empty, results are limited to that agent.
+//
+//nolint:dupl // intentionally mirrored with CostByModel for explicit query readability
+func (s *Store) CostByProvider(ctx context.Context, tenantID, agentID string, from, to time.Time) (map[string]float64, error) {
+	ctx, span := tracer.Start(ctx, "evidence.cost_by_provider",
+		trace.WithAttributes(
+			attribute.String("tenant_id", tenantID),
+			attribute.String("agent_id", agentID),
+		))
+	defer span.End()
+
+	query := `SELECT COALESCE(NULLIF(json_extract(evidence_json, '$.routing_decision.selected_provider'), ''), 'unknown'),
+	         SUM(COALESCE(json_extract(evidence_json, '$.execution.cost'), json_extract(evidence_json, '$.execution.cost_eur')))
+	         FROM evidence WHERE tenant_id = ?`
+	args := []interface{}{tenantID}
+	if agentID != "" {
+		query += ` AND agent_id = ?`
+		args = append(args, agentID)
+	}
+	if !from.IsZero() {
+		query += ` AND timestamp >= ?`
+		args = append(args, from)
+	}
+	if !to.IsZero() {
+		query += ` AND timestamp < ?`
+		args = append(args, to)
+	}
+	query += ` GROUP BY 1`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying evidence for cost by provider: %w", err)
+	}
+	defer rows.Close()
+
+	byProvider := make(map[string]float64)
+	for rows.Next() {
+		var provider string
+		var total float64
+		if err := rows.Scan(&provider, &total); err != nil {
+			continue
+		}
+		if provider == "" {
+			provider = "unknown"
+		}
+		byProvider[provider] = total
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating cost by provider: %w", err)
+	}
+	span.SetAttributes(attribute.Int("provider_count", len(byProvider)))
+	return byProvider, nil
 }
 
 // CostByTeam returns cost per team (gateway caller team) for the tenant in [from, to).

--- a/internal/evidence/store_test.go
+++ b/internal/evidence/store_test.go
@@ -903,6 +903,85 @@ func TestCostByAgent(t *testing.T) {
 	assert.InDelta(t, 0.5, byAgent["support-bot"], 0.0001)
 }
 
+func TestCostByProvider(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dayEnd := dayStart.Add(24 * time.Hour)
+
+	records := []*Evidence{
+		{
+			ID:             "ev-provider-1",
+			CorrelationID:  "corr-provider-1",
+			Timestamp:      now,
+			TenantID:       "tenant1",
+			AgentID:        "caller-a",
+			InvocationType: "gateway",
+			PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+			Classification: Classification{},
+			Execution: Execution{
+				ModelUsed: "gpt-4o-mini",
+				Cost:      1.25,
+				Tokens:    TokenUsage{Input: 100, Output: 100},
+			},
+			RoutingDecision: &RoutingDecision{SelectedProvider: "openai", SelectedModel: "gpt-4o-mini"},
+			AuditTrail:      AuditTrail{},
+			Compliance:      Compliance{},
+		},
+		{
+			ID:             "ev-provider-2",
+			CorrelationID:  "corr-provider-2",
+			Timestamp:      now,
+			TenantID:       "tenant1",
+			AgentID:        "caller-a",
+			InvocationType: "gateway",
+			PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+			Classification: Classification{},
+			Execution: Execution{
+				ModelUsed: "claude-sonnet-4",
+				Cost:      2.5,
+				Tokens:    TokenUsage{Input: 200, Output: 150},
+			},
+			RoutingDecision: &RoutingDecision{SelectedProvider: "anthropic", SelectedModel: "claude-sonnet-4"},
+			AuditTrail:      AuditTrail{},
+			Compliance:      Compliance{},
+		},
+		{
+			ID:             "ev-provider-3",
+			CorrelationID:  "corr-provider-3",
+			Timestamp:      now,
+			TenantID:       "tenant1",
+			AgentID:        "caller-a",
+			InvocationType: "gateway",
+			PolicyDecision: PolicyDecision{Allowed: false, Action: "deny"},
+			Classification: Classification{},
+			Execution: Execution{
+				ModelUsed: "gpt-4o-mini",
+				Cost:      0,
+				Tokens:    TokenUsage{},
+			},
+			RoutingDecision: &RoutingDecision{SelectedProvider: "openai", SelectedModel: "gpt-4o-mini"},
+			AuditTrail:      AuditTrail{},
+			Compliance:      Compliance{},
+		},
+	}
+	for _, ev := range records {
+		require.NoError(t, store.Store(ctx, ev))
+	}
+
+	byProvider, err := store.CostByProvider(ctx, "tenant1", "", dayStart, dayEnd)
+	require.NoError(t, err)
+	assert.Len(t, byProvider, 2)
+	assert.InDelta(t, 1.25, byProvider["openai"], 0.0001)
+	assert.InDelta(t, 2.5, byProvider["anthropic"], 0.0001)
+
+	byProviderAgent, err := store.CostByProvider(ctx, "tenant1", "caller-a", dayStart, dayEnd)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.25, byProviderAgent["openai"], 0.0001)
+	assert.InDelta(t, 2.5, byProviderAgent["anthropic"], 0.0001)
+}
+
 func TestGenerateWithDegradation(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/gateway/blocked_metrics_test.go
+++ b/internal/gateway/blocked_metrics_test.go
@@ -509,16 +509,23 @@ func TestGatewayMetrics_RuntimeEventMatchesEvidenceProjection(t *testing.T) {
 type budgetDenyPolicy struct{}
 
 func (p *budgetDenyPolicy) EvaluateGateway(_ context.Context, _ map[string]interface{}) (allowed bool, reasons []string, err error) {
-	return false, []string{"budget exceeded: daily limit"}, nil
+	return false, []string{"budget_exceeded: daily limit"}, nil
 }
 
 func TestBudgetDeniedRequest_RecordsSignedEvidence(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
 	cfg := &GatewayConfig{
 		Enabled:      true,
 		ListenPrefix: "/v1/proxy",
 		Mode:         ModeEnforce,
 		Providers: map[string]ProviderConfig{
-			"openai": {Enabled: true, BaseURL: "http://localhost:1"},
+			"openai": {Enabled: true, BaseURL: upstream.URL},
 		},
 		Callers: []CallerConfig{
 			{Name: "test-caller", TenantKey: "talon-gw-test-001", TenantID: "default"},
@@ -537,7 +544,10 @@ func TestBudgetDeniedRequest_RecordsSignedEvidence(t *testing.T) {
 	require.Len(t, list, 1)
 	ev := list[0]
 	assert.False(t, ev.PolicyDecision.Allowed)
+	assert.Equal(t, 0.0, ev.Execution.Cost)
+	assert.Greater(t, ev.Execution.EstimatedCost, 0.0)
 	require.NotEmpty(t, ev.Signature)
 	assert.True(t, evStore.VerifyRecord(&ev), "budget-denied evidence must remain signature-verifiable")
-	assert.Contains(t, strings.Join(ev.PolicyDecision.Reasons, ","), "budget")
+	assert.Contains(t, strings.Join(ev.PolicyDecision.Reasons, ","), "budget_exceeded")
+	assert.Equal(t, 0, upstreamCalls, "budget-denied request must not call upstream provider")
 }

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // OpenAI error response shape: https://platform.openai.com/docs/guides/error-codes
@@ -54,12 +55,39 @@ func WriteAnthropicError(w http.ResponseWriter, status int, message, errType str
 
 // WriteProviderError writes a provider-native error response based on provider name.
 func WriteProviderError(w http.ResponseWriter, provider string, status int, message string) {
+	cleanMessage, errType := normalizeGatewayError(message)
 	switch provider {
 	case "openai", "ollama":
-		WriteOpenAIError(w, status, message, "")
+		WriteOpenAIError(w, status, cleanMessage, errType)
 	case "anthropic":
-		WriteAnthropicError(w, status, message, "")
+		WriteAnthropicError(w, status, cleanMessage, errType)
 	default:
-		WriteOpenAIError(w, status, message, "")
+		WriteOpenAIError(w, status, cleanMessage, errType)
 	}
+}
+
+func normalizeGatewayError(message string) (cleanMessage string, errType string) {
+	raw := strings.TrimSpace(message)
+	if raw == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return raw, ""
+	}
+	errType = strings.TrimSpace(parts[0])
+	msg := strings.TrimSpace(parts[1])
+	if errType == "" || msg == "" {
+		return raw, ""
+	}
+	// Restrict machine codes to safe token characters.
+	for _, r := range errType {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		isSeparator := r == '_' || r == '-'
+		if !isLower && !isDigit && !isSeparator {
+			return raw, ""
+		}
+	}
+	return msg, errType
 }

--- a/internal/gateway/errors_test.go
+++ b/internal/gateway/errors_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -43,6 +44,23 @@ func TestWriteProviderError(t *testing.T) {
 		}
 		if w.Header().Get("Content-Type") != "application/json" {
 			t.Error("content-type not json")
+		}
+	})
+	t.Run("openai budget_exceeded code", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		WriteProviderError(w, "openai", http.StatusForbidden, "budget_exceeded: request would exceed caller daily cost limit (10.00)")
+		if w.Code != 403 {
+			t.Errorf("status = %d", w.Code)
+		}
+		var body openAIErrorBody
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Error.Code != "budget_exceeded" {
+			t.Fatalf("code = %q", body.Error.Code)
+		}
+		if strings.Contains(strings.ToLower(body.Error.Message), "budget_exceeded:") {
+			t.Fatalf("message still contains machine prefix: %q", body.Error.Message)
 		}
 	})
 	t.Run("anthropic", func(t *testing.T) {

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -31,6 +31,7 @@ type RecordGatewayEvidenceParams struct {
 	OutputPIIDetected       bool
 	OutputPIITypes          []string
 	Cost                    float64
+	EstimatedCost           float64
 	InputTokens             int
 	OutputTokens            int
 	DurationMS              int64
@@ -97,13 +98,14 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 			OutputPIITypes:    params.OutputPIITypes,
 		},
 		Execution: evidence.Execution{
-			ModelUsed:  params.Model,
-			Cost:       params.Cost,
-			Tokens:     evidence.TokenUsage{Input: params.InputTokens, Output: params.OutputTokens},
-			DurationMS: params.DurationMS,
-			TTFTMS:     params.TTFTMS,
-			TPOTMS:     params.TPOTMS,
-			Error:      params.Error,
+			ModelUsed:     params.Model,
+			Cost:          params.Cost,
+			EstimatedCost: params.EstimatedCost,
+			Tokens:        evidence.TokenUsage{Input: params.InputTokens, Output: params.OutputTokens},
+			DurationMS:    params.DurationMS,
+			TTFTMS:        params.TTFTMS,
+			TPOTMS:        params.TPOTMS,
+			Error:         params.Error,
 		},
 		SecretsAccessed:         params.SecretsAccessed,
 		AttachmentScan:          params.AttachmentScan,
@@ -122,6 +124,10 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		UpstreamKeyFingerprint:  params.UpstreamKeyFingerprint,
 		GatewayAnnotations:      sanitizeGatewayAnnotations(params.GatewayAnnotations),
 		RetryAttempt:            params.RetryAttempt,
+		RoutingDecision: &evidence.RoutingDecision{
+			SelectedProvider: params.Provider,
+			SelectedModel:    params.Model,
+		},
 	}
 	if !params.PolicyAllowed {
 		ev.PolicyDecision.Action = "deny"

--- a/internal/gateway/evidence_test.go
+++ b/internal/gateway/evidence_test.go
@@ -54,6 +54,9 @@ func TestRecordGatewayEvidence(t *testing.T) {
 	assert.Equal(t, "client", records[0].UpstreamKeySource)
 	assert.Equal(t, "abc123def456", records[0].UpstreamKeyFingerprint)
 	assert.Equal(t, []string{"quickstart_mode"}, records[0].GatewayAnnotations, "unsupported annotations must be dropped")
+	require.NotNil(t, records[0].RoutingDecision)
+	assert.Equal(t, "openai", records[0].RoutingDecision.SelectedProvider)
+	assert.Equal(t, "gpt-4o", records[0].RoutingDecision.SelectedModel)
 }
 
 // TestRecordGatewayEvidence_ToolGovernanceRoundTrip ensures tool governance is persisted

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -274,7 +274,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -329,7 +329,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"Request blocked: attachment violates policy")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
 				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, "", false,
-				[]string{"attachment policy block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				[]string{"attachment policy block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -363,7 +363,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -391,7 +391,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -417,7 +417,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		g.tryBudgetAlert(ctx, caller.TenantID, "monthly", pct, 80)
 		g.tryBudgetAlert(ctx, caller.TenantID, "monthly", pct, 95)
 	}
-	policyInput := buildGatewayPolicyInput(caller, route.Provider, extracted.Model, tier, estimatedCost, dailyCost, monthlyCost)
+	policyInput := buildGatewayPolicyInput(caller, g.config.ServerDefaults, route.Provider, extracted.Model, tier, estimatedCost, dailyCost, monthlyCost)
 	if g.sessionStore != nil && sessionID != "" {
 		if sess, err := g.sessionStore.Get(ctx, sessionID); err == nil {
 			policyInput["session_cost_total"] = sess.TotalCost
@@ -442,7 +442,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -464,7 +464,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusForbidden, reasons[0])
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -499,7 +499,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				WriteProviderError(w, route.Provider, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -517,7 +517,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
 					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0)
+						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0, estimatedCost)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -597,7 +597,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0, estimatedCost)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -673,7 +673,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -795,7 +795,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if forwardErr != nil {
 		forwardErrStr = forwardErr.Error()
 	}
-	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS)
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS, estimatedCost)
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
@@ -810,7 +810,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64) (*evidence.Evidence, error) {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64, estimatedCost float64) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -864,6 +864,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 		OutputPIIDetected:       outputPIIDetected,
 		OutputPIITypes:          outputPIITypes,
 		Cost:                    cost,
+		EstimatedCost:           estimatedCost,
 		InputTokens:             inputTokens,
 		OutputTokens:            outputTokens,
 		DurationMS:              durationMS,
@@ -1062,7 +1063,7 @@ func (g *Gateway) trackSessionUsage(ctx context.Context, sessionID, tenantID, ca
 	}
 }
 
-func buildGatewayPolicyInput(caller *CallerConfig, provider, model string, dataTier int, estimatedCost, dailyCost, monthlyCost float64) map[string]interface{} {
+func buildGatewayPolicyInput(caller *CallerConfig, defaults ServerDefaults, provider, model string, dataTier int, estimatedCost, dailyCost, monthlyCost float64) map[string]interface{} {
 	input := map[string]interface{}{
 		"provider":       provider,
 		"model":          model,
@@ -1073,11 +1074,21 @@ func buildGatewayPolicyInput(caller *CallerConfig, provider, model string, dataT
 		"caller_name":    caller.Name,
 		"tenant_id":      caller.TenantID,
 	}
+	if defaults.MaxDailyCost > 0 {
+		input["caller_max_daily_cost"] = defaults.MaxDailyCost
+	}
+	if defaults.MaxMonthlyCost > 0 {
+		input["caller_max_monthly_cost"] = defaults.MaxMonthlyCost
+	}
 	if caller.PolicyOverrides != nil {
 		input["caller_allowed_models"] = caller.PolicyOverrides.AllowedModels
 		input["caller_blocked_models"] = caller.PolicyOverrides.BlockedModels
-		input["caller_max_daily_cost"] = caller.PolicyOverrides.MaxDailyCost
-		input["caller_max_monthly_cost"] = caller.PolicyOverrides.MaxMonthlyCost
+		if caller.PolicyOverrides.MaxDailyCost > 0 {
+			input["caller_max_daily_cost"] = caller.PolicyOverrides.MaxDailyCost
+		}
+		if caller.PolicyOverrides.MaxMonthlyCost > 0 {
+			input["caller_max_monthly_cost"] = caller.PolicyOverrides.MaxMonthlyCost
+		}
 		if caller.PolicyOverrides.MaxDataTier != nil {
 			input["caller_max_data_tier"] = *caller.PolicyOverrides.MaxDataTier
 		}

--- a/internal/gateway/policy_input_test.go
+++ b/internal/gateway/policy_input_test.go
@@ -1,0 +1,46 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildGatewayPolicyInput_UsesServerDefaultsWhenCallerCapsUnset(t *testing.T) {
+	caller := &CallerConfig{
+		Name:     "support-slack-bot",
+		TenantID: "default",
+		PolicyOverrides: &CallerPolicyOverrides{
+			PIIAction: "warn",
+		},
+	}
+	defaults := ServerDefaults{
+		MaxDailyCost:   10.0,
+		MaxMonthlyCost: 200.0,
+	}
+
+	input := buildGatewayPolicyInput(caller, defaults, "openai", "gpt-4o-mini", 0, 0.5, 2.0, 15.0)
+
+	assert.Equal(t, 10.0, input["caller_max_daily_cost"])
+	assert.Equal(t, 200.0, input["caller_max_monthly_cost"])
+}
+
+func TestBuildGatewayPolicyInput_CallerCapsOverrideServerDefaults(t *testing.T) {
+	caller := &CallerConfig{
+		Name:     "support-slack-bot",
+		TenantID: "default",
+		PolicyOverrides: &CallerPolicyOverrides{
+			MaxDailyCost:   5.0,
+			MaxMonthlyCost: 120.0,
+		},
+	}
+	defaults := ServerDefaults{
+		MaxDailyCost:   10.0,
+		MaxMonthlyCost: 200.0,
+	}
+
+	input := buildGatewayPolicyInput(caller, defaults, "openai", "gpt-4o-mini", 0, 0.5, 2.0, 15.0)
+
+	assert.Equal(t, 5.0, input["caller_max_daily_cost"])
+	assert.Equal(t, 120.0, input["caller_max_monthly_cost"])
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -13,22 +13,23 @@ import (
 
 // Snapshot is the complete dashboard state returned by GET /api/v1/metrics.
 type Snapshot struct {
-	GeneratedAt      time.Time           `json:"generated_at"`
-	EnforcementMode  string              `json:"enforcement_mode"`
-	Uptime           string              `json:"uptime"`
-	DroppedEvents    uint64              `json:"dropped_events,omitempty"`
-	Summary          Summary             `json:"summary"`
-	RequestsTimeline []TimePoint         `json:"requests_timeline"`
-	PIITimeline      []TimePoint         `json:"pii_timeline"`
-	CostTimeline     []CostTimePoint     `json:"cost_timeline"`
-	CallerStats      []CallerStat        `json:"caller_stats"`
-	PIIBreakdown     []PIITypeStat       `json:"pii_breakdown"`
-	ToolGovernance   ToolGovernanceStats `json:"tool_governance"`
-	ShadowSummary    *ShadowSummary      `json:"shadow_summary,omitempty"`
-	ModelBreakdown   []ModelStat         `json:"model_breakdown"`
-	BudgetStatus     *BudgetStatus       `json:"budget_status,omitempty"`
-	CacheStats       *CacheStats         `json:"cache_stats,omitempty"`
-	PlanStats        *PlanStats          `json:"plan_stats,omitempty"`
+	GeneratedAt       time.Time           `json:"generated_at"`
+	EnforcementMode   string              `json:"enforcement_mode"`
+	Uptime            string              `json:"uptime"`
+	DroppedEvents     uint64              `json:"dropped_events,omitempty"`
+	Summary           Summary             `json:"summary"`
+	RequestsTimeline  []TimePoint         `json:"requests_timeline"`
+	PIITimeline       []TimePoint         `json:"pii_timeline"`
+	CostTimeline      []CostTimePoint     `json:"cost_timeline"`
+	CallerStats       []CallerStat        `json:"caller_stats"`
+	PIIBreakdown      []PIITypeStat       `json:"pii_breakdown"`
+	ToolGovernance    ToolGovernanceStats `json:"tool_governance"`
+	ShadowSummary     *ShadowSummary      `json:"shadow_summary,omitempty"`
+	ModelBreakdown    []ModelStat         `json:"model_breakdown"`
+	ProviderBreakdown []ProviderStat      `json:"provider_breakdown"`
+	BudgetStatus      *BudgetStatus       `json:"budget_status,omitempty"`
+	CacheStats        *CacheStats         `json:"cache_stats,omitempty"`
+	PlanStats         *PlanStats          `json:"plan_stats,omitempty"`
 }
 
 // Summary holds top-level KPIs.
@@ -141,6 +142,13 @@ type ViolationTypeStat struct {
 // ModelStat is cost and request count per LLM model.
 type ModelStat struct {
 	Model    string  `json:"model"`
+	Requests int     `json:"requests"`
+	CostEUR  float64 `json:"cost_eur"`
+}
+
+// ProviderStat is cost and request count per provider.
+type ProviderStat struct {
+	Provider string  `json:"provider"`
 	Requests int     `json:"requests"`
 	CostEUR  float64 `json:"cost_eur"`
 }
@@ -851,6 +859,7 @@ func (c *Collector) fillAggregateMetrics(ctx context.Context, snap *Snapshot) {
 	last24h := now.Add(-24 * time.Hour)
 
 	c.fillModelBreakdown(ctx, snap, dayStart, dayEnd)
+	c.fillProviderBreakdown(ctx, snap, dayStart, dayEnd)
 	c.fillBudgetStatus(ctx, snap, dayStart, dayEnd, monthStart, monthEnd)
 	c.fillCacheStats(ctx, snap, last24h, now)
 }
@@ -883,6 +892,19 @@ func (c *Collector) fillModelBreakdown(ctx context.Context, snap *Snapshot, dayS
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].CostEUR > models[j].CostEUR })
 	snap.ModelBreakdown = models
+}
+
+func (c *Collector) fillProviderBreakdown(ctx context.Context, snap *Snapshot, dayStart, dayEnd time.Time) {
+	byProvider, err := c.metricsQuerier.CostByProvider(ctx, c.tenantID, "", dayStart, dayEnd)
+	if err != nil || len(byProvider) == 0 {
+		return
+	}
+	providers := make([]ProviderStat, 0, len(byProvider))
+	for provider, cost := range byProvider {
+		providers = append(providers, ProviderStat{Provider: provider, CostEUR: cost})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].CostEUR > providers[j].CostEUR })
+	snap.ProviderBreakdown = providers
 }
 
 func (c *Collector) fillBudgetStatus(ctx context.Context, snap *Snapshot, dayStart, dayEnd, monthStart, monthEnd time.Time) {

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -13,12 +13,13 @@ import (
 
 // mockQuerier implements evidence.MetricsQuerier for testing.
 type mockQuerier struct {
-	costTotal    float64
-	costByAgent  map[string]float64
-	costByModel  map[string]float64
-	countInRange int
-	cacheHits    int64
-	cacheSaved   float64
+	costTotal      float64
+	costByAgent    map[string]float64
+	costByModel    map[string]float64
+	costByProvider map[string]float64
+	countInRange   int
+	cacheHits      int64
+	cacheSaved     float64
 }
 
 func (m *mockQuerier) CostTotal(_ context.Context, _, _ string, _, _ time.Time) (float64, error) {
@@ -31,6 +32,10 @@ func (m *mockQuerier) CostByAgent(_ context.Context, _ string, _, _ time.Time) (
 
 func (m *mockQuerier) CostByModel(_ context.Context, _, _ string, _, _ time.Time) (map[string]float64, error) {
 	return m.costByModel, nil
+}
+
+func (m *mockQuerier) CostByProvider(_ context.Context, _, _ string, _, _ time.Time) (map[string]float64, error) {
+	return m.costByProvider, nil
 }
 
 func (m *mockQuerier) CountInRange(_ context.Context, _, _ string, _, _ time.Time) (int, error) {
@@ -251,6 +256,19 @@ func TestMetricsQuerierModelBreakdown(t *testing.T) {
 	require.Len(t, snap.ModelBreakdown, 2)
 	assert.Equal(t, "gpt-4o", snap.ModelBreakdown[0].Model)
 	assert.InDelta(t, 1.5, snap.ModelBreakdown[0].CostEUR, 0.001)
+}
+
+func TestMetricsQuerierProviderBreakdown(t *testing.T) {
+	q := &mockQuerier{
+		costByProvider: map[string]float64{"openai": 1.5, "anthropic": 0.8},
+	}
+	c := newTestCollector("enforce", q)
+	defer c.Close()
+
+	snap := c.Snapshot(context.Background())
+	require.Len(t, snap.ProviderBreakdown, 2)
+	assert.Equal(t, "openai", snap.ProviderBreakdown[0].Provider)
+	assert.InDelta(t, 1.5, snap.ProviderBreakdown[0].CostEUR, 0.001)
 }
 
 func TestMetricsQuerierBudget(t *testing.T) {

--- a/internal/policy/gateway_engine_test.go
+++ b/internal/policy/gateway_engine_test.go
@@ -70,5 +70,6 @@ func TestGatewayEngine_EvaluateGateway_DenyDailyCost(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, allowed)
 	require.NotEmpty(t, reasons)
+	require.Contains(t, reasons[0], "budget_exceeded")
 	require.Contains(t, reasons[0], "daily")
 }

--- a/internal/policy/rego/gateway_access.rego
+++ b/internal/policy/rego/gateway_access.rego
@@ -40,7 +40,7 @@ deny contains msg if {
 	input.caller_max_daily_cost != null
 	input.caller_max_daily_cost > 0
 	input.daily_cost + input.estimated_cost > input.caller_max_daily_cost
-	msg := sprintf("Request would exceed caller daily cost limit (%.2f)", [input.caller_max_daily_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller daily cost limit (%.2f)", [input.caller_max_daily_cost])
 }
 
 # Per-caller monthly cost limit.
@@ -48,7 +48,7 @@ deny contains msg if {
 	input.caller_max_monthly_cost != null
 	input.caller_max_monthly_cost > 0
 	input.monthly_cost + input.estimated_cost > input.caller_max_monthly_cost
-	msg := sprintf("Request would exceed caller monthly cost limit (%.2f)", [input.caller_max_monthly_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller monthly cost limit (%.2f)", [input.caller_max_monthly_cost])
 }
 
 # Per-caller data tier restriction: request tier must not exceed caller's max.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/drift"
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
 	"github.com/dativo-io/talon/internal/health"
 	"github.com/dativo-io/talon/internal/memory"
 	"github.com/dativo-io/talon/internal/session"
@@ -625,7 +627,7 @@ func (s *Server) handleCostsExport(w http.ResponseWriter, r *http.Request) {
 	}
 	limit := req.Limit
 	if limit <= 0 {
-		limit = 1000
+		limit = 10000
 	}
 	var from, to time.Time
 	if req.From != "" {
@@ -830,23 +832,70 @@ func (s *Server) handleCostsBudget(w http.ResponseWriter, r *http.Request) {
 	if tenantID == "" {
 		tenantID = "default"
 	}
+	callerID := r.URL.Query().Get("caller")
+	if callerID == "" {
+		callerID = r.URL.Query().Get("agent_id")
+	}
 	now := time.Now().UTC()
 	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	dayEnd := dayStart.Add(24 * time.Hour)
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	monthEnd := monthStart.AddDate(0, 1, 0)
-	dailyUsed, _ := s.evidenceStore.CostTotal(r.Context(), tenantID, "", dayStart, dayEnd)
-	monthlyUsed, _ := s.evidenceStore.CostTotal(r.Context(), tenantID, "", monthStart, monthEnd)
+	dailyUsed, _ := s.evidenceStore.CostTotal(r.Context(), tenantID, callerID, dayStart, dayEnd)
+	monthlyUsed, _ := s.evidenceStore.CostTotal(r.Context(), tenantID, callerID, monthStart, monthEnd)
 	out := map[string]interface{}{
 		"tenant_id":    tenantID,
 		"daily_used":   dailyUsed,
 		"monthly_used": monthlyUsed,
 	}
+	if callerID != "" {
+		if dailyLimit, monthlyLimit, ok := lookupGatewayCallerCaps(tenantID, callerID); ok {
+			if dailyLimit > 0 {
+				out["daily_limit"] = dailyLimit
+			}
+			if monthlyLimit > 0 {
+				out["monthly_limit"] = monthlyLimit
+			}
+			out["budget_source"] = "gateway_caller_cap"
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+	}
 	if s.policy != nil && s.policy.Policies.CostLimits != nil {
 		out["daily_limit"] = s.policy.Policies.CostLimits.Daily
 		out["monthly_limit"] = s.policy.Policies.CostLimits.Monthly
+		out["budget_source"] = "policy_cost_limits"
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+func lookupGatewayCallerCaps(tenantID, callerID string) (dailyLimit float64, monthlyLimit float64, ok bool) {
+	path := strings.TrimSpace(os.Getenv("TALON_GATEWAY_CONFIG"))
+	if path == "" {
+		path = "talon.config.yaml"
+	}
+	cfg, err := gateway.LoadGatewayConfig(path)
+	if err != nil {
+		return 0, 0, false
+	}
+	for i := range cfg.Callers {
+		caller := cfg.Callers[i]
+		if caller.Name != callerID || caller.TenantID != tenantID {
+			continue
+		}
+		daily := cfg.ServerDefaults.MaxDailyCost
+		monthly := cfg.ServerDefaults.MaxMonthlyCost
+		if caller.PolicyOverrides != nil {
+			if caller.PolicyOverrides.MaxDailyCost > 0 {
+				daily = caller.PolicyOverrides.MaxDailyCost
+			}
+			if caller.PolicyOverrides.MaxMonthlyCost > 0 {
+				monthly = caller.PolicyOverrides.MaxMonthlyCost
+			}
+		}
+		return daily, monthly, daily > 0 || monthly > 0
+	}
+	return 0, 0, false
 }
 
 // handleCostsReport returns aggregate spend for a time range (for trends/summary). Query params: from, to (RFC3339), tenant_id, agent_id.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -525,6 +526,7 @@ func (s *Server) handleEvidenceVerify(w http.ResponseWriter, r *http.Request) {
 type evidenceExportRequest struct {
 	TenantID string `json:"tenant_id"`
 	AgentID  string `json:"agent_id"`
+	Caller   string `json:"caller,omitempty"`
 	From     string `json:"from"`
 	To       string `json:"to"`
 	Limit    int    `json:"limit"`
@@ -563,7 +565,12 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request", "format must be csv or json")
 		return
 	}
-	list, err := s.evidenceStore.List(r.Context(), tenantID, req.AgentID, from, to, limit)
+	agentID, err := resolveAgentOrCaller(req.AgentID, req.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	list, err := s.evidenceStore.List(r.Context(), tenantID, agentID, from, to, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -576,7 +583,7 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		cw := csv.NewWriter(w)
-		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "cost", "model_used", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity"})
+		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "policy_action", "cost", "model_used", "provider", "input_tokens", "output_tokens", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity"})
 		for i := range records {
 			rec := &records[i]
 			pii := rec.PIIDetectedCSV()
@@ -584,7 +591,8 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 			tools := rec.ToolsCalledCSV()
 			_ = cw.Write([]string{
 				rec.ID, rec.Timestamp.Format(time.RFC3339), rec.TenantID, rec.AgentID, rec.InvocationType,
-				strconv.FormatBool(rec.Allowed), strconv.FormatFloat(rec.Cost, 'f', -1, 64), rec.ModelUsed,
+				strconv.FormatBool(rec.Allowed), rec.PolicyAction, strconv.FormatFloat(rec.Cost, 'f', -1, 64), rec.ModelUsed, rec.Provider,
+				strconv.Itoa(rec.InputTokens), strconv.Itoa(rec.OutputTokens),
 				strconv.FormatInt(rec.DurationMS, 10), strconv.FormatBool(rec.HasError),
 				strconv.Itoa(rec.InputTier), strconv.Itoa(rec.OutputTier), pii, strconv.FormatBool(rec.PIIRedacted),
 				reasons, tools, rec.InputHash, rec.OutputHash, rec.UpstreamAuthMode, rec.UpstreamKeySource, rec.UpstreamKeyFingerprint, rec.GatewayAnnotationsCSV(), rec.PrimaryExplanationCode, rec.PrimaryExplanationReason, rec.PrimaryVersionIdentity,
@@ -594,6 +602,95 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, records)
+}
+
+//nolint:gocyclo // mirrors handleEvidenceExport flow with explicit per-step validation and response branching
+func (s *Server) handleCostsExport(w http.ResponseWriter, r *http.Request) {
+	var req evidenceExportRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: "+err.Error())
+		return
+	}
+	tenantID := TenantIDFromContext(r.Context())
+	if tenantID == "" {
+		tenantID = req.TenantID
+	}
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	agentID, err := resolveAgentOrCaller(req.AgentID, req.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 1000
+	}
+	var from, to time.Time
+	if req.From != "" {
+		from, _ = time.Parse(time.RFC3339, req.From)
+	}
+	if req.To != "" {
+		to, _ = time.Parse(time.RFC3339, req.To)
+	}
+	format := req.Format
+	if format == "" {
+		format = "json"
+	}
+	if format != "csv" && format != "json" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "format must be csv or json")
+		return
+	}
+	list, err := s.evidenceStore.List(r.Context(), tenantID, agentID, from, to, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	records := make([]evidence.ExportRecord, len(list))
+	for i := range list {
+		records[i] = evidence.ToExportRecord(&list[i])
+	}
+	if format == "csv" {
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		cw := csv.NewWriter(w)
+		_ = cw.Write([]string{
+			"evidence_id", "tenant_id", "agent_id", "timestamp", "model", "provider",
+			"cost_eur", "input_tokens", "output_tokens", "policy_decision", "policy_reason",
+		})
+		for i := range records {
+			rec := &records[i]
+			policyDecision := rec.PolicyAction
+			if policyDecision == "" {
+				if rec.Allowed {
+					policyDecision = "allow"
+				} else {
+					policyDecision = "deny"
+				}
+			}
+			_ = cw.Write([]string{
+				rec.ID, rec.TenantID, rec.AgentID, rec.Timestamp.Format(time.RFC3339), rec.ModelUsed, rec.Provider,
+				strconv.FormatFloat(rec.Cost, 'f', -1, 64), strconv.Itoa(rec.InputTokens), strconv.Itoa(rec.OutputTokens),
+				policyDecision, rec.PolicyReasonsCSV(),
+			})
+		}
+		cw.Flush()
+		return
+	}
+	writeJSON(w, http.StatusOK, records)
+}
+
+func resolveAgentOrCaller(agentID, caller string) (string, error) {
+	agent := strings.TrimSpace(agentID)
+	caller = strings.TrimSpace(caller)
+	if caller == "" {
+		return agent, nil
+	}
+	if agent != "" && agent != caller {
+		return "", fmt.Errorf("agent_id and caller must match when both are provided")
+	}
+	return caller, nil
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,6 +293,7 @@ func (s *Server) Routes() http.Handler {
 		r.Get("/v1/costs", s.handleCosts)
 		r.Get("/v1/costs/budget", s.handleCostsBudget)
 		r.Get("/v1/costs/report", s.handleCostsReport)
+		r.Post("/v1/costs/export", s.handleCostsExport)
 
 		r.Get("/v1/memory", s.handleMemoryList)
 		r.Get("/v1/memory/as-of", s.handleMemoryAsOf)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1411,6 +1411,74 @@ func TestEvidenceExport(t *testing.T) {
 	assert.Equal(t, "text/csv; charset=utf-8", rec.Header().Get("Content-Type"))
 }
 
+func TestCostsExport_IncludesDeniedRowsAndProvider(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	ev := &evidence.Evidence{
+		ID:             "gw_cost_export_1",
+		CorrelationID:  "corr_cost_export_1",
+		Timestamp:      time.Now().UTC(),
+		TenantID:       "default",
+		AgentID:        "support-slack-bot",
+		InvocationType: "gateway",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false,
+			Action:  "deny",
+			Reasons: []string{"budget_exceeded: daily limit"},
+		},
+		Classification: evidence.Classification{},
+		Execution: evidence.Execution{
+			ModelUsed:     "gpt-4o-mini",
+			Cost:          0,
+			EstimatedCost: 0.02,
+			Tokens:        evidence.TokenUsage{},
+		},
+		RoutingDecision: &evidence.RoutingDecision{
+			SelectedProvider: "openai",
+			SelectedModel:    "gpt-4o-mini",
+		},
+		AuditTrail: evidence.AuditTrail{},
+		Compliance: evidence.Compliance{},
+	}
+	require.NoError(t, store.Store(context.Background(), ev))
+
+	srv := NewServer(nil, store, nil, engine, pol, "", nil, "", map[string]string{"k": "default"})
+	r := srv.Routes()
+
+	// JSON path
+	body := `{"tenant_id":"default","caller":"support-slack-bot","format":"json","limit":10}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/costs/export", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer k")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]interface{}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "gw_cost_export_1", rows[0]["id"])
+	assert.Equal(t, "openai", rows[0]["provider"])
+	assert.Equal(t, "deny", rows[0]["policy_action"])
+
+	// CSV path
+	body = `{"tenant_id":"default","caller":"support-slack-bot","format":"csv","limit":10}`
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/costs/export", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer k")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/csv; charset=utf-8", rec.Header().Get("Content-Type"))
+	assert.Contains(t, rec.Body.String(), "evidence_id,tenant_id,agent_id")
+	assert.Contains(t, rec.Body.String(), "budget_exceeded")
+}
+
 func TestEvidenceGetAndVerifySuccess(t *testing.T) {
 	pol := minimalPolicy()
 	engine, err := policy.NewEngine(context.Background(), pol)

--- a/tests/smoke_sections/09_cost.sh
+++ b/tests/smoke_sections/09_cost.sh
@@ -19,17 +19,43 @@ test_section_09_cost() {
     sed -i.bak 's/daily:.*/daily: 0.001/' "$dir/agent.talon.yaml" 2>/dev/null || true
   fi
   run_talon run "Reply PONG" &>/dev/null; true
+  local second_denied=0
   if run_talon run "Reply PONG again" 2>/dev/null; then
     echo "  ✓  first run under budget (or policy not enforced)"
     record_pass
   else
+    second_denied=1
     echo "  ✓  second run denied (daily budget exceeded)"
     record_pass
+  fi
+  if [[ "$second_denied" -eq 1 ]]; then
+    local last_id
+    last_id="$(run_talon audit list --limit 1 2>/dev/null | grep -oE '(req|gw)_[[:alnum:]_-]+' | head -1 || true)"
+    if [[ -n "$last_id" ]]; then
+      local audit_show
+      audit_show="$(run_talon audit show "$last_id" 2>/dev/null || true)"
+      if grep -qi "budget_exceeded" <<< "$audit_show" || grep -qi "budget" <<< "$audit_show"; then
+        echo "  ✓  denied request evidence contains budget reason ($last_id)"
+        record_pass
+      else
+        echo "  -  denied request evidence did not include explicit budget marker"
+      fi
+    fi
   fi
   assert_pass "talon costs exits 0" run_talon costs
   local cost_out; cost_out="$(run_talon costs 2>/dev/null)"; true
   assert_pass "talon costs stdout contains numeric cost" grep -qE '[0-9]+\.?[0-9]*' <<< "$cost_out"
   assert_pass "talon costs --tenant default exits 0" run_talon costs --tenant default
+  assert_pass "talon costs --json exits 0" run_talon costs --tenant default --json
+  local cost_json_out; cost_json_out="$(run_talon costs --tenant default --json 2>/dev/null || true)"
+  assert_pass "talon costs --json outputs JSON object" jq -e 'type=="object"' <<< "$cost_json_out" &>/dev/null
+  assert_pass "talon costs --by-provider exits 0" run_talon costs --tenant default --by-provider
+  assert_pass "talon costs export --format csv exits 0" run_talon costs export --tenant default --format csv --limit 20
+  assert_pass "talon costs export --format json exits 0" run_talon costs export --tenant default --format json --limit 20
+  local cost_export_json; cost_export_json="$(run_talon costs export --tenant default --format json --limit 20 2>/dev/null || true)"
+  if [[ -n "$cost_export_json" ]]; then
+    assert_pass "cost export JSON is an array" jq -e 'type=="array"' <<< "$cost_export_json" &>/dev/null
+  fi
   cd "$REPO_ROOT" || true
 }
 

--- a/tests/smoke_sections/09_cost.sh
+++ b/tests/smoke_sections/09_cost.sh
@@ -48,7 +48,12 @@ test_section_09_cost() {
   assert_pass "talon costs --tenant default exits 0" run_talon costs --tenant default
   assert_pass "talon costs --json exits 0" run_talon costs --tenant default --json
   local cost_json_out; cost_json_out="$(run_talon costs --tenant default --json 2>/dev/null || true)"
-  assert_pass "talon costs --json outputs JSON object" jq -e 'type=="object"' <<< "$cost_json_out" &>/dev/null
+  if [[ -n "$cost_json_out" ]] && jq -e 'type=="object"' <<< "$cost_json_out" &>/dev/null; then
+    echo "  ✓  talon costs --json outputs JSON object"
+    record_pass
+  else
+    log_failure "talon costs --json outputs JSON object" "output=$(echo "$cost_json_out" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | cut -c1-200)"
+  fi
   assert_pass "talon costs --by-provider exits 0" run_talon costs --tenant default --by-provider
   assert_pass "talon costs export --format csv exits 0" run_talon costs export --tenant default --format csv --limit 20
   assert_pass "talon costs export --format json exits 0" run_talon costs export --tenant default --format json --limit 20

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -616,7 +616,8 @@ CACHEEOF
   # CLI costs --by-provider: compare provider names with dashboard provider_breakdown
   local cli_byprovider; cli_byprovider="$(run_talon costs --by-provider --tenant default 2>/dev/null)"; true
   assert_pass "talon costs --by-provider exits 0" run_talon costs --by-provider --tenant default
-  local cli_providers; cli_providers="$(echo "$cli_byprovider" | grep '€' | grep -v '^Total' | awk '{print $1}' | sort)"
+  local cli_providers
+  cli_providers="$(echo "$cli_byprovider" | awk '/€/ {print $1}' | grep -E '^[a-zA-Z0-9._-]+$' | grep -v -E '^(Total|Provider|Tenant|7d)$' | sort)"
   local dash_providers; dash_providers="$(jq -r '.provider_breakdown[].provider // empty' <<< "$snap_after" 2>/dev/null | sort)"
   echo "[SMOKE] CONSISTENCY|cli_providers|$(echo "$cli_providers" | tr '\n' ',')"
   echo "[SMOKE] CONSISTENCY|dash_providers|$(echo "$dash_providers" | tr '\n' ',')"

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -436,6 +436,8 @@ CACHEEOF
     jq -e '.tool_governance | type == "object"' <<< "$snap_after" &>/dev/null
   assert_pass "snapshot has model_breakdown array" \
     jq -e '.model_breakdown | type == "array"' <<< "$snap_after" &>/dev/null
+  assert_pass "snapshot has provider_breakdown array" \
+    jq -e '.provider_breakdown | type == "array"' <<< "$snap_after" &>/dev/null
 
   # --- 23.5b: Budget status fields (omitempty — present when budget limits configured) ---
   local has_budget; has_budget="$(jq 'has("budget_status") and (.budget_status != null)' <<< "$snap_after")"
@@ -609,6 +611,25 @@ CACHEEOF
     fi
   else
     echo "  -  model parity: could not extract models from CLI or dashboard"
+  fi
+
+  # CLI costs --by-provider: compare provider names with dashboard provider_breakdown
+  local cli_byprovider; cli_byprovider="$(run_talon costs --by-provider --tenant default 2>/dev/null)"; true
+  assert_pass "talon costs --by-provider exits 0" run_talon costs --by-provider --tenant default
+  local cli_providers; cli_providers="$(echo "$cli_byprovider" | grep '€' | grep -v '^Total' | awk '{print $1}' | sort)"
+  local dash_providers; dash_providers="$(jq -r '.provider_breakdown[].provider // empty' <<< "$snap_after" 2>/dev/null | sort)"
+  echo "[SMOKE] CONSISTENCY|cli_providers|$(echo "$cli_providers" | tr '\n' ',')"
+  echo "[SMOKE] CONSISTENCY|dash_providers|$(echo "$dash_providers" | tr '\n' ',')"
+  if [[ -n "$dash_providers" ]]; then
+    if [[ "$cli_providers" == "$dash_providers" ]]; then
+      echo "  ✓  CLI costs --by-provider providers match dashboard provider_breakdown"
+      record_pass
+    else
+      log_failure "CLI --by-provider provider set should match dashboard provider_breakdown" \
+        "cli=[$cli_providers] dash=[$dash_providers]"
+    fi
+  else
+    echo "  -  provider_breakdown is empty (may need more traffic)"
   fi
 
   # --- 23.7b: CLI report ↔ dashboard evidence count + PII parity ---

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -103,8 +103,8 @@
     <div class="runtime-warning" id="runtime-warning-banner"></div>
     <div class="cards">
     <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Visible requests</div><div class="value" id="card-requests">—</div></div>
-    <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Visible cost</div><div class="value" id="card-daily">— &euro;</div></div>
-    <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Monthly cost</div><div class="value" id="card-monthly">— &euro;</div></div>
+    <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Visible cost (evidence-backed)</div><div class="value" id="card-daily">— &euro;</div></div>
+    <div class="card card-link" data-tab="evidence" data-filter=""><div class="label">Monthly cost (evidence-backed)</div><div class="value" id="card-monthly">— &euro;</div></div>
     <div class="card card-link" data-tab="plans" data-filter=""><div class="label">Pending plans</div><div class="value" id="card-plans">—</div></div>
     <div class="card card-link" data-tab="memory" data-filter=""><div class="label">Pending memory</div><div class="value" id="card-memory-pending">—</div></div>
     <div class="card card-link" data-tab="evidence" data-filter="blocked"><div class="label">Blocked</div><div class="value" id="card-blocked">—</div></div>
@@ -167,7 +167,7 @@
   <div id="panel-evidence" class="panel active">
     <p class="compliance-overlay">Evidence supports: GDPR Art. 30, EU AI Act documentation (when present in metadata).</p>
     <p class="refresh">Evidence-grade, not just logs. Talon signs every evidence record at creation time; if a signed field changes later, verification fails.</p>
-    <p class="refresh" id="evidence-scope-note">Verified evidence proves both governance decisions and cost attribution.</p>
+    <p class="refresh" id="evidence-scope-note">Verified evidence proves both governance decisions and cost attribution. Today/month totals on this page are evidence-backed (not runtime-only telemetry).</p>
     <div class="evidence-filters">
       <label>Tenant <input type="text" id="filter-tenant" placeholder="optional" /></label>
       <label>Agent <input type="text" id="filter-agent" placeholder="optional" /></label>
@@ -738,7 +738,7 @@
           syncPolicyOutcomeFromEvidence(d.entries || []);
           tbody.innerHTML = '';
           if (!(d.entries || []).length) {
-            tbody.innerHTML = '<tr><td colspan="8" class="refresh">No evidence yet. Run a request (CLI or proxy) to generate signed records, then verify integrity inline from this table.</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="8" class="refresh">No evidence yet. Configure a gateway caller budget (max_daily_cost/max_monthly_cost), run a proxied request, then verify signed records and cost attribution from this table.</td></tr>';
             setEvidenceDetailVisible(false);
             return;
           }

--- a/web/gateway_dashboard.html
+++ b/web/gateway_dashboard.html
@@ -125,6 +125,7 @@
   <div class="kpi">
     <div class="kpi-label">Total Cost</div>
     <div class="kpi-value" id="kpi-cost">--</div>
+    <div class="kpi-sub">Runtime telemetry (last 24h)</div>
   </div>
   <div class="kpi">
     <div class="kpi-label">Avg Latency</div>
@@ -206,6 +207,7 @@
   <!-- Budget Status -->
   <div class="panel" id="panel-budget" style="display:none">
     <div class="panel-title">Budget Utilization</div>
+    <div class="kpi-sub">Evidence-backed calendar totals (today/month)</div>
     <div id="budget-content"></div>
   </div>
 
@@ -213,7 +215,7 @@
   <div class="panel grid-full">
     <div class="panel-title">Caller Breakdown</div>
     <table>
-      <thead><tr><th>Caller</th><th>Requests</th><th>Success</th><th>Failed</th><th>Timeout</th><th>Denied</th><th>Rate</th><th>Cost (EUR)</th><th>EUR/Success</th><th>Avg Latency</th><th>Trend(7d)</th></tr></thead>
+      <thead><tr><th>Caller</th><th>Requests</th><th>Success</th><th>Failed</th><th>Timeout</th><th>Denied</th><th>Rate</th><th>Cost (EUR)</th><th>EUR/Success</th><th>Avg Latency</th><th>Trend(7d)</th><th>Evidence</th></tr></thead>
       <tbody id="caller-table"></tbody>
     </table>
   </div>
@@ -228,8 +230,16 @@
   <div class="panel" id="panel-models">
     <div class="panel-title">Model Breakdown (today)</div>
     <table>
-      <thead><tr><th>Model</th><th>Cost (EUR)</th></tr></thead>
+      <thead><tr><th>Model</th><th>Cost (EUR)</th><th>Evidence</th></tr></thead>
       <tbody id="model-table"></tbody>
+    </table>
+  </div>
+
+  <div class="panel" id="panel-providers">
+    <div class="panel-title">Provider Breakdown (today)</div>
+    <table>
+      <thead><tr><th>Provider</th><th>Cost (EUR)</th><th>Evidence</th></tr></thead>
+      <tbody id="provider-table"></tbody>
     </table>
   </div>
 
@@ -457,6 +467,7 @@
     renderToolGovernance(d.tool_governance);
     renderShadow(d.shadow_summary);
     renderModels(d.model_breakdown || []);
+    renderProviders(d.provider_breakdown || []);
     renderBudget(d.budget_status);
     renderCache(d.cache_stats);
   }
@@ -479,9 +490,18 @@
     svg.innerHTML = '<polygon class="area" points="' + area + '" fill="' + fill + '"/><polyline points="' + line + '" stroke="' + stroke + '" fill="none" stroke-width="2"/>';
   }
 
+  function evidenceDashboardURL() {
+    var token = window.TALON_ADMIN_KEY || '';
+    if (!token) return '/dashboard#evidence-gateway';
+    return '/dashboard?talon_admin_key=' + encodeURIComponent(token) + '#evidence-gateway';
+  }
+
   function renderCallerTable(callers) {
     var tb = document.getElementById('caller-table');
-    if (callers.length === 0) { tb.innerHTML = '<tr><td colspan="11" style="color:var(--text-dim)">No caller data</td></tr>'; return; }
+    if (callers.length === 0) {
+      tb.innerHTML = '<tr><td colspan="12" style="color:var(--text-dim)">No caller data yet. Configure gateway callers with max_daily_cost/max_monthly_cost and send a proxied request to generate signed cost evidence.</td></tr>';
+      return;
+    }
     var totalCostPerSuccess = callers.reduce(function(acc, c) { return acc + (c.cost_per_success || 0); }, 0);
     var avgCostPerSuccess = callers.length > 0 ? totalCostPerSuccess / callers.length : 0;
     tb.innerHTML = callers.map(function(c) {
@@ -489,7 +509,8 @@
       var rateClass = rate >= 0.9 ? 'rate-good' : (rate >= 0.7 ? 'rate-warn' : 'rate-bad');
       var cps = c.cost_per_success || 0;
       var cpsClass = (avgCostPerSuccess > 0 && cps > (2 * avgCostPerSuccess)) ? 'cost-hot' : '';
-      return '<tr><td>' + esc(c.caller) + '</td><td>' + fmt(c.requests) + '</td><td>' + fmt(c.successful) + '</td><td>' + fmt(c.failed) + '</td><td>' + fmt(c.timed_out) + '</td><td>' + fmt(c.denied) + '</td><td class="' + rateClass + '">' + (rate * 100).toFixed(1) + '%</td><td>€' + (c.cost_eur || 0).toFixed(4) + '</td><td class="' + cpsClass + '">€' + cps.toFixed(4) + '</td><td>' + c.avg_latency_ms + 'ms</td><td>' + renderCallerTrend(c.violation_trend) + '</td></tr>';
+      var evidenceLink = '<a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a>';
+      return '<tr><td>' + esc(c.caller) + '</td><td>' + fmt(c.requests) + '</td><td>' + fmt(c.successful) + '</td><td>' + fmt(c.failed) + '</td><td>' + fmt(c.timed_out) + '</td><td>' + fmt(c.denied) + '</td><td class="' + rateClass + '">' + (rate * 100).toFixed(1) + '%</td><td>€' + (c.cost_eur || 0).toFixed(4) + '</td><td class="' + cpsClass + '">€' + cps.toFixed(4) + '</td><td>' + c.avg_latency_ms + 'ms</td><td>' + renderCallerTrend(c.violation_trend) + '</td><td>' + evidenceLink + '</td></tr>';
     }).join('');
   }
 
@@ -627,9 +648,20 @@
 
   function renderModels(models) {
     var tb = document.getElementById('model-table');
-    if (models.length === 0) { tb.innerHTML = '<tr><td colspan="2" style="color:var(--text-dim)">No model data</td></tr>'; return; }
+    if (models.length === 0) { tb.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No model data</td></tr>'; return; }
     tb.innerHTML = models.map(function(m) {
-      return '<tr><td>' + esc(m.model) + '</td><td>€' + (m.cost_eur || 0).toFixed(4) + '</td></tr>';
+      return '<tr><td>' + esc(m.model) + '</td><td>€' + (m.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
+    }).join('');
+  }
+
+  function renderProviders(providers) {
+    var tb = document.getElementById('provider-table');
+    if (providers.length === 0) {
+      tb.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No provider data</td></tr>';
+      return;
+    }
+    tb.innerHTML = providers.map(function(p) {
+      return '<tr><td>' + esc(p.provider) + '</td><td>€' + (p.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
     }).join('');
   }
 
@@ -646,7 +678,7 @@
       var color2 = bs.monthly_percent > 90 ? 'var(--red)' : bs.monthly_percent > 70 ? 'var(--yellow)' : 'var(--green)';
       html += '<div><div style="display:flex;justify-content:space-between;margin-bottom:4px"><span>Monthly</span><span>€' + bs.monthly_used.toFixed(2) + ' / €' + bs.monthly_limit.toFixed(2) + ' (' + bs.monthly_percent.toFixed(1) + '%)</span></div><div class="bar-container"><div class="bar-fill" style="width:' + Math.min(bs.monthly_percent, 100) + '%;background:' + color2 + '"></div></div></div>';
     }
-    document.getElementById('budget-content').innerHTML = html || '<span style="color:var(--text-dim)">No budget limits configured</span>';
+    document.getElementById('budget-content').innerHTML = html || '<span style="color:var(--text-dim)">No budget limits configured. Set caller max_daily_cost/max_monthly_cost in gateway config to enforce hard caps before provider calls.</span>';
   }
 
   function renderCache(cs) {


### PR DESCRIPTION
## Summary
- enforce hard caller daily/monthly caps before provider calls with stable `budget_exceeded` denial reasons, default-policy cap fallback, and denied evidence carrying `estimated_cost` while keeping actual provider cost at zero
- extend cost attribution and exports across CLI/API/dashboard by adding provider-aware aggregation (`CostByProvider`), `talon costs --caller/--by-provider/--json`, `talon costs export`, and `POST /v1/costs/export` joinable to evidence IDs
- improve buyer-facing EMEA SMB UX/docs with provider breakdown and evidence-link affordances in dashboards, updated gateway example config, and a "Cap AI spend for a Slack/support bot in 10 minutes" guide

## Test plan
- [x] `make test`
- [x] `make check`
- [x] `make lint`
- [x] `go test ./internal/cmd ./internal/evidence ./internal/gateway ./internal/metrics ./internal/policy ./internal/server`
- [x] `bash -n tests/smoke_sections/09_cost.sh`
- [x] `bash -n tests/smoke_sections/23_dashboard_metrics.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway policy evaluation, pre-call denial paths, and cost/budget reporting surfaces that operators rely on for spend control; regressions could allow overspend or mis-report caps.
> 
> **Overview**
> This PR tightens **gateway spend governance** and makes **cost attribution auditable** end-to-end.
> 
> **Hard caps before upstream calls:** Caller daily/monthly limits now feed policy input from **server defaults** when per-caller overrides are unset, with **conservative pre-call cost estimation** wired into the gateway. Budget denials use a stable **`budget_exceeded`** machine code in Rego and API errors, return **403 without calling the provider**, and write **signed evidence** with **zero actual cost** plus **`estimated_cost`** on the denied path.
> 
> **Evidence-backed FinOps surfaces:** The evidence store gains **`CostByProvider`**; exports and audit CSV/JSON add **provider**, **tokens**, and **policy_action**. CLI adds **`talon costs --caller`**, **`--by-provider`**, **`--json`**, and **`talon costs export`**; HTTP adds **`POST /v1/costs/export`** (joinable to evidence by ID). Metrics/dashboard expose **`provider_breakdown`** and clearer **evidence vs runtime telemetry** labeling, with smoke tests extended for JSON export and dashboard parity.
> 
> **Buyer docs/examples:** The cost guide is reframed as a **10-minute Slack/support bot cap** walkthrough; the gateway example caller is **`support-slack-bot`** with monthly cap; docs index and gateway-dashboard reference are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d787a903590ed644ad766af15b565ea5cc36c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->