### PR TITLE
fix(scripts): CI lint for auditorpackgen

### DIFF
--- a/scripts/auditorpackgen/main.go
+++ b/scripts/auditorpackgen/main.go
@@ -70,8 +70,8 @@ func main() {
 	}
 
 	var records []evidence.Evidence
-	for _, p := range scenarios {
-		ev, err := gen.Generate(ctx, p)
+	for i := range scenarios {
+		ev, err := gen.Generate(ctx, scenarios[i])
 		if err != nil {
 			fatal("generate: %v", err)
 		}
@@ -117,22 +117,22 @@ func main() {
 	}
 
 	manifest := map[string]interface{}{
-		"generated_at":            time.Now().UTC().Format(time.RFC3339),
-		"source":                  "scripts/auditorpackgen (offline; no docker-compose)",
-		"record_count_estimate":   len(records),
+		"generated_at":          time.Now().UTC().Format(time.RFC3339),
+		"source":                "scripts/auditorpackgen (offline; no docker-compose)",
+		"record_count_estimate": len(records),
 		"files": map[string]string{
-			"evidence_signed":          "evidence.signed.json",
-			"compliance_report_html":   "compliance-report.html",
-			"compliance_report_json":   "compliance-report.json",
+			"evidence_signed":        "evidence.signed.json",
+			"compliance_report_html": "compliance-report.html",
+			"compliance_report_json": "compliance-report.json",
 		},
 		"verify_commands": []string{
 			"TALON_SIGNING_KEY=" + testSigningKey + " talon audit verify --file examples/auditor-pack/evidence.signed.json",
 		},
-		"claim_note": "Supporting controls and evidence for auditor review — not a completed legal filing. See LIMITATIONS.md.",
+		"claim_note":               "Supporting controls and evidence for auditor review — not a completed legal filing. See LIMITATIONS.md.",
 		"offline_signing_key_note": "Offline pack uses a fixed demo key; docker-compose regeneration uses the stack vault key.",
 	}
 	mb, _ := json.MarshalIndent(manifest, "", "  ")
-	if err := os.WriteFile(filepath.Join(*outDir, "manifest.json"), mb, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(*outDir, "manifest.json"), mb, 0o600); err != nil {
 		fatal("manifest: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes CI failure on main after #167 merge (`golangci-lint` + `gofmt` format check).

- `rangeValCopy`: index loop over scenarios slice
- `gofumpt`: manifest map alignment
- `gosec G306`: manifest.json written with `0600` permissions

## Test plan

- [x] `golangci-lint run ./scripts/auditorpackgen/...` — 0 issues
- [x] `gofumpt -w` applied

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and file-permission tweaks only; no change to evidence generation or signing logic.
> 
> **Overview**
> Unblocks **CI** on `scripts/auditorpackgen/main.go` after lint/format failures on main.
> 
> The scenario loop now uses an **index range** (`for i := range scenarios` with `scenarios[i]`) instead of ranging by value, satisfying **rangeValCopy**. Manifest map literals were **re-aligned** for **gofumpt**. **`manifest.json`** is written with mode **`0600`** instead of **`0644`**, matching other auditor-pack outputs and addressing **gosec G306**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a389f3546d8088c3bf36fa43953ba843dc26b1e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->