### PR TITLE
docs(license): use canonical Apache 2.0 text with copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026, Sergiusz Enin
+   Copyright 2026 Sergiusz Enin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Replace `LICENSE` with the canonical Apache License 2.0 text from apache.org
- Fill in the appendix copyright notice: `Copyright 2026 Sergiusz Enin`

The license body is byte-for-byte identical to the canonical Apache source; the only change is the appendix placeholder, which the license itself instructs you to fill in.

## Test plan
- [x] `diff` against `https://www.apache.org/licenses/LICENSE-2.0.txt` shows only the appendix copyright line changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only license text; no runtime, security, or data-handling impact.
> 
> **Overview**
> Aligns the root **`LICENSE`** with the canonical Apache 2.0 text and sets the appendix boilerplate to **`Copyright 2026 Sergiusz Enin`** (removing the comma after the year so the notice matches the standard appendix format).
> 
> This is a legal/documentation-only change; release packaging already ships **`LICENSE`** via Goreleaser and labels images as Apache-2.0—no application behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d61c2fce41efdc61f44ec8b16ec274aa0e411c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->