### PR TITLE
docs: compliance-claim discipline pass (#122)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,4 +23,7 @@ jobs:
           config-file: '.github/mlc_config.json'
           use-quiet-mode: 'yes'
           folder-path: 'docs/,examples/'
-          file-path: 'README.md,CONTRIBUTING.md,CHANGELOG.md'
+          file-path: 'README.md,CONTRIBUTING.md,CHANGELOG.md,LIMITATIONS.md'
+
+      - name: Compliance-claim discipline
+        run: bash scripts/check-claim-discipline.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,14 @@ Thanks for helping improve Talon.
 
 - Keep behavior changes accompanied by tests.
 - Prefer clear, verifiable claims in docs (commands, source links, or test references).
-- For compliance wording, use "supports controls" language; do not claim guaranteed compliance.
+
+### Compliance-claim discipline (required)
+
+EU buyers distrust overclaiming, so every compliance reference must be under-claimed:
+
+- **Always** phrase as "supporting controls / evidence for `<regulation/article>`" and pair a feature with the article it supports (e.g. "output PII scan → supporting control for GDPR Art. 32").
+- **Never** claim a compliance *outcome*: avoid "GDPR compliant", "makes you compliant", "ensures/guarantees compliance", or "X to compliant". The operator remains responsible for the legal determination.
+- See [LIMITATIONS.md](LIMITATIONS.md) for the compliance boundary and [`internal/compliance/mapping.go`](internal/compliance/mapping.go) for the built-in article mappings.
 
 ## Testing
 

--- a/docs/ADOPTION_SCENARIOS.md
+++ b/docs/ADOPTION_SCENARIOS.md
@@ -1,6 +1,6 @@
 # Dativo Talon — Adoption Scenarios
 
-**Three Paths to Compliant AI Automation**
+**Three Paths to Governed AI Automation**
 
 ---
 
@@ -102,7 +102,7 @@ compliance:
 ### Profile
 - **Company:** Spanish eSIM provider, 150 employees
 - **Use Case:** Custom Slack bot for Tier 1 support (built 6 months ago)
-- **Current State:** Python bot calling OpenAI, works great but not compliant
+- **Current State:** Python bot calling OpenAI, works great but ungoverned (no audit trail, no PII controls)
 - **Compliance:** GDPR + NIS2 audit in 3 months
 
 ### Current Architecture (Before Talon)
@@ -123,7 +123,7 @@ Dev Lead: "I can't tell you. We didn't log that."
 Compliance Officer: "We have 3 months until NIS2 audit. Fix this or shut it down."
 ```
 
-### Timeline: 1 Day to Compliant
+### Timeline: 1 Day to Governed
 
 #### Morning (2 hours): Add Talon Governance
 
@@ -217,9 +217,9 @@ talon audit export \
 
 **Result:**
 - ✅ Slack bot still works (same UX for support team)
-- ✅ Now GDPR + NIS2 compliant (audit trail + PII redaction)
+- ✅ Now has supporting controls and evidence for GDPR + NIS2 (audit trail + PII redaction)
 - ✅ No rewrite needed (5 lines of code changed)
-- ✅ Can prove compliance to auditors
+- ✅ Can show auditors evidence of the governance controls in place
 
 **Total Effort:** 4 hours (0.5 person-days)
 
@@ -262,7 +262,7 @@ IT Lead: "No, that's in their logs. We don't have access."
 Compliance Officer: "We're the data controller. We're liable. This is unacceptable."
 ```
 
-### Timeline: 1 Week to Compliant
+### Timeline: 1 Week to Governed
 
 #### Week 1, Day 1-2: Shadow Mode Validation (4 hours)
 

--- a/docs/VENDOR_INTEGRATION_GUIDE.md
+++ b/docs/VENDOR_INTEGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Dativo Talon — Vendor Integration Guide
 
-**Making Third-Party AI Vendors Compliant**
+**Governing Third-Party AI Vendors**
 
 ---
 
@@ -707,4 +707,4 @@ curl -X POST https://talon.your-company.local/tools/call \
 - **Community Slack:** https://dativo-community.slack.com
 - **Enterprise Support:** enterprise@dativo.com
 
-**Remember:** The goal isn't to replace your vendors — it's to make them compliant. Talon adds the governance layer vendors can't provide.
+**Remember:** The goal isn't to replace your vendors — it's to govern them and generate your own evidence. Talon adds the governance and audit layer vendors can't provide; the compliance determination stays with you as the data controller.

--- a/internal/cache/README.md
+++ b/internal/cache/README.md
@@ -1,6 +1,6 @@
 # Governed Semantic Cache
 
-This package implements Talon's semantic cache for LLM completions: cost and latency optimization by serving similar prompts from cache instead of calling the LLM. The cache is **GDPR Article 17 compliant**, PII-safe, tenant-isolated, and auditable.
+This package implements Talon's semantic cache for LLM completions: cost and latency optimization by serving similar prompts from cache instead of calling the LLM. The cache **supports GDPR Article 17 controls** (erasure), is PII-safe, tenant-isolated, and auditable.
 
 ## Cache vs memory (clarification)
 

--- a/internal/pack/wizard.go
+++ b/internal/pack/wizard.go
@@ -94,7 +94,7 @@ var builtinPacks = []PackDescriptor{
 		// Flowise pack deferred to post-v0.2 (requires conversation-level interception).
 		ID:          "flowise",
 		DisplayName: "Flowise",
-		Description: "Conversation audit — GDPR-compliant chat history governance",
+		Description: "Conversation audit — chat history governance with supporting controls for GDPR",
 		Order:       30,
 		Hidden:      true,
 	},

--- a/scripts/check-claim-discipline.sh
+++ b/scripts/check-claim-discipline.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# check-claim-discipline.sh
+#
+# Fails if any public doc claims a compliance *outcome* instead of
+# "supporting controls / evidence for <article>". See CONTRIBUTING.md
+# ("Compliance-claim discipline") and LIMITATIONS.md.
+#
+# Scope: README.md, docs/**, examples/**, and other root *.md files.
+# Excluded: internal_docs/ (internal strategy notes), and the two files
+# that intentionally quote the banned phrases as negative examples
+# (LIMITATIONS.md, CONTRIBUTING.md).
+#
+# Usage: scripts/check-claim-discipline.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Outcome-guaranteeing phrases that must never appear in public docs.
+# Deliberately narrow: a bare "<vendor> is GDPR compliant" inside quoted
+# dialogue is allowed; only operator-facing outcome guarantees are banned.
+PATTERN='makes? (you|your|them|it)[^.]{0,40}compliant'
+PATTERN+='|(ensures?|guarantees?)[^.]{0,25}(compliance|gdpr|nis2|dora|iso ?27001|ai act)'
+PATTERN+='|compliance (is )?guaranteed'
+PATTERN+='|fully compliant'
+PATTERN+='|100% compliant'
+PATTERN+='|[0-9]+ (hours?|days?|weeks?) to compliant'
+PATTERN+='| to compliant\b'
+
+# Build the list of files to scan (newline-delimited), excluding the two
+# files that intentionally quote the banned phrases as negative examples.
+file_list=$(
+  {
+    [ -f README.md ] && echo README.md
+    find docs examples -type f -name '*.md' 2>/dev/null || true
+    find . -maxdepth 1 -type f -name '*.md' 2>/dev/null || true
+  } | sed 's#^\./##' | sort -u | grep -vxE '(LIMITATIONS|CONTRIBUTING)\.md' || true
+)
+
+if [ -z "$file_list" ]; then
+  echo "check-claim-discipline: no files to scan"
+  exit 0
+fi
+
+if matches=$(printf '%s\n' "$file_list" | tr '\n' '\0' | xargs -0 grep -niE "$PATTERN" 2>/dev/null); then
+  echo "ERROR: compliance-claim discipline violation(s) found." >&2
+  echo "Use 'supporting controls / evidence for <article>' wording instead." >&2
+  echo "See CONTRIBUTING.md (Compliance-claim discipline) and LIMITATIONS.md." >&2
+  echo >&2
+  echo "$matches" >&2
+  exit 1
+fi
+
+echo "check-claim-discipline: no compliance-outcome claims found in public docs"


### PR DESCRIPTION
## Summary

Compliance-claim discipline pass (proof-bar area 4), now unblocked by the merged `LIMITATIONS.md` (#117). Removes compliance-*outcome* language from public docs and enforces the rule going forward.

**Style rule + policy**
- Adds a "Compliance-claim discipline (required)" section to `CONTRIBUTING.md`: always "supporting controls / evidence for `<article>`", never "GDPR compliant" / "makes you compliant" / "ensures/guarantees compliance". Links to `LIMITATIONS.md` and `internal/compliance/mapping.go`.

**Docs audit (outcome language -> supporting-controls language)**
- `docs/ADOPTION_SCENARIOS.md`: "Compliant" framing -> "Governed"; "now GDPR + NIS2 compliant" -> "has supporting controls and evidence for GDPR + NIS2"; "prove compliance" -> "show auditors evidence".
- `docs/VENDOR_INTEGRATION_GUIDE.md`: title "Making Vendors Compliant" -> "Governing Vendors"; closing line no longer claims Talon "makes them compliant" and notes the determination stays with the data controller.
- `internal/cache/README.md`: "GDPR Article 17 compliant" -> "supports GDPR Article 17 controls".
- `internal/pack/wizard.go`: pack description "GDPR-compliant" -> "supporting controls for GDPR".

Quoted compliance-officer / vendor dialogue is intentionally kept — it reinforces the skeptical-buyer message and is not a Talon claim. Provider metadata fields named `GDPRCompliant` (self-declared, "verified only") are left as-is.

**CI guard (optional per issue, included)**
- `scripts/check-claim-discipline.sh` fails on outcome phrases ("makes you compliant", "guarantees compliance", "fully compliant", "N days to compliant", ...). Wired into the Docs workflow. Excludes `LIMITATIONS.md` / `CONTRIBUTING.md`, which quote the banned phrases as negative examples.
- Also added `LIMITATIONS.md` to the markdown link-check scope.

Closes #122.

## Test plan

- [x] `bash scripts/check-claim-discipline.sh` passes on the current tree.
- [x] Guard regex catches "makes you compliant" / "N days to Compliant" / "fully compliant" / "guarantees GDPR compliance" and allows quoted dialogue + "supporting controls for GDPR Art. 32".
- [x] `go build ./internal/pack/...` succeeds.
- [ ] Docs workflow (link check + claim guard) passes in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contributor guidelines only, plus a non-runtime docs CI script; no product behavior or security paths change.
> 
> **Overview**
> This PR tightens **compliance-claim discipline** across public-facing material: docs and copy must describe **supporting controls / evidence** for specific articles, not compliance outcomes.
> 
> **Contributor policy:** `CONTRIBUTING.md` adds a required section (always pair features with articles; never "GDPR compliant" / "makes you compliant" / guarantees). It points to `LIMITATIONS.md` and `internal/compliance/mapping.go`.
> 
> **Wording pass:** Adoption and vendor guides reframe "compliant" paths as **governed**, describe post-Talon state as controls + evidence (not "now compliant"), and clarify the data controller owns the legal determination. `internal/cache/README.md` and the hidden Flowise pack string in `internal/pack/wizard.go` drop outcome-style GDPR claims.
> 
> **CI enforcement:** New `scripts/check-claim-discipline.sh` greps public markdown for banned outcome phrases (with exclusions for `LIMITATIONS.md` / `CONTRIBUTING.md` negative examples). The Docs workflow runs it and adds `LIMITATIONS.md` to markdown link-check `file-path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4adcf493049529c680b0022d5f006336b603b19f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->