### PR TITLE
docs(limitations): add explicit boundaries guide

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,58 @@
+# Talon Limitations
+
+This document states what Talon does **not** guarantee today.
+
+Talon is designed to provide governance controls, policy enforcement, and tamper-evident evidence around LLM and MCP traffic. It does **not** replace every security, compliance, or runtime-control layer that a production environment may need.
+
+## Not an OS-level or kernel sandbox
+
+Talon is not a VM, container boundary, kernel sandbox, or host-isolation product.
+
+- It can govern requests that pass through Talon.
+- It does not by itself prevent host-level escape, kernel compromise, or lateral movement on the machine where Talon runs.
+- If you need stronger isolation, run Talon inside the operator's chosen sandboxing or workload-isolation layer.
+
+## Not a full trust mesh or A2A fabric
+
+Talon is not a general trust mesh, service identity plane, or full agent-to-agent coordination system.
+
+- It focuses on governing model and tool traffic at the Talon boundary.
+- It does not by itself establish end-to-end trust between every downstream service, agent, worker, and human approval step in a broader system.
+
+## Tool governance is request filtering today
+
+Today, Talon's tool governance is request-body filtering, not runtime execution interception.
+
+- Talon evaluates requested tool names against allow/forbid policy and removes disallowed tools before forwarding the request.
+- This is useful for preventing the model from seeing or selecting disallowed tools in the governed request path.
+- It does not by itself supervise arbitrary code after a request leaves Talon, intercept tool execution inside another runtime, or guarantee that an external system will not invoke tools through some separate path.
+
+## Evidence signatures prove integrity, not correctness
+
+Talon signs evidence records with HMAC-SHA256 so operators can verify tamper-evidence and export integrity.
+
+- A valid signature shows that the signed record was not modified after Talon wrote it, assuming the signing key remains protected.
+- A signature does **not** prove that Talon's decision was correct, complete, lawful, or appropriate for every environment.
+- A signature also does not prove that upstream or downstream systems behaved correctly outside the signed record.
+
+## Compliance remains the operator's determination
+
+Talon supports controls that operators may use in GDPR, NIS2, DORA, EU AI Act, or similar programs.
+
+- Talon can provide policy enforcement, evidence, routing controls, and audit support.
+- Talon does **not** grant certification, legal sign-off, or guaranteed compliance by itself.
+- Whether a deployment satisfies regulatory, contractual, or internal-policy obligations remains the operator's responsibility.
+
+## Key-management assumptions
+
+Talon's trust properties depend on operator-managed secrets and deployment hygiene.
+
+- If signing keys, provider credentials, or vault material are exposed, Talon's guarantees are weakened accordingly.
+- Evidence integrity depends on protecting the signing key and controlling who can write or export records.
+- Operators are responsible for key rotation, access control, network security, host hardening, backup handling, and environment-specific secret management.
+
+## Scope reminder
+
+Talon is best understood as a governance layer on the request path, not as a complete security or compliance stack.
+
+Use Talon together with the rest of your platform controls when you need stronger isolation, runtime enforcement, or formal compliance determinations.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,14 +1,14 @@
 # Talon Limitations
 
-Talon is a governance layer for LLM and MCP request paths. It can enforce policy, record evidence, and steer routing on the Talon path. It is not a complete security, runtime, or compliance platform.
+Talon governs LLM and MCP traffic that passes through its request path. It can enforce policy, route requests, and record evidence there. It is not a complete security, runtime, or compliance platform.
 
 ## Not a sandbox
 
 Talon is not a VM boundary, container runtime, kernel sandbox, or host-isolation layer.
 
 - It governs requests that pass through Talon.
-- It does not prevent host escape, kernel compromise, or lateral movement on the machine where it runs.
-- If you need execution isolation, add your own workload sandboxing and host hardening.
+- It does not prevent host escape, kernel compromise, or lateral movement on the host where it runs.
+- If you need execution isolation, add separate sandboxing and host hardening.
 
 ## Not a full trust mesh
 
@@ -25,14 +25,14 @@ Today Talon governs tools by filtering request payloads before they go upstream.
 - It removes disallowed tools from the governed request path.
 - It does not intercept tool execution inside another runtime.
 - It does not supervise arbitrary code after a request leaves Talon.
-- It does not stop the same tool from being invoked through a separate path outside Talon.
+- It does not stop the same tool from being invoked on a separate path outside Talon.
 
 ## HMAC signatures prove integrity, not correctness
 
 Talon signs evidence records with HMAC-SHA256.
 
 - A valid signature shows the signed record was not modified after Talon wrote it, assuming the signing key remains protected.
-- It does not prove Talon's decision was correct, complete, lawful, or suitable for every environment.
+- It does not prove Talon's decision was correct, complete, lawful, or right for every environment.
 - It does not prove upstream or downstream systems behaved correctly outside the signed record.
 
 ## Compliance remains the operator's determination

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,47 +1,46 @@
 # Talon Limitations
 
-This document states the main guarantees Talon does not make today.
-
-Talon is a governance layer for LLM and MCP request paths. It adds policy enforcement, evidence records, and routing controls, but it does not replace the rest of a production security, runtime, or compliance stack.
+Talon is a governance layer for LLM and MCP request paths. It can enforce policy, record evidence, and steer routing on the Talon path. It is not a complete security, runtime, or compliance platform.
 
 ## Not a sandbox
 
-Talon is not a VM, container boundary, kernel sandbox, or host-isolation product.
+Talon is not a VM boundary, container runtime, kernel sandbox, or host-isolation layer.
 
 - It governs requests that pass through Talon.
-- It does not prevent host escape, kernel compromise, or lateral movement on the machine where Talon runs.
-- Use your own workload-isolation layer if you need stronger execution isolation.
+- It does not prevent host escape, kernel compromise, or lateral movement on the machine where it runs.
+- If you need execution isolation, add your own workload sandboxing and host hardening.
 
 ## Not a full trust mesh
 
-Talon is not a general trust mesh, service identity plane, or agent-to-agent coordination system.
+Talon is not a general service-identity plane, trust mesh, or agent-to-agent coordination system.
 
-- It governs model and tool traffic at the Talon boundary.
-- It does not establish end-to-end trust across every downstream service, worker, agent, or human approval step in a larger system.
+- It applies controls at the Talon boundary.
+- It does not create end-to-end trust across downstream services, workers, agents, or human approval steps.
 
-## Tool governance stops at request filtering
+## Tool governance is request filtering today
 
-Talon's tool governance currently filters request payloads before forwarding them upstream.
+Today Talon governs tools by filtering request payloads before they go upstream.
 
-- Talon checks requested tool names against allow and forbid policy and removes disallowed tools from the governed request path.
+- It checks requested tool names against allow and forbid policy.
+- It removes disallowed tools from the governed request path.
 - It does not intercept tool execution inside another runtime.
 - It does not supervise arbitrary code after a request leaves Talon.
-- It does not guarantee that another system will not invoke the same tool through a separate path.
+- It does not stop the same tool from being invoked through a separate path outside Talon.
 
-## Evidence signatures prove record integrity, not decision correctness
+## HMAC signatures prove integrity, not correctness
 
 Talon signs evidence records with HMAC-SHA256.
 
 - A valid signature shows the signed record was not modified after Talon wrote it, assuming the signing key remains protected.
-- A signature does not prove Talon's decision was correct, complete, lawful, or appropriate for every environment.
-- A signature does not prove upstream or downstream systems behaved correctly outside the signed record.
+- It does not prove Talon's decision was correct, complete, lawful, or suitable for every environment.
+- It does not prove upstream or downstream systems behaved correctly outside the signed record.
 
-## Compliance remains the operator's responsibility
+## Compliance remains the operator's determination
 
-Talon can support GDPR, NIS2, DORA, EU AI Act, and similar programs with policy enforcement, evidence, and routing controls.
+Talon can provide supporting controls and evidence for GDPR, NIS2, DORA, the EU AI Act, and similar programs.
 
 - It does not grant certification, legal sign-off, or guaranteed compliance by itself.
-- Whether a deployment satisfies regulatory, contractual, or internal-policy obligations remains the operator's responsibility.
+- Whether a deployment satisfies regulatory, contractual, or internal obligations remains the operator's responsibility.
 
 ## Trust depends on operator-managed keys and deployment hygiene
 
@@ -53,4 +52,4 @@ Talon's trust properties depend on operator-managed secrets and deployment contr
 
 ## Scope reminder
 
-Treat Talon as a governance layer on the request path, not a complete security or compliance platform.
+Treat Talon as a governance layer on the request path, not as a complete security or compliance stack.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,58 +1,56 @@
 # Talon Limitations
 
-This document states what Talon does **not** guarantee today.
+This document states the main guarantees Talon does not make today.
 
-Talon is designed to provide governance controls, policy enforcement, and tamper-evident evidence around LLM and MCP traffic. It does **not** replace every security, compliance, or runtime-control layer that a production environment may need.
+Talon is a governance layer for LLM and MCP request paths. It adds policy enforcement, evidence records, and routing controls, but it does not replace the rest of a production security, runtime, or compliance stack.
 
-## Not an OS-level or kernel sandbox
+## Not a sandbox
 
 Talon is not a VM, container boundary, kernel sandbox, or host-isolation product.
 
-- It can govern requests that pass through Talon.
-- It does not by itself prevent host-level escape, kernel compromise, or lateral movement on the machine where Talon runs.
-- If you need stronger isolation, run Talon inside the operator's chosen sandboxing or workload-isolation layer.
+- It governs requests that pass through Talon.
+- It does not prevent host escape, kernel compromise, or lateral movement on the machine where Talon runs.
+- Use your own workload-isolation layer if you need stronger execution isolation.
 
-## Not a full trust mesh or A2A fabric
+## Not a full trust mesh
 
-Talon is not a general trust mesh, service identity plane, or full agent-to-agent coordination system.
+Talon is not a general trust mesh, service identity plane, or agent-to-agent coordination system.
 
-- It focuses on governing model and tool traffic at the Talon boundary.
-- It does not by itself establish end-to-end trust between every downstream service, agent, worker, and human approval step in a broader system.
+- It governs model and tool traffic at the Talon boundary.
+- It does not establish end-to-end trust across every downstream service, worker, agent, or human approval step in a larger system.
 
-## Tool governance is request filtering today
+## Tool governance stops at request filtering
 
-Today, Talon's tool governance is request-body filtering, not runtime execution interception.
+Talon's tool governance currently filters request payloads before forwarding them upstream.
 
-- Talon evaluates requested tool names against allow/forbid policy and removes disallowed tools before forwarding the request.
-- This is useful for preventing the model from seeing or selecting disallowed tools in the governed request path.
-- It does not by itself supervise arbitrary code after a request leaves Talon, intercept tool execution inside another runtime, or guarantee that an external system will not invoke tools through some separate path.
+- Talon checks requested tool names against allow and forbid policy and removes disallowed tools from the governed request path.
+- It does not intercept tool execution inside another runtime.
+- It does not supervise arbitrary code after a request leaves Talon.
+- It does not guarantee that another system will not invoke the same tool through a separate path.
 
-## Evidence signatures prove integrity, not correctness
+## Evidence signatures prove record integrity, not decision correctness
 
-Talon signs evidence records with HMAC-SHA256 so operators can verify tamper-evidence and export integrity.
+Talon signs evidence records with HMAC-SHA256.
 
-- A valid signature shows that the signed record was not modified after Talon wrote it, assuming the signing key remains protected.
-- A signature does **not** prove that Talon's decision was correct, complete, lawful, or appropriate for every environment.
-- A signature also does not prove that upstream or downstream systems behaved correctly outside the signed record.
+- A valid signature shows the signed record was not modified after Talon wrote it, assuming the signing key remains protected.
+- A signature does not prove Talon's decision was correct, complete, lawful, or appropriate for every environment.
+- A signature does not prove upstream or downstream systems behaved correctly outside the signed record.
 
-## Compliance remains the operator's determination
+## Compliance remains the operator's responsibility
 
-Talon supports controls that operators may use in GDPR, NIS2, DORA, EU AI Act, or similar programs.
+Talon can support GDPR, NIS2, DORA, EU AI Act, and similar programs with policy enforcement, evidence, and routing controls.
 
-- Talon can provide policy enforcement, evidence, routing controls, and audit support.
-- Talon does **not** grant certification, legal sign-off, or guaranteed compliance by itself.
+- It does not grant certification, legal sign-off, or guaranteed compliance by itself.
 - Whether a deployment satisfies regulatory, contractual, or internal-policy obligations remains the operator's responsibility.
 
-## Key-management assumptions
+## Trust depends on operator-managed keys and deployment hygiene
 
-Talon's trust properties depend on operator-managed secrets and deployment hygiene.
+Talon's trust properties depend on operator-managed secrets and deployment controls.
 
-- If signing keys, provider credentials, or vault material are exposed, Talon's guarantees are weakened accordingly.
+- If signing keys, provider credentials, or vault material are exposed, Talon's guarantees weaken accordingly.
 - Evidence integrity depends on protecting the signing key and controlling who can write or export records.
-- Operators are responsible for key rotation, access control, network security, host hardening, backup handling, and environment-specific secret management.
+- Operators remain responsible for key rotation, access control, host hardening, network security, backup handling, and environment-specific secret management.
 
 ## Scope reminder
 
-Talon is best understood as a governance layer on the request path, not as a complete security or compliance stack.
-
-Use Talon together with the rest of your platform controls when you need stronger isolation, runtime enforcement, or formal compliance determinations.
+Treat Talon as a governance layer on the request path, not a complete security or compliance platform.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 [Docs](docs/README.md) ·
+[Limitations](LIMITATIONS.md) ·
 [Quickstart](docs/tutorials/proxy-quickstart.md) ·
 [Docker demo](examples/docker-compose/README.md) ·
 [Dashboard](docs/reference/gateway-dashboard.md) ·


### PR DESCRIPTION
Fixes #117.

## Summary
- add a root `LIMITATIONS.md` that states Talon's current non-claims in plain language
- cover the boundaries called out in the issue: sandboxing, trust mesh scope, tool governance maturity, HMAC signature semantics, compliance responsibility, and key-management assumptions
- link the new guide from the top of `README.md`

## Validation
- `npx --yes markdown-link-check@3.12.2 README.md LIMITATIONS.md -c .github/mlc_config.json`
- `make check` could not complete in this environment because `golangci-lint` is not installed locally (`make: golangci-lint: No such file or directory`)
