### PR TITLE
chore(release): cut v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+## [1.5.5] - 2026-06-01
+
 ### Added
 
 - **feat(evidence): signed export and offline file verification.** Added `talon audit export --format signed-json|signed-ndjson` and `talon audit verify --file <path>` so operators and compliance teams can verify evidence integrity outside the running instance. This matters for GDPR/NIS2 handoffs where auditors request portable, tamper-evident artifacts. Verify quickly with `talon audit export --format signed-json --output signed.json && talon audit verify --file signed.json`.
@@ -485,7 +487,8 @@ For user-facing entries, include:
 - EU AI Act: risk management, transparency, human oversight (Art. 9, 13, 14).
 - Data residency: tier-based EU model routing.
 
-[Unreleased]: https://github.com/dativo-io/talon/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/dativo-io/talon/compare/v1.5.5...HEAD
+[1.5.5]: https://github.com/dativo-io/talon/compare/v1.5.0...v1.5.5
 [1.5.0]: https://github.com/dativo-io/talon/compare/v1.4.6...v1.5.0
 [1.4.6]: https://github.com/dativo-io/talon/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/dativo-io/talon/compare/v1.4.0...v1.4.5


### PR DESCRIPTION
## Summary

- Promote the `Unreleased` evidence integrity work to a new `## [1.5.5] - 2026-06-01` changelog section: signed export + offline file verification, persistent dashboard evidence integrity UX, and the tamper-proof demo / signed export runbook docs.
- Refresh changelog comparison links (`[Unreleased]` now compares from `v1.5.5`, plus a new `[1.5.5]` link from `v1.5.0`).

Version is derived from git tags via `git describe` / ldflags, so no source version constant changes are required; the `v1.5.5` tag will be cut on `main` after merge.

## Test plan

- [ ] `make build && ./bin/talon version` reports the resolved version
- [ ] Changelog renders with the new 1.5.5 section and valid compare links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and GitHub compare link updates; no runtime, auth, or deployment behavior changes in the diff.
> 
> **Overview**
> **Release bookkeeping only:** adds a dated **`[1.5.5] - 2026-06-01`** section to `CHANGELOG.md` that documents already-shipped work—signed evidence export/offline verify CLI, dashboard evidence integrity states, and evidence integrity docs/runbooks—without changing application code.
> 
> **Link maintenance:** `[Unreleased]` now compares `v1.5.5...HEAD`, and a new `[1.5.5]` compare link points from `v1.5.0` to `v1.5.5`. Version resolution stays tag/`git describe`-driven; no version constant edits in source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8949ef8af1c121f8d5779b30d83ba455cc7d8ce8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->