### PR TITLE
docs: add evidence integrity specification (#121)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -51,4 +51,5 @@ A valid signature proves that this evidence record was signed with the deploymen
 
 - [SECURITY.md](SECURITY.md) — security boundaries and threat-model snapshot
 - [Evidence store](docs/explanation/evidence-store.md) — how records are created, signed, and verified
-- A formal threat model, an evidence integrity specification, and reproducible benchmarks are forthcoming.
+- [Evidence integrity specification](docs/reference/evidence-integrity-spec.md) — byte-exact fields, serialization, signing, and independent verification
+- A formal threat model and reproducible benchmarks are forthcoming.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ Choose the shortest path for your situation:
 | Doc | Description |
 |-----|-------------|
 | [Configuration and environment](reference/configuration.md) | Environment variables, crypto keys, and config reference. |
+| [Evidence integrity specification](reference/evidence-integrity-spec.md) | Normative signed-record spec: fields, canonical serialization, HMAC-SHA256 signing, and the independent verification procedure. |
 | [Authentication and key scopes](reference/authentication-and-key-scopes.md) | Which keys authenticate which endpoint families (gateway vs control plane vs dashboard). |
 | [Gateway dashboard](reference/gateway-dashboard.md) | Dashboard endpoints, metrics API schema, snapshot fields, and authentication. |
 | [Operational control plane](reference/operational-control-plane.md) | Run management (list/kill/pause/resume), tenant lockdown, runtime overrides, tool approval gates. |
@@ -93,6 +94,7 @@ Choose the shortest path for your situation:
 | [What Talon does to your request](explanation/what-talon-does-to-your-request.md) | Pipeline, latency, threat boundaries, and reproducible checks. |
 | [Why not just a PII proxy?](explanation/why-not-a-pii-proxy.md) | Control-plane vs scrubber differentiation with proof commands. |
 | [Evidence store](explanation/evidence-store.md) | HMAC integrity model and verification flow. |
+| [Evidence integrity specification](reference/evidence-integrity-spec.md) | Byte-exact spec so a third party can independently verify a record. |
 | [Evidence integrity 5-minute proof](tutorials/evidence-integrity-demo.md) | Fast proof moment for auditors/operators, including offline signed-export verification. |
 | [Security policy](../SECURITY.md) | Vulnerability reporting process and security scope. |
 | [Docker Compose demo](../examples/docker-compose/README.md) | Fastest no-key proof loop. |

--- a/docs/explanation/evidence-store.md
+++ b/docs/explanation/evidence-store.md
@@ -80,9 +80,13 @@ talon audit verify --file march-signed-evidence.json
 The file verifier reports total/valid/invalid/malformed/unsupported counts and exits non-zero if any record is invalid or unverifiable.
 
 **What this proves:** The signing key never leaves the server. If the signature
-is valid, the record has not been modified since Talon created it. This provides
-ISO 27001 A.8.15 compliance (tamper-proof logging) without requiring external
-infrastructure like a blockchain or append-only storage.
+is valid, the record has not been modified since Talon created it. This is a
+supporting control for ISO 27001 A.8.15 (tamper-evident logging) without requiring
+external infrastructure like a blockchain or append-only storage.
+
+For the byte-exact field list, canonical serialization, and signing/verification
+procedure — written so a third party can verify a record independently — see the
+[Evidence integrity specification](../reference/evidence-integrity-spec.md).
 
 ## Progressive Disclosure
 

--- a/docs/reference/evidence-integrity-spec.md
+++ b/docs/reference/evidence-integrity-spec.md
@@ -1,0 +1,217 @@
+# Evidence Integrity Specification
+
+**Status:** stable · **Version:** 1.0 · **Scope:** the signed evidence record produced by Talon.
+
+This is the normative specification for how a Talon evidence record is serialized,
+signed, and verified. It is written so that a third party can independently verify a
+Talon record — or reproduce a signature — from this document alone, without reading the
+Go source.
+
+The normative source of the record shape is the `Evidence` struct in
+[`internal/evidence/store.go`](../../internal/evidence/store.go); the signing and
+verification primitives are in
+[`internal/evidence/signature.go`](../../internal/evidence/signature.go). Where this
+document and the source disagree, the source is authoritative — please file an issue so
+the spec can be corrected.
+
+> **Integrity, not correctness.** A valid signature proves that the record was signed
+> with the deployment's configured key and has not been modified since signing. It does
+> **not** prove that the policy decision, model response, tool result, or operator
+> configuration was correct. See [LIMITATIONS.md](../../LIMITATIONS.md).
+
+## 1. Overview
+
+```
+record (signature = "")  ──serialize──▶  canonical bytes  ──HMAC-SHA256(key)──▶  mac
+                                                                                  │
+                                              signature = "hmac-sha256:" + hex(mac)
+```
+
+Signing happens once, at record creation (`Store.Store` in
+[`internal/evidence/store.go`](../../internal/evidence/store.go)). Verification recomputes
+the signature from the stored record and compares it in constant time
+(`Store.VerifyRecord`). The signing key never leaves the operator's deployment.
+
+## 2. Record fields
+
+A record is a single JSON object. Every field listed below is covered by the signature.
+Fields marked **always** are always present; fields marked **optional** are omitted when
+they hold their zero value (see [§3.3](#33-omitempty-rules)).
+
+Top-level fields, **in serialization order** (this order is significant — see
+[§3.2](#32-field-order)):
+
+| # | JSON key | Type | Presence |
+|---|----------|------|----------|
+| 1 | `id` | string | always |
+| 2 | `correlation_id` | string | always |
+| 3 | `session_id` | string | optional |
+| 4 | `stage` | string | optional |
+| 5 | `candidate_index` | number | optional |
+| 6 | `judge_score` | number | optional |
+| 7 | `selected` | bool | optional |
+| 8 | `timestamp` | string (RFC 3339) | always |
+| 9 | `tenant_id` | string | always |
+| 10 | `agent_id` | string | always |
+| 11 | `team` | string | optional |
+| 12 | `invocation_type` | string | always |
+| 13 | `request_source_id` | string | optional |
+| 14 | `policy_decision` | object | always |
+| 15 | `classification` | object | always |
+| 16 | `attachment_scan` | object | optional |
+| 17 | `tool_governance` | object | optional |
+| 18 | `execution` | object | always |
+| 19 | `model_routing_rationale` | string | optional |
+| 20 | `secrets_accessed` | array(string) | optional |
+| 21 | `upstream_auth_mode` | string | optional |
+| 22 | `upstream_key_source` | string | optional |
+| 23 | `upstream_key_fingerprint` | string | optional |
+| 24 | `gateway_annotations` | array(string) | optional |
+| 25 | `memory_writes` | array(object) | optional |
+| 26 | `memory_reads` | array(object) | optional |
+| 27 | `audit_trail` | object | always |
+| 28 | `compliance` | object | always |
+| 29 | `agent_reasoning` | string | optional |
+| 30 | `agent_verified` | bool | optional |
+| 31 | `observation_mode_override` | bool | optional |
+| 32 | `shadow_violations` | array(object) | optional |
+| 33 | `status` | string | optional |
+| 34 | `failure_reason` | string | optional |
+| 35 | `signature` | string | always |
+| 36 | `routing_decision` | object | optional |
+| 37 | `cache_hit` | bool | optional |
+| 38 | `cache_entry_id` | string | optional |
+| 39 | `cache_similarity` | number | optional |
+| 40 | `cost_saved` | number | optional |
+| 41 | `plan_review` | object | optional |
+| 42 | `retry_attempt` | string | optional |
+| 43 | `explanations` | array(object) | optional |
+| 44 | `plan_id` | string | optional |
+| 45 | `graph_run_id` | string | optional |
+
+Nested objects (`policy_decision`, `classification`, `execution`, `audit_trail`,
+`compliance`, and the optional objects) follow the same encoding rules recursively; their
+field order and `omitempty` behavior are defined by their Go structs in
+[`internal/evidence/store.go`](../../internal/evidence/store.go). The audit-critical
+nested fields are:
+
+- `policy_decision`: `allowed` (bool), `action` (string), `reasons` (array, optional),
+  `policy_version` (string).
+- `classification`: `input_tier`, `output_tier` (numbers), `pii_detected` (array,
+  optional), `pii_redacted` (bool), and optional output-scan fields.
+- `execution`: `model_used` (string), `cost` (number), `tokens` (object),
+  `duration_ms` (number), plus optional fields.
+- `audit_trail`: SHA-256 `input_hash` / `output_hash` content digests.
+- `compliance`: `frameworks` (array) and `data_location`.
+
+## 3. Canonical serialization
+
+The canonical byte sequence is the JSON encoding of the record with the `signature` field
+set to the empty string `""`. It is produced by Go's `encoding/json.Marshal`; a faithful
+re-implementation in any language must reproduce the following rules byte-for-byte.
+
+### 3.1 Object form
+
+- A single JSON object, UTF-8 encoded.
+- **No insignificant whitespace** between tokens (no spaces after `:` or `,`).
+- **No trailing newline** (the encoder is `json.Marshal`, not a streaming `Encoder`).
+
+### 3.2 Field order
+
+Object members appear in the struct declaration order shown in [§2](#2-record-fields), not
+alphabetical order. Go's `encoding/json` emits struct fields in declaration order; any
+re-implementation must use the same fixed order. (There are no Go `map` fields at the top
+level, so ordering is fully deterministic.)
+
+### 3.3 `omitempty` rules
+
+A field tagged `,omitempty` is omitted entirely when it holds its Go zero value:
+`""` for strings, `0` for numbers, `false` for booleans, and `null`/length 0 for
+pointers, slices, and maps. Note: Go's `omitempty` does **not** omit empty *structs*, so
+the **always**-present object fields (e.g. `policy_decision`) are emitted even when their
+sub-fields are zero.
+
+The `signature` field is **not** tagged `omitempty`. In the canonical (pre-signing) form
+it is therefore always present and serialized as `"signature":""`.
+
+### 3.4 String, number, and time encoding
+
+- **Strings** use standard JSON escaping, with Go's default **HTML escaping enabled**:
+  `<` → `\u003c`, `>` → `\u003e`, `&` → `\u0026`, and U+2028 / U+2029 → `\u2028` /
+  `\u2029`. A re-implementation must apply the same escaping or signatures will not match.
+- **Timestamps** (`timestamp`) are RFC 3339 / ISO 8601 with up to nanosecond precision,
+  the output of Go's `time.Time.MarshalJSON` (e.g. `2026-06-02T21:15:02.123456789Z`).
+  Trailing-zero fractional digits are trimmed.
+- **Numbers** use Go's default `encoding/json` formatting (integers without a decimal
+  point; floats in the shortest round-trippable form).
+
+## 4. Signing procedure
+
+Given the canonical bytes `C` from [§3](#3-canonical-serialization) and the resolved key
+`K` from [§6](#6-key-resolution):
+
+1. Compute `mac = HMAC-SHA256(K, C)` (RFC 2104, SHA-256).
+2. Encode `mac` as **lowercase** hexadecimal (64 hex characters).
+3. The signature string is the literal prefix `hmac-sha256:` followed by that hex string,
+   e.g. `hmac-sha256:9f86d081884c7d65...`.
+4. Set the record's `signature` field to this string and persist the record.
+
+See `Signer.Sign` in [`internal/evidence/signature.go`](../../internal/evidence/signature.go).
+
+## 5. Verification procedure
+
+Given a stored record `R` whose `signature` field holds `S`:
+
+1. Save `S`, then set `R.signature = ""`.
+2. Recompute the canonical bytes `C'` from `R` per [§3](#3-canonical-serialization).
+3. Compute `expected = "hmac-sha256:" + hex(HMAC-SHA256(K, C'))`.
+4. The record is **valid** iff `expected == S`, compared in **constant time**
+   (`hmac.Equal` over the full prefixed strings). Restore `R.signature = S`.
+
+Any post-signing modification to any field — timestamp, cost, PII findings, policy
+decision, etc. — changes `C'` and causes verification to fail. See `Store.VerifyRecord` in
+[`internal/evidence/store.go`](../../internal/evidence/store.go).
+
+### CLI
+
+```bash
+talon audit verify <evidence-id>        # verify one record from the live store
+talon audit verify --file export.json   # verify a signed export offline
+```
+
+The file verifier reports total / valid / invalid / missing-signature / unparseable
+counts and exits non-zero if any record fails. See
+[Evidence store](../explanation/evidence-store.md) and the
+[compliance export runbook](../guides/compliance-export-runbook.md).
+
+## 6. Key resolution
+
+The signing key is supplied via `TALON_SIGNING_KEY` (or configuration). It is interpreted
+by `resolveSigningKey` in
+[`internal/evidence/signature.go`](../../internal/evidence/signature.go):
+
+- If the value is **64 or more characters, even length, and all hexadecimal**, it is
+  hex-decoded to raw bytes, which must be **at least 32 bytes**.
+- Otherwise the value's **raw UTF-8 bytes** are used directly, and must be **at least 32
+  bytes**.
+
+The same `K` is used for signing and verification (symmetric HMAC). Custody, rotation, and
+backup of the key are operator responsibilities; see [LIMITATIONS.md](../../LIMITATIONS.md).
+
+## 7. Reproducibility test
+
+The round-trip property — that following this spec independently produces a signature the
+verifier accepts, and that tampering is detected — is asserted by
+`TestEvidenceIntegritySpecRoundTrip` in
+[`internal/evidence/integrity_spec_test.go`](../../internal/evidence/integrity_spec_test.go).
+It serializes a record per [§3](#3-canonical-serialization), signs it per
+[§4](#4-signing-procedure), verifies it with an independently constructed signer and with
+`Store.VerifyRecord`, and confirms that mutating a field invalidates the signature.
+
+## 8. Limitations
+
+- HMAC is **symmetric**: anyone holding the signing key can produce valid signatures. The
+  signature attests integrity under the operator's key custody, not third-party
+  non-repudiation. Asymmetric signing is out of scope for this version.
+- The signature does not bind the record to a specific host or instance beyond the shared
+  key, and it does not attest the correctness of the decision it records.

--- a/internal/evidence/integrity_spec_test.go
+++ b/internal/evidence/integrity_spec_test.go
@@ -1,0 +1,101 @@
+package evidence
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvidenceIntegritySpecRoundTrip is the executable counterpart to
+// docs/reference/evidence-integrity-spec.md. It proves that following the
+// documented procedure — serialize with signature="" (§3), HMAC-SHA256 and
+// prefix with "hmac-sha256:" (§4), then verify (§5) — produces a signature the
+// verifier accepts, and that any post-signing mutation is detected.
+func TestEvidenceIntegritySpecRoundTrip(t *testing.T) {
+	// A representative record. Fields are populated across types (strings,
+	// numbers, bools, slices, nested objects, timestamp) to exercise the
+	// canonical-serialization rules in the spec.
+	ev := &Evidence{
+		ID:             "evt_spec_roundtrip",
+		CorrelationID:  "corr_123",
+		Timestamp:      time.Date(2026, 6, 2, 21, 15, 2, 123456789, time.UTC),
+		TenantID:       "acme",
+		AgentID:        "support-bot",
+		InvocationType: "gateway",
+		PolicyDecision: PolicyDecision{
+			Allowed:       true,
+			Action:        "allow",
+			Reasons:       []string{"within budget"},
+			PolicyVersion: "v1",
+		},
+		Classification: Classification{
+			InputTier:   1,
+			PIIDetected: []string{"email", "iban"},
+			PIIRedacted: true,
+		},
+		Execution: Execution{
+			ModelUsed:  "gpt-4o-mini",
+			Cost:       0.0031,
+			DurationMS: 142,
+		},
+		AuditTrail: AuditTrail{
+			InputHash:  "sha256:aaa",
+			OutputHash: "sha256:bbb",
+		},
+		Compliance: Compliance{
+			Frameworks:   []string{"gdpr", "eu-ai-act"},
+			DataLocation: "eu-central-1",
+		},
+		// Signature is intentionally empty; it is set by the signing procedure.
+	}
+
+	// §3: canonical bytes are the JSON encoding with signature == "".
+	require.Empty(t, ev.Signature, "record must be unsigned before computing canonical bytes")
+	canonical, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	// The canonical form always carries an empty signature field (no omitempty).
+	assert.Contains(t, string(canonical), `"signature":""`,
+		"canonical form must include an empty signature field")
+
+	// §4: HMAC-SHA256, hex-encoded, with the "hmac-sha256:" prefix.
+	signer, err := NewSigner(testSigningKey)
+	require.NoError(t, err)
+	sig, err := signer.Sign(canonical)
+	require.NoError(t, err)
+
+	const prefix = "hmac-sha256:"
+	require.True(t, strings.HasPrefix(sig, prefix), "signature must carry the hmac-sha256: prefix")
+	hexPart := strings.TrimPrefix(sig, prefix)
+	assert.Len(t, hexPart, 64, "SHA-256 hex digest must be 64 characters")
+	assert.Equal(t, strings.ToLower(hexPart), hexPart, "hex digest must be lowercase")
+
+	ev.Signature = sig
+
+	// §5 (independent verifier): a third party with the same key, re-deriving
+	// the canonical bytes per the spec, accepts the signature.
+	independent, err := NewSigner(testSigningKey)
+	require.NoError(t, err)
+	saved := ev.Signature
+	ev.Signature = ""
+	recomputed, err := json.Marshal(ev)
+	require.NoError(t, err)
+	ev.Signature = saved
+	assert.True(t, independent.Verify(recomputed, sig),
+		"independently serialized + verified record must validate")
+
+	// §5 (Talon verifier): Store.VerifyRecord agrees.
+	store := newTestStore(t)
+	assert.True(t, store.VerifyRecord(ev), "Store.VerifyRecord must accept a spec-conformant signature")
+
+	// Tamper detection: mutating any signed field invalidates the signature.
+	originalModel := ev.Execution.ModelUsed
+	ev.Execution.ModelUsed = originalModel + "-tampered"
+	assert.False(t, store.VerifyRecord(ev), "mutating a signed field must invalidate the signature")
+	ev.Execution.ModelUsed = originalModel
+	assert.True(t, store.VerifyRecord(ev), "restoring the field must re-validate the signature")
+}


### PR DESCRIPTION
## Summary

Adds a normative specification for the signed evidence record (proof-bar area 3), written so a third party can independently verify a Talon record — or reproduce a signature — from the document alone.

- **`docs/reference/evidence-integrity-spec.md`** — the spec:
  - Full top-level field list **in serialization order** (45 fields), with always/optional presence.
  - **Canonical serialization** rules a re-implementation must match byte-for-byte: Go `encoding/json` struct-field order, `omitempty` semantics, HTML escaping (`<`/`>`/`&`/U+2028/U+2029), RFC 3339 nanosecond timestamps, no insignificant whitespace, no trailing newline, and the always-present `"signature":""` in canonical form.
  - **Signing** (`HMAC-SHA256`, lowercase hex, `hmac-sha256:` prefix), **verification** (recompute with empty signature, constant-time compare), and **key resolution** (raw vs hex, >= 32 bytes).
  - Explicit **integrity-not-correctness** boundary and an HMAC-symmetry limitation note.
- **`internal/evidence/integrity_spec_test.go`** — `TestEvidenceIntegritySpecRoundTrip` serializes a record per the spec, signs it, verifies with both an independently constructed `Signer` and `Store.VerifyRecord`, and asserts that mutating a signed field invalidates the signature. The spec links to this test.

Cross-linked from the docs index (Reference + Proof Pack), the evidence-store explainer, and `LIMITATIONS.md` (the spec is no longer listed as "forthcoming"). Also reworded one evidence-store ISO 27001 line to supporting-control language (claim discipline, #122).

Normative source remains the `Evidence` struct in `internal/evidence/store.go` and the primitives in `internal/evidence/signature.go`; the doc says so and asks for an issue if they drift.

Closes #121.

## Test plan

- [x] `go test ./internal/evidence/` passes (incl. new round-trip test).
- [x] `gofmt -l` clean on the new test; claim-discipline guard passes.
- [x] All spec links verified to resolve.
- [ ] Docs workflow (link check + claim guard) passes in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a conformance test only; no changes to signing, storage, or API runtime behavior.
> 
> **Overview**
> Adds a **normative evidence integrity specification** (`docs/reference/evidence-integrity-spec.md`) so third parties can reproduce and verify signed records without reading Go: field list in serialization order, canonical JSON rules (including `signature: ""`, `omitempty`, and Go HTML escaping), **HMAC-SHA256** signing with the `hmac-sha256:` prefix, verification, and key resolution. A new **`TestEvidenceIntegritySpecRoundTrip`** in `internal/evidence/integrity_spec_test.go` exercises that procedure and tamper detection; the spec points at the test.
> 
> Docs are wired in from the index (Reference + Proof Pack), **LIMITATIONS.md** (spec is live, not “forthcoming”), and the evidence-store explainer. The evidence-store page also softens ISO 27001 A.8.15 wording to **supporting control / tamper-evident** language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293d83925d1d72e233cfcdd2898d51055763eedc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->