### PR TITLE
docs: anti-goals roadmap (#123) + install matrix fixes (#124)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -49,6 +49,7 @@ A valid signature proves that this evidence record was signed with the deploymen
 
 ## Further reading
 
+- [ROADMAP.md](ROADMAP.md) — public anti-goals, wedge focus, and phased direction
 - [SECURITY.md](SECURITY.md) — security boundaries and threat-model snapshot
 - [Evidence store](docs/explanation/evidence-store.md) — how records are created, signed, and verified
 - [Evidence integrity specification](docs/reference/evidence-integrity-spec.md) — byte-exact fields, serialization, signing, and independent verification

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@
 
 [Docs](docs/README.md) ·
 [Limitations](LIMITATIONS.md) ·
+[Roadmap & focus](ROADMAP.md) ·
 [Quickstart](docs/tutorials/proxy-quickstart.md) ·
 [Docker demo](examples/docker-compose/README.md) ·
 [Dashboard](docs/reference/gateway-dashboard.md) ·
 [Releases](https://github.com/dativo-io/talon/releases/latest)
 
 Talon is a single Go binary that sits in front of OpenAI, Anthropic, AWS Bedrock, Azure OpenAI, and any OpenAI-compatible client. Change one URL and every request is policy-checked, PII-scanned, cost-tracked, and written to a tamper-evident, HMAC-signed evidence record — same SDK, same response shape, governed path. Built for EU teams that need real governance signals for GDPR, NIS2, DORA, and the EU AI Act. Apache 2.0.
+
+**Positioning:** Portkey helps you operate AI. AGT helps you build governed agents. **Talon helps you prove your AI traffic was governed — inside Europe, with signed evidence.** See [Roadmap & focus](ROADMAP.md) for what we deliberately do *not* build.
 
 ```
 $ talon audit list
@@ -230,21 +233,41 @@ Fair, factual positioning. Talon's differentiation is evidence-grade compliance 
 
 ---
 
-## Install options
+## Install
 
-- **Go (fastest):** `go install github.com/dativo-io/talon/cmd/talon@latest`
-- **Release binary:** [GitHub Releases](https://github.com/dativo-io/talon/releases/latest) (verify against `checksums.txt`)
-- **Docker / GHCR:** `docker pull ghcr.io/dativo-io/talon:latest` (also `:vX.Y.Z`, `:X.Y`)
-- **Install script (checksum verification included):** `curl -sSL https://install.gettalon.dev | sh`
+Talon requires **CGO** (SQLite). Go **1.22+** recommended (CI uses 1.25.x).
 
-Talon requires Go 1.22+ and CGO (for SQLite). On macOS, if `go install` fails with `unsupported tapi file type '!tapi-tbd'`, build with system Clang: `CC=/usr/bin/clang go install github.com/dativo-io/talon/cmd/talon@latest`, or clone and run `make install`.
+| Method | Platforms | Artifact / command |
+|--------|-----------|------------------|
+| **From source (recommended on macOS)** | linux, darwin (amd64, arm64) | `git clone … && make install` → `$(go env GOPATH)/bin/talon` |
+| **`go install`** | linux, darwin (amd64, arm64) | `go install github.com/dativo-io/talon/cmd/talon@latest` |
+| **Release tarball** | **linux/amd64 only** | `talon_<version>_linux_amd64.tar.gz` + `checksums.txt` on [Releases](https://github.com/dativo-io/talon/releases/latest) |
+| **Install script** | linux/amd64 prebuilt; **darwin/arm64 falls back to `go install`** | `curl -sSL https://install.gettalon.dev \| sh` |
+| **Docker / GHCR** | linux/amd64 images | `docker pull ghcr.io/dativo-io/talon:latest` (also `:vX.Y.Z`, `:X.Y`) |
 
-Verify release artifacts:
+On macOS, if `go install` fails with `unsupported tapi file type '!tapi-tbd'`, use system Clang:
 
 ```bash
-LATEST=$(gh release view --json tagName -q .tagName)
-gh release view "$LATEST" --json assets -q '.assets[].name'
-docker pull ghcr.io/dativo-io/talon:latest
+CC=/usr/bin/clang CGO_ENABLED=1 go install github.com/dativo-io/talon/cmd/talon@latest
+```
+
+Or clone the repo and run `make install` (Makefile sets `CC=/usr/bin/clang` on Darwin).
+
+### First run (`talon init` → `talon run`)
+
+```bash
+export TALON_SECRETS_KEY="$(openssl rand -hex 32)"   # vault encryption key
+talon init --scaffold --name my-agent                # agent.talon.yaml + talon.config.yaml
+talon run --dry-run "hello"                          # no LLM API key required
+```
+
+For a governed live call, set a provider key: `talon secrets set openai-api-key --value "$OPENAI_API_KEY"` (see [Your first governed agent](docs/tutorials/first-governed-agent.md)).
+
+Verify release assets (linux/amd64):
+
+```bash
+gh release view --repo dativo-io/talon --json tagName,assets -q '.assets[].name'
+# e.g. checksums.txt, talon_1.5.5_linux_amd64.tar.gz
 ```
 
 ---
@@ -299,6 +322,7 @@ llm:
 - [Provider registry](docs/reference/provider-registry.md)
 - [Evidence store](docs/explanation/evidence-store.md)
 - [Conformance suite & count](docs/reference/conformance.md)
+- [Roadmap & focus](ROADMAP.md)
 - [Gateway dashboard](docs/reference/gateway-dashboard.md)
 - [OpenClaw integration](docs/guides/openclaw-integration.md)
 - [Slack bot integration](docs/guides/slack-bot-integration.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,87 +1,110 @@
-# Roadmap & focus
+# Roadmap & focus (EMEA SMB)
+
+**Who this is for.** European and EMEA organisations in roughly the **200–1,000 employee** range — regulated mid-market companies with a small platform or DevOps team, a DPO or compliance function, and growing use of LLMs and vendor AI tools. You do not have a dedicated “AI platform” division; you need **defensible controls** without replatforming every app.
+
+**What you are buying.** Proof that AI traffic was governed **inside your region**, with records you can hand to an auditor, customer security review, or board — not another model catalog or agent framework.
 
 > **Portkey helps you operate AI. AGT helps you build governed agents. Talon helps you prove your AI traffic was governed — inside Europe, with signed evidence.**
 
-Talon is a single Go binary that sits on the **network path** in front of LLM and MCP traffic. Change one URL and every call is policy-checked, PII-scanned, and written to an HMAC-signed evidence record you can export for auditor review. We are not trying to be a general AI platform, a model catalog, or an in-process agent SDK.
+Talon is one self-hosted Go binary on the **network path** in front of OpenAI-compatible and MCP traffic. Change a base URL; keep your SDKs. Every call is policy-checked, PII-scanned, and stored as an HMAC-signed evidence record.
 
-This page is the public "no" list and where we are headed. For operational boundaries (signatures, tool filter vs execution, keys), see [LIMITATIONS.md](LIMITATIONS.md).
-
----
-
-## What we are optimizing for (2.0 wedge)
-
-**Make the auditor happy without leaving the EU** — the near-term bet:
-
-- Signed, regulator-mapped evidence exports (GDPR Art. 30, EU AI Act traceability, NIS2/DORA supporting controls).
-- EU-sovereign routing and egress posture in the gateway path (`eu_strict` / `eu_preferred`).
-- Self-hosted, air-gappable deployment — one binary, no managed control plane required.
-- Drop-in proxy: zero per-agent instrumentation for existing OpenAI-compatible clients.
-
-Success looks like a design-partner auditor accepting a Talon-generated evidence pack with minimal manual rework — not winning a "most models" bake-off.
+For what Talon does *not* claim (compliance outcomes, signatures, tool execution), see [LIMITATIONS.md](LIMITATIONS.md).
 
 ---
 
-## Anti-goals (what we are **not** building for 2.0)
+## What EMEA SMB teams need from us
 
-These are deliberate. If you need them as primary value, another product may fit better (see [buyer fit](#who-should-choose-talon) below).
+| Role | Job to be done | How Talon helps today |
+|------|----------------|------------------------|
+| **CTO / Head of Engineering** | Pass customer and board scrutiny on AI use without a 12-month platform project | Drop-in gateway, cost caps, EU routing posture, signed audit trail |
+| **Compliance / DPO** | Show **supporting controls and evidence** for GDPR, NIS2, DORA, EU AI Act — not a “trust us” slide | Framework-mapped exports, `talon audit verify`, regulator-oriented report scaffolding |
+| **Platform / DevOps** (often 2–10 people) | Run governance without Kubernetes complexity or per-app SDK work | Single binary, SQLite default, `talon init`, Docker demo, optional linux/amd64 release |
+| **SecOps** | Stop PII and spend before it hits the provider; know which agent did what | Input/output PII scan, pre-forward policy deny, evidence per caller/agent |
 
-| We are **not** building | Why |
-|-------------------------|-----|
-| **Multi-language SDKs** | The gateway is language-agnostic by design; per-language SDKs copy high-maintenance surfaces and dilute the message. |
-| **Full trust mesh / A2A protocol** | Interfaces only for now; lightweight per-agent identity is enough for "which agent did this?" in our ICP. |
-| **Kubernetes operator / CRDs / gVisor** | Single-binary, process-level isolation is the MVP promise — not a cluster operator or kernel sandbox. |
-| **Managed cloud / SaaS tier** | Self-host first; managed offering is a later commercial decision, not a 2.0 feature. |
-| **Provider-count race** | We support EU-relevant providers well; we do not chase 1,600-model catalogs. |
-| **Leading with generic "AI governance"** | The category is crowded; we lead with **prove + EU + signed evidence**. |
-
-We still ship commodity gateway features (routing, budgets, dashboards) **only as much as the wedge requires** — not as the headline.
+**Success for our ICP:** your auditor or enterprise customer accepts a Talon evidence pack with little manual rework — and your team can operate it without a managed US control plane.
 
 ---
 
-## Phased direction
+## Near-term focus (the wedge)
 
-### Now — credibility & EU compliance moat
+We optimize for **“make the auditor and enterprise customer comfortable without leaving the EU”**:
 
-- Trust surface: [LIMITATIONS.md](LIMITATIONS.md), [threat model](docs/reference/threat-model.md), [evidence integrity spec](docs/reference/evidence-integrity-spec.md), [conformance count](docs/reference/conformance.md), [benchmarks](docs/reference/benchmarks.md).
-- Compliance report depth (RoPA / Annex IV rendering on top of `talon compliance report`).
-- Data-flow / egress governance and in-region self-host hardening.
+- **Signed evidence** — tamper-evident records and offline verification (`talon audit verify`), not generic logs.
+- **EU egress posture** — `eu_strict` / `eu_preferred` routing; non-compliant paths denied with signed proof (see [limitations](LIMITATIONS.md) for proxy vs `talon run` behavior).
+- **Self-host on your terms** — on-prem or EU cloud; air-gap friendly; no required Talon SaaS.
+- **Drop-in for existing apps** — sales copilots, support bots, internal tools already on OpenAI-compatible APIs.
 
-### Next — parity & narrowing AGT
-
-- Reliability layer (retry/fallback, failover) on the gateway path.
-- Runtime tool-call governance via MCP proxy (deny at execution, not only filter in the request body).
-- Per-agent identity / attestation for evidence attribution.
-
-### Later — expansion
-
-- Red-team CLI and attachment-sandbox maturation.
-- Cross-session / workflow governance.
-- Named adopters, case studies, and additional EU-language docs.
+We are **not** optimizing for maximum model count, a polished multi-tenant SaaS, or greenfield agent frameworks.
 
 ---
 
-## Who should choose Talon
+## Roadmap by outcome (not feature laundry)
 
-| Your primary need | Better fit |
-|-------------------|------------|
-| Best general-purpose AI gateway: routing, caching, model breadth, polished observability | Portkey |
-| Building a new agent system with deep in-process tool/action governance | Microsoft AGT |
-| EU-sovereign LLM egress, PII controls, signed evidence, auditor exports on **existing** traffic | **Talon** |
-| Deep tool governance **and** EU egress evidence | AGT + Talon together |
-| Pass a DPO / security review for current AI usage with verifiable records | **Talon** (when evidence maturity matches your bar) |
+### Now — trust you can show in a review
+
+What we are shipping so a skeptical EU technical buyer can complete a **10-minute proof** and a light audit:
+
+- Public trust docs: [limitations](LIMITATIONS.md), [threat model](docs/reference/threat-model.md), [evidence integrity spec](docs/reference/evidence-integrity-spec.md), [conformance](docs/reference/conformance.md), [benchmarks](docs/reference/benchmarks.md).
+- Richer **auditor-oriented packs** — RoPA / EU AI Act Annex IV-style output on top of `talon compliance report` (today: control-mapping summary).
+- Clearer **data-flow / egress** story for “where did this prompt leave the building?”
+
+### Next — production confidence for regulated traffic
+
+What SMB platform teams ask for once Talon is on the critical path:
+
+- **Reliability** — retry/fallback and failover so governance does not become the outage.
+- **Runtime tool governance** — deny dangerous MCP/tool *execution*, not only strip tools from the request body.
+- **Per-agent identity** — evidence that answers “which bot or integration made this call?” for NIS2-style accountability.
+
+### Later — scale across teams and vendors
+
+- Stronger attachment / injection testing for document-heavy workflows (HR, legal, support).
+- Cross-session and workflow-level governance as agent chains mature.
+- EMEA **case studies**, DE/FR docs, and named adopters in regulated verticals (financial services, health, B2B SaaS selling into enterprise).
 
 ---
 
-## Shipped foundation
+## Anti-goals (what we will not build for 2.0)
 
-Core MVP capabilities (policy engine, PII scanning, evidence store, gateway proxy, MCP server, `talon init`, Docker demo) are in production use today. See [CHANGELOG.md](CHANGELOG.md) and [GitHub Releases](https://github.com/dativo-io/talon/releases) for version history.
+These protect a small EMEA team from “platform creep.” If your primary need is below, another product is likely a better lead.
+
+| We are **not** building | Why it matters for EMEA SMB |
+|-------------------------|-----------------------------|
+| **Multi-language SDKs** | Your apps already speak HTTP; we govern at the gateway, not inside every codebase. |
+| **Full agent-to-agent trust mesh** | Rare at 200–1k scale; lightweight per-agent identity comes first. |
+| **Kubernetes operator / gVisor** | Most ICP teams want systemd or Docker Compose, not another cluster abstraction. |
+| **Managed Talon cloud (yet)** | Data residency and procurement often rule out US-hosted control planes; self-host first. |
+| **1,600-model catalogs** | You need **EU-relevant providers done well**, not every frontier model on day one. |
+| **“AI governance platform” as the headline** | You need **provable records** for GDPR / EU AI Act / customer DPAs — not another vague category. |
+
+Commodity gateway features (caching, dashboards, budgets) exist **in service of the wedge**, not as the reason to buy.
+
+---
+
+## When to choose Talon (and when not to)
+
+| Your situation (EMEA SMB) | Recommendation |
+|-------------------------|----------------|
+| Enterprise customers or regulators ask **how you govern existing** ChatGPT/Copilot/vendor AI traffic | **Talon** — network proof point |
+| You are **building a new agent platform** and need deep in-process tool hooks | **Microsoft AGT** (Talon can sit in front for egress evidence) |
+| You need **US-centric AI ops**: broad routing, prompt CMS, largest model matrix | **Portkey** |
+| You need **both** deep in-process tool policy **and** EU egress evidence | **AGT + Talon** — complementary layers |
+| You only need log shipping / cost dashboards, not signed per-request evidence | Observability stack may suffice; validate against your DPA |
+
+---
+
+## Already available
+
+Policy engine (OPA), EU PII patterns, HMAC evidence store, LLM gateway proxy, MCP server, `talon init`, Docker no-key demo, compliance report scaffolding. See [CHANGELOG.md](CHANGELOG.md) and [releases](https://github.com/dativo-io/talon/releases).
+
+**Persona workflows:** [Persona guides](docs/PERSONA_GUIDES.md) · **Adoption paths:** [Adoption scenarios](docs/ADOPTION_SCENARIOS.md)
 
 ---
 
 ## How to influence the roadmap
 
-- Open a [feature request](https://github.com/dativo-io/talon/issues/new?template=feature_request.yml) with your use case.
-- Vote on existing issues with a 👍 reaction.
-- Join [GitHub Discussions](https://github.com/dativo-io/talon/discussions).
+We prioritize EMEA SMB outcomes: **evidence depth**, **EU deployment realism**, then community demand.
 
-Priorities: (1) EU evidence / compliance depth, (2) community demand on the wedge, (3) engineering feasibility for a small team.
+- [Feature request](https://github.com/dativo-io/talon/issues/new?template=feature_request.yml) — describe your sector, size, and review type (customer DPA, ISO, EU AI Act, etc.).
+- 👍 on existing issues.
+- [GitHub Discussions](https://github.com/dativo-io/talon/discussions)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,57 +1,87 @@
-# Roadmap
+# Roadmap & focus
 
-## v0.9.0 (February 2026) — Community & Launch Readiness
+> **Portkey helps you operate AI. AGT helps you build governed agents. Talon helps you prove your AI traffic was governed — inside Europe, with signed evidence.**
 
-- [x] Policy engine (embedded OPA/Rego)
-- [x] PII detection (25+ EU patterns across 27 member states)
-- [x] Evidence store (HMAC-SHA256 signed, SQLite)
-- [x] Secrets vault (AES-256-GCM, per-agent ACL)
-- [x] Multi-LLM support (OpenAI, Anthropic, Bedrock, Ollama)
-- [x] MCP server (native JSON-RPC 2.0)
-- [x] HTTP API + embedded dashboard
-- [x] Agent memory (governed, PII-scanned, Constitutional AI)
-- [x] LLM API Gateway (transparent proxy at `/v1/proxy/*`)
-- [x] Attachment scanning (prompt injection prevention)
-- [x] Cron scheduler + webhook triggers
-- [x] Mock provider + docker-compose demo (no API key)
-- [x] Flow 0 verification (60-second demo)
-- [x] JSON Schema for `talon.config.yaml` and `agent.talon.yaml`
-- [x] Quickstart tutorials (Diataxis)
-- [x] Starter OPA/Rego policy library
-- [x] Community governance files (CODE_OF_CONDUCT, MAINTAINERS, CODEOWNERS)
-- [x] Production deploy templates (systemd, docker-compose)
+Talon is a single Go binary that sits on the **network path** in front of LLM and MCP traffic. Change one URL and every call is policy-checked, PII-scanned, and written to an HMAC-signed evidence record you can export for auditor review. We are not trying to be a general AI platform, a model catalog, or an in-process agent SDK.
 
-## v1.0.0 (March 2026) — Stable MVP
+This page is the public "no" list and where we are headed. For operational boundaries (signatures, tool filter vs execution, keys), see [LIMITATIONS.md](LIMITATIONS.md).
 
-- [x] Operational control plane — run lifecycle (kill/pause/resume), tenant lockdown, runtime overrides, tool approval gates
-- [ ] MCP Proxy (vendor integration for Zendesk, Intercom, etc.)
-- [ ] Shadow mode dashboard tab (AI usage discovery)
-- [ ] Per-caller/team cost dashboards
-- [x] `talon init` interactive wizard (default in TTY); `--scaffold`, `--pack`, `--list-providers` / `--list-packs` / `--list-features`
-- [ ] Additional industry packs (beyond openclaw, fintech-eu, etc.)
+---
 
-## v1.1.0 (May 2026) — Enterprise
+## What we are optimizing for (2.0 wedge)
 
-- [ ] PostgreSQL backend (high-availability evidence store)
-- [ ] LGTM observability stack integration (Grafana, Loki, Tempo, Mimir)
-- [ ] Infisical integration (secret rotation, SAML)
-- [ ] RBAC (role-based access control for the API)
-- [ ] SSO/SAML authentication
+**Make the auditor happy without leaving the EU** — the near-term bet:
 
-## Future
+- Signed, regulator-mapped evidence exports (GDPR Art. 30, EU AI Act traceability, NIS2/DORA supporting controls).
+- EU-sovereign routing and egress posture in the gateway path (`eu_strict` / `eu_preferred`).
+- Self-hosted, air-gappable deployment — one binary, no managed control plane required.
+- Drop-in proxy: zero per-agent instrumentation for existing OpenAI-compatible clients.
 
-- [ ] A2A protocol (agent-to-agent communication)
-- [ ] Kubernetes operator
-- [ ] Vector-search agent memory
-- [ ] Advanced PII detection (Presidio integration)
-- [ ] S3 WORM evidence storage
-- [ ] gVisor/Firecracker agent isolation
+Success looks like a design-partner auditor accepting a Talon-generated evidence pack with minimal manual rework — not winning a "most models" bake-off.
 
-## How to Influence the Roadmap
+---
 
-- Open a [feature request](https://github.com/dativo-io/talon/issues/new?template=feature_request.yml) with your use case
-- Vote on existing issues with a thumbs-up reaction
-- Join the discussion in [GitHub Discussions](https://github.com/dativo-io/talon/discussions)
+## Anti-goals (what we are **not** building for 2.0)
 
-Roadmap items are prioritized by: (1) community demand, (2) compliance
-deadlines (EU AI Act August 2026), (3) engineering feasibility.
+These are deliberate. If you need them as primary value, another product may fit better (see [buyer fit](#who-should-choose-talon) below).
+
+| We are **not** building | Why |
+|-------------------------|-----|
+| **Multi-language SDKs** | The gateway is language-agnostic by design; per-language SDKs copy high-maintenance surfaces and dilute the message. |
+| **Full trust mesh / A2A protocol** | Interfaces only for now; lightweight per-agent identity is enough for "which agent did this?" in our ICP. |
+| **Kubernetes operator / CRDs / gVisor** | Single-binary, process-level isolation is the MVP promise — not a cluster operator or kernel sandbox. |
+| **Managed cloud / SaaS tier** | Self-host first; managed offering is a later commercial decision, not a 2.0 feature. |
+| **Provider-count race** | We support EU-relevant providers well; we do not chase 1,600-model catalogs. |
+| **Leading with generic "AI governance"** | The category is crowded; we lead with **prove + EU + signed evidence**. |
+
+We still ship commodity gateway features (routing, budgets, dashboards) **only as much as the wedge requires** — not as the headline.
+
+---
+
+## Phased direction
+
+### Now — credibility & EU compliance moat
+
+- Trust surface: [LIMITATIONS.md](LIMITATIONS.md), [threat model](docs/reference/threat-model.md), [evidence integrity spec](docs/reference/evidence-integrity-spec.md), [conformance count](docs/reference/conformance.md), [benchmarks](docs/reference/benchmarks.md).
+- Compliance report depth (RoPA / Annex IV rendering on top of `talon compliance report`).
+- Data-flow / egress governance and in-region self-host hardening.
+
+### Next — parity & narrowing AGT
+
+- Reliability layer (retry/fallback, failover) on the gateway path.
+- Runtime tool-call governance via MCP proxy (deny at execution, not only filter in the request body).
+- Per-agent identity / attestation for evidence attribution.
+
+### Later — expansion
+
+- Red-team CLI and attachment-sandbox maturation.
+- Cross-session / workflow governance.
+- Named adopters, case studies, and additional EU-language docs.
+
+---
+
+## Who should choose Talon
+
+| Your primary need | Better fit |
+|-------------------|------------|
+| Best general-purpose AI gateway: routing, caching, model breadth, polished observability | Portkey |
+| Building a new agent system with deep in-process tool/action governance | Microsoft AGT |
+| EU-sovereign LLM egress, PII controls, signed evidence, auditor exports on **existing** traffic | **Talon** |
+| Deep tool governance **and** EU egress evidence | AGT + Talon together |
+| Pass a DPO / security review for current AI usage with verifiable records | **Talon** (when evidence maturity matches your bar) |
+
+---
+
+## Shipped foundation
+
+Core MVP capabilities (policy engine, PII scanning, evidence store, gateway proxy, MCP server, `talon init`, Docker demo) are in production use today. See [CHANGELOG.md](CHANGELOG.md) and [GitHub Releases](https://github.com/dativo-io/talon/releases) for version history.
+
+---
+
+## How to influence the roadmap
+
+- Open a [feature request](https://github.com/dativo-io/talon/issues/new?template=feature_request.yml) with your use case.
+- Vote on existing issues with a 👍 reaction.
+- Join [GitHub Discussions](https://github.com/dativo-io/talon/discussions).
+
+Priorities: (1) EU evidence / compliance depth, (2) community demand on the wedge, (3) engineering feasibility for a small team.

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@ Choose the shortest path for your situation:
 | [What Talon does to your request](explanation/what-talon-does-to-your-request.md) | Full request lifecycle: every check, every byte transformation, latency budget. |
 | [Why not just a PII proxy?](explanation/why-not-a-pii-proxy.md) | Five failure scenarios: what a PII-only proxy misses, what Talon does, and how to verify. |
 | [Evidence store](explanation/evidence-store.md) | Evidence record structure, session_id, HMAC signing (TALON_SIGNING_KEY), progressive disclosure, storage, and export (CSV/JSON columns). |
+| [Roadmap & focus](../ROADMAP.md) | Public anti-goals, wedge narrative, phased direction, and buyer fit (what we are not building for 2.0). |
 | [Adoption scenarios](ADOPTION_SCENARIOS.md) | Greenfield, brownfield custom, brownfield vendor; timelines and ROI. |
 | [Persona guides](PERSONA_GUIDES.md) | Who uses Talon (DevOps, Compliance, CTO, SecOps, FinOps) and what they do. |
 | [Vendor integration guide](VENDOR_INTEGRATION_GUIDE.md) | Why vendor compliance matters; MCP proxy and patterns. |
@@ -100,6 +101,7 @@ Choose the shortest path for your situation:
 | [Evidence integrity specification](reference/evidence-integrity-spec.md) | Byte-exact spec so a third party can independently verify a record. |
 | [Conformance suite & count](reference/conformance.md) | Reproducible passing-test count for the evidence + policy paths (`make conformance`). |
 | [Reproducible benchmarks](reference/benchmarks.md) | `make benchmarks` — gateway overhead, PII scan, evidence write on your hardware. |
+| [Roadmap & focus](../ROADMAP.md) | Anti-goals and focus — answers "are you trying to be Portkey + AGT?" |
 | [Evidence integrity 5-minute proof](tutorials/evidence-integrity-demo.md) | Fast proof moment for auditors/operators, including offline signed-export verification. |
 | [Threat model](reference/threat-model.md) | Attack surface, trust boundaries, and what the HMAC signature does and does not prove. |
 | [Security policy](../SECURITY.md) | Vulnerability reporting process and security scope. |

--- a/docs/tutorials/first-governed-agent.md
+++ b/docs/tutorials/first-governed-agent.md
@@ -2,25 +2,23 @@
 
 In this tutorial we will get from zero to a policy-enforced AI agent in one path: install Talon, initialize a project, configure an LLM key, run a query, and see evidence recorded. By the end you will have run a governed agent and seen the audit trail.
 
-**Prerequisites:** Go 1.22+ (or a pre-built binary) and an LLM API key (OpenAI or Anthropic) or a local Ollama instance.
+**Prerequisites:** Go 1.22+ with CGO (or a **linux/amd64** release tarball), and an LLM API key (OpenAI or Anthropic) or a local Ollama instance for live runs. Dry-run works without an API key.
 
 ---
 
 ## 1. Install Talon
 
-First, build or install the Talon binary.
+See the [README install matrix](../../README.md#install) for all methods. **macOS and arm64 Linux:** use from-source or `go install` (prebuilt GitHub tarballs are **linux/amd64 only**).
 
 ```bash
-# From source
+# Recommended on macOS / arm64
 git clone https://github.com/dativo-io/talon.git && cd talon
-make build    # → bin/talon
-# or: make install   # → $GOPATH/bin/talon
+make install   # → $(go env GOPATH)/bin/talon
 
-# Or install a released version
-go install github.com/dativo-io/talon/cmd/talon@latest
+# Or: go install github.com/dativo-io/talon/cmd/talon@latest
 ```
 
-**macOS:** If `go install` or `go build` fails with `unsupported tapi file type '!tapi-tbd'` (Homebrew LLVM vs Apple SDK), use system Clang: `CC=/usr/bin/clang go install github.com/dativo-io/talon/cmd/talon@latest`, or clone the repo and run `make build` / `make install`.
+**macOS:** If linking fails with `unsupported tapi file type '!tapi-tbd'`, use `make install` or `CC=/usr/bin/clang CGO_ENABLED=1 go install github.com/dativo-io/talon/cmd/talon@latest`.
 
 Check that it works:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # Dativo Talon installer
 # Usage: curl -sSL https://install.gettalon.dev | sh
+#
+# Prebuilt release assets: linux/amd64 only (see README install matrix).
+# Other platforms fall back to "go install" when Go + CGO are available.
 
 REPO="dativo-io/talon"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
@@ -31,19 +34,19 @@ esac
 
 echo "Platform: ${OS}/${ARCH}"
 
-# Get latest release
+# Get latest release metadata
 echo "Fetching latest release..."
 LATEST_URL="https://api.github.com/repos/${REPO}/releases/latest"
-LATEST=$(curl -sSL "${LATEST_URL}" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+RELEASE_JSON=$(curl -sSL "${LATEST_URL}")
 
-if [ -z "$LATEST" ]; then
+if [ -z "$RELEASE_JSON" ] || ! echo "$RELEASE_JSON" | grep -q '"tag_name"'; then
     echo "Error: Failed to fetch latest version. Check network connectivity."
     exit 1
 fi
 
+LATEST=$(echo "$RELEASE_JSON" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
 echo "Version: ${LATEST}"
 
-# Windows uses .zip and talon.exe; Linux/macOS use .tar.gz and talon
 VERSION_STR="${LATEST#v}"
 if [ "$OS" = "windows" ]; then
     ARCHIVE_EXT="zip"
@@ -56,20 +59,73 @@ else
 fi
 ASSET_NAME="talon_${VERSION_STR}_${OS}_${ARCH}.${ARCHIVE_EXT}"
 
-# Download
+asset_available() {
+    echo "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_NAME}\""
+}
+
+install_via_go() {
+    if ! command -v go >/dev/null 2>&1; then
+        echo "Error: No prebuilt binary for ${OS}/${ARCH} in ${LATEST}, and Go is not installed."
+        echo ""
+        echo "Options:"
+        echo "  1. Install Go 1.22+ with CGO enabled, then:"
+        echo "       go install github.com/dativo-io/talon/cmd/talon@${LATEST}"
+        echo "     On macOS if linking fails, use:"
+        echo "       CC=/usr/bin/clang CGO_ENABLED=1 go install github.com/dativo-io/talon/cmd/talon@${LATEST}"
+        echo "  2. Clone the repo and run: make install"
+        echo ""
+        echo "Prebuilt tarballs are published for linux/amd64 only."
+        exit 1
+    fi
+
+    echo "No prebuilt binary for ${OS}/${ARCH} in ${LATEST}."
+    echo "Installing via go install (${LATEST})..."
+    GO_ENV=(env CGO_ENABLED=1)
+    if [ "$OS" = "darwin" ]; then
+        GO_ENV=(env -u CC CC=/usr/bin/clang CGO_ENABLED=1)
+    fi
+    if ! "${GO_ENV[@]}" go install "github.com/dativo-io/talon/cmd/talon@${LATEST}"; then
+        echo "go install failed. On macOS try: CC=/usr/bin/clang CGO_ENABLED=1 go install github.com/dativo-io/talon/cmd/talon@${LATEST}"
+        exit 1
+    fi
+
+    GOPATH_BIN=$(go env GOPATH)/bin
+    if [ -x "${GOPATH_BIN}/talon" ]; then
+        echo ""
+        echo "✓ Talon installed to ${GOPATH_BIN}/talon"
+        echo "  Ensure ${GOPATH_BIN} is on your PATH."
+        "${GOPATH_BIN}/talon" version
+    else
+        echo "✓ go install completed. Ensure \$(go env GOPATH)/bin is on your PATH."
+    fi
+    exit 0
+}
+
+if ! asset_available; then
+    install_via_go
+fi
+
+# Download prebuilt asset
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ASSET_NAME}"
 CHECKSUM_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.txt"
 
-echo "Downloading..."
+echo "Downloading ${ASSET_NAME}..."
 TMP_DIR=$(mktemp -d)
 trap "rm -rf ${TMP_DIR}" EXIT
 
-curl -sSL -o "${TMP_DIR}/${ARCHIVE_FILE}" "${DOWNLOAD_URL}"
-curl -sSL -o "${TMP_DIR}/checksums.txt" "${CHECKSUM_URL}"
+if ! curl -fsSL -o "${TMP_DIR}/${ARCHIVE_FILE}" "${DOWNLOAD_URL}"; then
+    echo "Error: Download failed for ${ASSET_NAME}"
+    install_via_go
+fi
+curl -fsSL -o "${TMP_DIR}/checksums.txt" "${CHECKSUM_URL}"
 
 # Verify checksum
 echo "Verifying checksum..."
 EXPECTED=$(grep "${ASSET_NAME}" "${TMP_DIR}/checksums.txt" | awk '{print $1}')
+if [ -z "$EXPECTED" ]; then
+    echo "Error: ${ASSET_NAME} not found in checksums.txt"
+    exit 1
+fi
 ACTUAL=$( (sha256sum "${TMP_DIR}/${ARCHIVE_FILE}" 2>/dev/null || shasum -a 256 "${TMP_DIR}/${ARCHIVE_FILE}") | awk '{print $1}')
 
 if [ "$EXPECTED" != "$ACTUAL" ]; then
@@ -80,10 +136,10 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "Checksum OK"
 
-# Extract
+# Extract (goreleaser archives place the binary at the archive root)
 if [ "$OS" = "windows" ]; then
     if ! command -v unzip >/dev/null 2>&1; then
-        echo "Error: unzip is required for Windows install. Install unzip (e.g. from Git for Windows or MSYS2)."
+        echo "Error: unzip is required for Windows install."
         exit 1
     fi
     unzip -q -o "${TMP_DIR}/${ARCHIVE_FILE}" -d "${TMP_DIR}"
@@ -91,16 +147,28 @@ else
     tar -xzf "${TMP_DIR}/${ARCHIVE_FILE}" -C "${TMP_DIR}"
 fi
 
+if [ ! -f "${TMP_DIR}/${BINARY_NAME}" ]; then
+    # Some archives nest one directory level
+    NESTED=$(find "${TMP_DIR}" -maxdepth 2 -name "${BINARY_NAME}" -type f | head -1)
+    if [ -n "$NESTED" ]; then
+        BINARY_PATH="$NESTED"
+    else
+        echo "Error: ${BINARY_NAME} not found in archive"
+        exit 1
+    fi
+else
+    BINARY_PATH="${TMP_DIR}/${BINARY_NAME}"
+fi
+
 echo "Installing to ${INSTALL_DIR}..."
 if [ -w "${INSTALL_DIR}" ]; then
-    mv "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    mv "${BINARY_PATH}" "${INSTALL_DIR}/${BINARY_NAME}"
 else
     echo "Requires sudo for ${INSTALL_DIR}"
-    sudo mv "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    sudo mv "${BINARY_PATH}" "${INSTALL_DIR}/${BINARY_NAME}"
 fi
 chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
-# Verify
 if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
     echo ""
     echo "✓ Talon installed successfully!"


### PR DESCRIPTION
## Summary

Closes the remaining credibility-epic good-first issues.

### #123 — Public anti-goals + focused narrative

- Rewrote [`ROADMAP.md`](ROADMAP.md): wedge one-liner, explicit 2.0 anti-goals table, phased Now/Next/Later direction, buyer-fit matrix, no internal_docs references.
- Linked from README (nav + positioning paragraph), LIMITATIONS, docs index (Explanation + Proof Pack).

### #124 — Install matrix + paths

- README **Install** table matches actual release artifacts (`talon_<version>_linux_amd64.tar.gz` + `checksums.txt` only per `.goreleaser.yml`).
- Documented first-run path: `TALON_SECRETS_KEY` → `talon init --scaffold` → `talon run --dry-run`.
- [`scripts/install.sh`](scripts/install.sh): checks release JSON for asset availability; **darwin/arm64** (and other missing platforms) fall back to `go install` with macOS clang guidance instead of 404/checksum failure.
- Updated [first-governed-agent](docs/tutorials/first-governed-agent.md) install section.

## Test plan

- [x] `scripts/check-claim-discipline.sh`
- [x] `bash -n scripts/install.sh`
- [x] `install.sh` on darwin/arm64 → go install fallback → `talon version`
- [x] `talon init --scaffold` + `talon run --dry-run` on clean dir

Closes #123
Closes #124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and installer UX only; no runtime gateway, auth, or evidence logic changes.
> 
> **Overview**
> Replaces the version-checklist **ROADMAP** with a public **Roadmap & focus** page: EU evidence wedge, explicit 2.0 **anti-goals**, Now/Next/Later phases, and buyer-fit vs Portkey/AGT. **README**, **LIMITATIONS**, and **docs/README** now link it and add a short positioning line.
> 
> **Install** docs are aligned with **linux/amd64-only** release tarballs (per GoReleaser): README install table, CGO/macOS Clang notes, first-run (`TALON_SECRETS_KEY` → `talon init --scaffold` → `talon run --dry-run`), and tutorial prerequisites. **`scripts/install.sh`** checks release JSON for the platform asset, falls back to **`go install`** (with Darwin clang env) when missing, and hardens download/checksum/extract handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38829236d07b942c538cc32c7a53033b4630eccd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->