### PR TITLE
docs: sharpen LIMITATIONS boundaries (tool path + key custody)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -23,7 +23,7 @@ This table is the source of truth for capability claims. If a demo or doc descri
 
 ## Evidence boundary
 
-A valid signature proves that this evidence record was signed with the deployment's configured key and has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
+A valid signature proves that this evidence record was signed with the deployment's configured key and — assuming that key remains protected — has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
 
 - Verify a record with `talon audit verify <id>` or `talon audit verify --file <export>` — see [evidence store](docs/explanation/evidence-store.md).
 - The signature covers the canonical JSON of the stored fields ([`VerifyRecord`](internal/evidence/store.go)). It is not instance attestation, and it does not vouch for upstream provider behavior.
@@ -32,6 +32,7 @@ A valid signature proves that this evidence record was signed with the deploymen
 
 - Today, forbidden tools are stripped from request bodies before forwarding ([`internal/gateway/tool_filter.go`](internal/gateway/tool_filter.go)); the README "pre-execution filter" wording reflects this.
 - Not yet: runtime execution interception or per-execution MCP tool-call governance with a signed deny.
+- It does not prevent the same tool from being invoked on a path that does not pass through Talon.
 - "Tool governance: Yes" in the README comparison means request-body filtering today, not runtime execution control.
 
 ## Isolation boundary


### PR DESCRIPTION
## Summary

Enhances the existing `LIMITATIONS.md` with two honest scope points contributed in the community PR #155 by @ded-furby, adapted into the current structure:

- **Tool-governance boundary** — adds: "It does not prevent the same tool from being invoked on a path that does not pass through Talon." This closes a real gap a skeptical reviewer would ask about.
- **Evidence boundary** — folds the signing-key-custody assumption directly into the integrity claim: "...signed with the deployment's configured key and — assuming that key remains protected — has not been modified since signing."

### Context

`LIMITATIONS.md` already landed on `main` (closing #117) with a capability status table, source-code links, EU-routing/PII honesty, and docs-surface cross-links. PR #155 proposed a parallel, standalone version that now conflicts with `main` and no longer closes #117. Rather than lose its best ideas, this PR captures the two unique, high-value lines from #155 and credits the author via `Co-authored-by`.

## Test plan

- [x] Claim-discipline guard passes (`scripts/check-claim-discipline.sh`).
- [x] Diff is limited to the two intended lines; existing links unchanged.
- [ ] Docs workflow (link check + claim guard) passes in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to LIMITATIONS.md with no runtime or security behavior changes.
> 
> **Overview**
> **`LIMITATIONS.md`** tightens two scope statements so reviewers see where Talon’s claims stop.
> 
> The **evidence boundary** now states that a valid signature means the record was signed with the deployment key and, **assuming that key stays protected**, was not altered after signing—making key custody an explicit assumption in the integrity claim.
> 
> The **tool-governance boundary** adds that Talon does **not** block the same tool from running on traffic that **bypasses** Talon (only the gateway path gets request-body filtering today).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a8d597df6c2c01cb3dee3bcb3b512ca60d10fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->