### PR TITLE
docs: add buyer-trust LIMITATIONS.md (#117)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,52 @@
+# Limitations
+
+Talon provides policy enforcement, routing controls, PII handling, and signed evidence records for AI gateway traffic. It does not determine legal compliance for an operator, and it does not prove that a downstream model, tool, or human decision was correct.
+
+This page maps where Talon's claims stop. It applies to the network gateway / proxy path that every request flows through.
+
+## Capability status
+
+| Status | Capabilities |
+|--------|--------------|
+| **Available now** | OpenAI-compatible proxy governance; input and output PII scanning; OPA policy allow/deny decisions; HMAC-signed evidence records; `talon audit verify` |
+| **Partial today** | EU routing and data sovereignty in the gateway path: a non-compliant route is **denied with signed evidence**, not silently re-routed across providers ([`internal/llm/router.go`](internal/llm/router.go) plus the proxy path). The gateway proxy and the `talon run` router can differ on routing behavior. |
+| **Roadmap** | Runtime tool **execution** interception via the MCP proxy; a filled-in auditor RoPA / EU AI Act Annex IV pack; broader trust mesh / A2A (currently an anti-goal) |
+
+## Compliance boundary
+
+- Talon provides supporting controls and evidence — for example, framework-mapped reports via `talon compliance report`. A report is a control-mapping summary, not a completed legal filing.
+- The operator remains responsible for the legal and compliance determination.
+- We use "supports evidence for GDPR Art. X" style wording, never "GDPR compliant" or "makes you compliant" (see article mappings in [`internal/compliance/mapping.go`](internal/compliance/mapping.go)).
+- PII detection is regex- and heuristic-based. It supports GDPR Art. 32-style controls but does not guarantee complete recall.
+
+## Evidence boundary
+
+A valid signature proves that this evidence record was signed with the deployment's configured key and has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
+
+- Verify a record with `talon audit verify <id>` or `talon audit verify --file <export>` — see [evidence store](docs/explanation/evidence-store.md).
+- The signature covers the canonical JSON of the stored fields ([`VerifyRecord`](internal/evidence/store.go)). It is not instance attestation, and it does not vouch for upstream provider behavior.
+
+## Tool-governance boundary
+
+- Today, forbidden tools are stripped from request bodies before forwarding ([`internal/gateway/tool_filter.go`](internal/gateway/tool_filter.go)); the README "pre-execution filter" wording reflects this.
+- Not yet: runtime execution interception or per-execution MCP tool-call governance with a signed deny.
+- "Tool governance: Yes" in the README comparison means request-body filtering today, not runtime execution control.
+
+## Isolation boundary
+
+- Talon is not an OS or kernel sandbox, and does not ship a gVisor or Kubernetes-operator isolation layer (see [anti-goals](internal_docs/talon-2/06-roadmap-anti-goals-risks.md)).
+- It applies process-level controls inside a single binary; host hardening remains the operator's responsibility.
+- LLM and MCP providers and any external tools are separate trust boundaries. Talon does not secure vendor infrastructure.
+
+## Deployment and key-management assumptions
+
+- Custody, rotation, and backup of `TALON_SIGNING_KEY` are operator responsibilities ([`NewSigner`](internal/evidence/signature.go) requires a key of at least 32 bytes).
+- Provider registry and EU routing claims depend on accurate configuration (`.talon.yaml` and gateway config).
+- Air-gapped deployment and an auditor-grade export pack are roadmap items unless explicitly documented as live.
+- When Talon sits on the critical path, availability and failover are not yet claimed as production-grade.
+
+## Further reading
+
+- [SECURITY.md](SECURITY.md) — security boundaries and threat-model snapshot
+- [Evidence store](docs/explanation/evidence-store.md) — how records are created, signed, and verified
+- A formal threat model, an evidence integrity specification, and reproducible benchmarks are forthcoming.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 [Docs](docs/README.md) ·
+[Limitations](LIMITATIONS.md) ·
 [Quickstart](docs/tutorials/proxy-quickstart.md) ·
 [Docker demo](examples/docker-compose/README.md) ·
 [Dashboard](docs/reference/gateway-dashboard.md) ·


### PR DESCRIPTION
## Summary

Adds a short, buyer-trust `LIMITATIONS.md` at the repo root that maps where Talon's README claims stop, and links it from the README nav row so the boundaries are visible rather than buried in the docs index.

- Opening boundary paragraph: Talon provides policy enforcement, routing, PII handling, and signed evidence; it does not determine legal compliance or prove a downstream model/tool/human decision was correct.
- Capability status table aligned with the north-star demo (#107): Available now / Partial today / Roadmap, so `[~]` demo items are not read as GA.
- Five concise boundary sections (2-3 bullets each): compliance, evidence, tool governance, isolation, deployment/key management.
- The evidence section keeps the narrow signature claim (integrity and tamper-evidence, not correctness). The compliance section uses "supports evidence for <article>" wording, reinforcing the claim-discipline pass (#122).

Claims are cross-checked against the implementation: `internal/evidence/signature.go` (HMAC key requirements), `internal/evidence/store.go` (`VerifyRecord`), `internal/gateway/tool_filter.go` (request-body filtering today), and `internal/compliance/mapping.go` (article mappings).

Closes #117. Reinforces #122 wording; the full public-docs audit, CONTRIBUTING claims line, and CI banned-phrase guard remain in #122's scope.

## Test plan

- [ ] Markdown link check (CI Docs workflow) passes; README's new `Limitations` link resolves.
- [ ] Manually confirmed every path referenced in `LIMITATIONS.md` exists.
- [ ] Render `LIMITATIONS.md` on GitHub and confirm the status table and section anchors display correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds a root-level **LIMITATIONS.md** that states what Talon does *not* claim (legal compliance, correctness of model/tool/human outcomes) and scopes claims to the gateway/proxy path.
> 
> The new page includes a **capability status** table (available / partial / roadmap), plus short boundaries for compliance wording, evidence signatures, tool governance (request-body filtering vs runtime MCP execution), isolation, and deployment/signing-key assumptions, with links into existing docs and implementation paths.
> 
> The **README** nav row gains a **Limitations** link so buyers see these boundaries without digging through the docs index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deabb0726b864bc6f6badbbd0fd362656ff52465. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->