### PR TITLE
docs: add buyer-trust LIMITATIONS.md (#117)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,54 @@
+# Limitations
+
+Talon provides policy enforcement, routing controls, PII handling, and signed evidence records for AI gateway traffic. It does not determine legal compliance for an operator, and it does not prove that a downstream model, tool, or human decision was correct.
+
+This page states plainly where Talon's claims stop. It applies to the network gateway / proxy path that every request flows through.
+
+## Capability status
+
+| Status | Capabilities |
+|--------|--------------|
+| **Available now** | OpenAI-compatible proxy governance; input and output PII scanning; OPA policy allow/deny decisions; HMAC-signed evidence records; `talon audit verify` |
+| **Partial today** | EU routing and data sovereignty in the gateway path: a non-compliant route is **denied with signed evidence**, not silently re-routed across providers ([`internal/llm/router.go`](internal/llm/router.go)). The gateway proxy and the `talon run` router can differ on routing behavior. |
+| **Roadmap** | Runtime tool **execution** interception via the MCP proxy; a filled-in auditor RoPA / EU AI Act Annex IV pack; broader trust mesh / agent-to-agent governance |
+
+This table is the source of truth for capability claims. If a demo or doc describes a "partial" item, it should not be presented as generally available.
+
+## Compliance boundary
+
+- Talon provides supporting controls and evidence — for example, framework-mapped reports via `talon compliance report`. A report is a control-mapping summary, not a completed legal filing.
+- The operator remains responsible for the legal and compliance determination.
+- We use "supports evidence for GDPR Art. X" style wording, never "GDPR compliant" or "makes you compliant" (the built-in article mappings live in [`internal/compliance/mapping.go`](internal/compliance/mapping.go)).
+- PII detection is regex- and heuristic-based. It supports GDPR Art. 32-style controls but does not guarantee complete recall.
+
+## Evidence boundary
+
+A valid signature proves that this evidence record was signed with the deployment's configured key and has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
+
+- Verify a record with `talon audit verify <id>` or `talon audit verify --file <export>` — see [evidence store](docs/explanation/evidence-store.md).
+- The signature covers the canonical JSON of the stored fields ([`VerifyRecord`](internal/evidence/store.go)). It is not instance attestation, and it does not vouch for upstream provider behavior.
+
+## Tool-governance boundary
+
+- Today, forbidden tools are stripped from request bodies before forwarding ([`internal/gateway/tool_filter.go`](internal/gateway/tool_filter.go)); the README "pre-execution filter" wording reflects this.
+- Not yet: runtime execution interception or per-execution MCP tool-call governance with a signed deny.
+- "Tool governance: Yes" in the README comparison means request-body filtering today, not runtime execution control.
+
+## Isolation boundary
+
+- Talon applies process-level controls inside a single binary. It is not an OS or kernel sandbox, and it does not ship a gVisor, Kubernetes-operator, or container-escape isolation layer — these are deliberate non-goals for the current scope.
+- Host hardening remains the operator's responsibility.
+- LLM and MCP providers and any external tools are separate trust boundaries. Talon does not secure vendor infrastructure.
+
+## Deployment and key-management assumptions
+
+- Custody, rotation, and backup of `TALON_SIGNING_KEY` are operator responsibilities ([`NewSigner`](internal/evidence/signature.go) requires a key of at least 32 bytes).
+- Provider registry and EU routing claims depend on accurate configuration (`.talon.yaml` and gateway config).
+- Air-gapped deployment and an auditor-grade export pack are roadmap items unless explicitly documented as live.
+- When Talon sits on the critical path, availability and failover are not yet claimed as production-grade.
+
+## Further reading
+
+- [SECURITY.md](SECURITY.md) — security boundaries and threat-model snapshot
+- [Evidence store](docs/explanation/evidence-store.md) — how records are created, signed, and verified
+- A formal threat model, an evidence integrity specification, and reproducible benchmarks are forthcoming.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 [Docs](docs/README.md) ·
+[Limitations](LIMITATIONS.md) ·
 [Quickstart](docs/tutorials/proxy-quickstart.md) ·
 [Docker demo](examples/docker-compose/README.md) ·
 [Dashboard](docs/reference/gateway-dashboard.md) ·


### PR DESCRIPTION
## Summary

Re-adds `LIMITATIONS.md` (after the #156 -> #157 revert), this time with **no `internal_docs/` references** — the reason the first attempt was reverted.

- Public, buyer-facing page: links only to public artifacts (Go source files, `SECURITY.md`, `docs/explanation/evidence-store.md`).
- Anti-goals (no OS/kernel sandbox, no gVisor/k8s-operator isolation, no full trust mesh/A2A) are stated **inline**, not linked to internal strategy notes.
- One-line boundary opener + capability status table (Available now / Partial today / Roadmap) + five concise boundary sections: compliance, evidence, tool governance, isolation, deployment/key management.
- Evidence section keeps the narrow signature claim (integrity and tamper-evidence, not correctness). Compliance section uses "supports evidence for <article>" wording.
- Linked from the README nav row so the boundaries are visible, not buried.

Claims are cross-checked against the implementation: `internal/evidence/signature.go`, `internal/evidence/store.go` (`VerifyRecord`), `internal/gateway/tool_filter.go`, `internal/compliance/mapping.go`.

Closes #117.

## Test plan

- [ ] `grep -r internal_docs LIMITATIONS.md` returns nothing (verified locally).
- [ ] Every linked path in `LIMITATIONS.md` resolves (verified locally).
- [ ] Markdown Quality / link check passes; README's `Limitations` link resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change clarifying marketing and legal boundaries; no runtime or security behavior changes.
> 
> **Overview**
> Adds a public **`LIMITATIONS.md`** that defines where Talon’s product claims end: a capability table (available / partial / roadmap) and short boundaries for compliance, evidence signatures, tool filtering vs runtime MCP control, process-level isolation, and operator key/config duties. Links point only at public docs and source paths (no `internal_docs`).
> 
> The **README** nav gains a **Limitations** link so buyers see these boundaries next to Docs and Quickstart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca15e83911e6a622c087538a721c695cf509368. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->