### PR TITLE
docs(limitations): merge ded-furby boundary clarifications from #155

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -23,7 +23,7 @@ This table is the source of truth for capability claims. If a demo or doc descri
 
 ## Evidence boundary
 
-A valid signature proves that this evidence record was signed with the deployment's configured key and has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
+A valid signature proves that this evidence record was signed with the deployment's configured key and — assuming that key remains protected — has not been modified since signing. It does not prove that the policy, model response, tool result, or operator decision was correct.
 
 - Verify a record with `talon audit verify <id>` or `talon audit verify --file <export>` — see [evidence store](docs/explanation/evidence-store.md).
 - The signature covers the canonical JSON of the stored fields ([`VerifyRecord`](internal/evidence/store.go)). It is not instance attestation, and it does not vouch for upstream provider behavior.
@@ -31,6 +31,7 @@ A valid signature proves that this evidence record was signed with the deploymen
 ## Tool-governance boundary
 
 - Today, forbidden tools are stripped from request bodies before forwarding ([`internal/gateway/tool_filter.go`](internal/gateway/tool_filter.go)); the README "pre-execution filter" wording reflects this.
+- Talon does not prevent the same tool from being invoked on a separate path that does not pass through Talon.
 - Not yet: runtime execution interception or per-execution MCP tool-call governance with a signed deny.
 - "Tool governance: Yes" in the README comparison means request-body filtering today, not runtime execution control.
 


### PR DESCRIPTION
## Summary

Resolves merge conflicts for community PR #155 by rebasing onto current `main` and applying @ded-furby's two sharper boundary statements to the consolidated `LIMITATIONS.md`:

1. **Evidence boundary** — HMAC claim now includes *assuming that key remains protected*.
2. **Tool-governance boundary** — Talon does not prevent the same tool from being invoked on a separate path that does not pass through Talon.

The full alternate `LIMITATIONS.md` from #155 is superseded by the version already on `main`; this PR lands only the net-new clarifications with `Co-authored-by: ded-furby`.

Closes #117 when merged. After merge, we will close #155 with a pointer here.

## Test plan

- [x] `scripts/check-claim-discipline.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to capability boundaries; no code, auth, or data-path changes.
> 
> **Overview**
> **`LIMITATIONS.md`** picks up two boundary clarifications from community PR #155 (merged into the current doc on `main`):
> 
> The **evidence boundary** now states that HMAC integrity holds only **assuming the signing key remains protected**, not unconditionally after signing.
> 
> The **tool-governance boundary** adds that Talon **cannot block the same tool** if it is invoked **outside** the gateway path.
> 
> No runtime or policy code changes—documentation and claim discipline only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7e9751f66f7284bae5371c7a38ec1bc39db082. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->