### PR TITLE
feat(evidence): record classified data flow in signed evidence (#131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.10']
+        go-version: ['1.25.11']
 
     steps:
       - uses: actions/checkout@v4
@@ -84,10 +84,10 @@ jobs:
           path: coverage-${{ matrix.go-version }}.out
 
       - name: Upload to Codecov
-        if: matrix.go-version == '1.25.10'
+        if: matrix.go-version == '1.25.11'
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage-1.25.10.out
+          file: ./coverage-1.25.11.out
           fail_ci_if_error: false
 
   lint:
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: golangci-lint
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Install cross-compilation tools

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for minimal image size (<50MB target)
 
 # Stage 1: Build
-FROM golang:1.25.10-alpine AS builder
+FROM golang:1.25.11-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache gcc musl-dev sqlite-dev git

--- a/docs/reference/evidence-integrity-spec.md
+++ b/docs/reference/evidence-integrity-spec.md
@@ -1,6 +1,6 @@
 # Evidence Integrity Specification
 
-**Status:** stable · **Version:** 1.0 · **Scope:** the signed evidence record produced by Talon.
+**Status:** stable · **Version:** 1.1 · **Scope:** the signed evidence record produced by Talon.
 
 This is the normative specification for how a Talon evidence record is serialized,
 signed, and verified. It is written so that a third party can independently verify a
@@ -88,6 +88,7 @@ Top-level fields, **in serialization order** (this order is significant — see
 | 43 | `explanations` | array(object) | optional |
 | 44 | `plan_id` | string | optional |
 | 45 | `graph_run_id` | string | optional |
+| 46 | `data_flow` | object | optional |
 
 Nested objects (`policy_decision`, `classification`, `execution`, `audit_trail`,
 `compliance`, and the optional objects) follow the same encoding rules recursively; their
@@ -103,6 +104,13 @@ nested fields are:
   `duration_ms` (number), plus optional fields.
 - `audit_trail`: SHA-256 `input_hash` / `output_hash` content digests.
 - `compliance`: `frameworks` (array) and `data_location`.
+- `data_flow` (optional): `detector` (string, optional) and `items` (array of
+  objects linking classified data sources to destinations). Each item carries
+  `source`, `source_detail` (optional), `tier`, `entity_types` (sorted array,
+  optional), `entity_count` (optional), `value_digests` (sorted array of
+  per-request salted SHA-256 prefixes, optional — never raw values),
+  `disposition`, and a `destination` object (`kind`, `name`, `model`,
+  `endpoint`, `region`; the last three optional).
 
 ## 3. Canonical serialization
 
@@ -208,7 +216,17 @@ It serializes a record per [§3](#3-canonical-serialization), signs it per
 [§4](#4-signing-procedure), verifies it with an independently constructed signer and with
 `Store.VerifyRecord`, and confirms that mutating a field invalidates the signature.
 
-## 8. Limitations
+## 8. Changelog
+
+- **1.1** — added optional top-level field `data_flow` (#46), appended after
+  `graph_run_id`. Records signed under spec 1.0 verify unchanged (the field is
+  omitted when absent, so their canonical bytes are identical). Note the
+  established caveat for every additive field: a verifier built against spec
+  1.0 drops the unknown `data_flow` member on parse and therefore cannot
+  verify records that carry it — use a 1.1 verifier for new records.
+- **1.0** — initial version.
+
+## 9. Limitations
 
 - HMAC is **symmetric**: anyone holding the signing key can produce valid signatures. The
   signature attests integrity under the operator's key custody, not third-party

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dativo-io/talon
 
-go 1.25.10
+go 1.25.11
 
 require (
 	// HTTP Router (Prompt 6)

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	golang.org/x/term v0.40.0
+	golang.org/x/text v0.23.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -106,7 +107,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/classifier/analyzer.go
+++ b/internal/classifier/analyzer.go
@@ -1,0 +1,120 @@
+package classifier
+
+import (
+	"context"
+	"sort"
+)
+
+// DetectorTalonRegex identifies the built-in regex/recognizer scanner as the
+// analysis engine in evidence records (data_flow.detector).
+const DetectorTalonRegex = "talon-regex"
+
+// Analyzer is the engine-neutral text-analysis interface. The built-in
+// *Scanner satisfies it; third-party engines (e.g. a Microsoft Presidio HTTP
+// adapter mapping RecognizerResult{entity_type, start, end, score} to
+// PIIEntity) can plug in by implementing it. Everything downstream —
+// tiering, flow digests, evidence — consumes only *Classification.
+//
+// Offset convention: PIIEntity.Position is a byte offset into the analyzed
+// text (Go regexp FindAllStringIndex semantics). Adapters for engines that
+// report character/rune offsets (Presidio does) must convert.
+type Analyzer interface {
+	// Analyze scans text and returns a classification. Implementations
+	// must respect ctx cancellation and never retain the input text.
+	Analyze(ctx context.Context, text string) (*Classification, error)
+	// Detector returns the engine identifier recorded in evidence.
+	Detector() string
+}
+
+var _ Analyzer = (*Scanner)(nil)
+
+// Analyze implements Analyzer for the built-in regex scanner.
+func (s *Scanner) Analyze(ctx context.Context, text string) (*Classification, error) {
+	return s.Scan(ctx, text), nil
+}
+
+// Detector implements Analyzer for the built-in regex scanner.
+func (s *Scanner) Detector() string { return DetectorTalonRegex }
+
+// MergeEntitySpans resolves overlapping or duplicate entity spans into
+// non-overlapping entities, the same resolution Redact applies before
+// placeholder replacement (and the post-processing Presidio applies in its
+// analyzer). Overlapping spans are merged into one entity: the
+// higher-sensitivity type wins, the span is extended to cover both, and the
+// value is re-sliced from text. Use before counting entities or computing
+// value digests so overlapping recognizers do not inflate results.
+func MergeEntitySpans(text string, entities []PIIEntity) []PIIEntity {
+	if len(entities) == 0 {
+		return nil
+	}
+
+	type span struct {
+		start       int
+		end         int
+		ptype       string
+		sensitivity int
+		confidence  float64
+	}
+
+	spans := make([]span, len(entities))
+	for i, e := range entities {
+		spans[i] = span{
+			start:       e.Position,
+			end:         e.Position + len(e.Value),
+			ptype:       e.Type,
+			sensitivity: e.Sensitivity,
+			confidence:  e.Confidence,
+		}
+	}
+
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		lenI := spans[i].end - spans[i].start
+		lenJ := spans[j].end - spans[j].start
+		if lenI != lenJ {
+			return lenI > lenJ
+		}
+		return spans[i].sensitivity > spans[j].sensitivity
+	})
+
+	var merged []span
+	for _, m := range spans {
+		if len(merged) == 0 {
+			merged = append(merged, m)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if m.start < last.end {
+			if m.sensitivity > last.sensitivity {
+				last.ptype = m.ptype
+				last.sensitivity = m.sensitivity
+			}
+			if m.end > last.end {
+				last.end = m.end
+			}
+			if m.confidence > last.confidence {
+				last.confidence = m.confidence
+			}
+		} else {
+			merged = append(merged, m)
+		}
+	}
+
+	out := make([]PIIEntity, 0, len(merged))
+	for _, m := range merged {
+		value := ""
+		if m.start >= 0 && m.end <= len(text) && m.start <= m.end {
+			value = text[m.start:m.end]
+		}
+		out = append(out, PIIEntity{
+			Type:        m.ptype,
+			Value:       value,
+			Position:    m.start,
+			Confidence:  m.confidence,
+			Sensitivity: m.sensitivity,
+		})
+	}
+	return out
+}

--- a/internal/classifier/analyzer_test.go
+++ b/internal/classifier/analyzer_test.go
@@ -1,0 +1,106 @@
+package classifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerImplementsAnalyzer(t *testing.T) {
+	var a Analyzer = MustNewScanner()
+	assert.Equal(t, DetectorTalonRegex, a.Detector())
+
+	text := "My IBAN is DE89370400440532013000"
+	cls, err := a.Analyze(context.Background(), text)
+	require.NoError(t, err)
+	require.NotNil(t, cls)
+	assert.True(t, cls.HasPII)
+
+	// Analyze must agree with Scan (same engine underneath).
+	direct := MustNewScanner().Scan(context.Background(), text)
+	assert.Equal(t, direct.Tier, cls.Tier)
+	assert.Equal(t, len(direct.Entities), len(cls.Entities))
+}
+
+func TestMergeEntitySpans(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		entities []PIIEntity
+		want     []PIIEntity
+	}{
+		{
+			name:     "empty",
+			text:     "hello",
+			entities: nil,
+			want:     nil,
+		},
+		{
+			name: "non_overlapping_preserved",
+			text: "a@b.de and DE89370400440532013000",
+			entities: []PIIEntity{
+				{Type: "iban", Value: "DE89370400440532013000", Position: 11, Confidence: 0.9, Sensitivity: 3},
+				{Type: "email", Value: "a@b.de", Position: 0, Confidence: 0.8, Sensitivity: 1},
+			},
+			want: []PIIEntity{
+				{Type: "email", Value: "a@b.de", Position: 0, Confidence: 0.8, Sensitivity: 1},
+				{Type: "iban", Value: "DE89370400440532013000", Position: 11, Confidence: 0.9, Sensitivity: 3},
+			},
+		},
+		{
+			name: "exact_duplicates_collapse",
+			text: "a@b.de",
+			entities: []PIIEntity{
+				{Type: "email", Value: "a@b.de", Position: 0, Confidence: 0.8, Sensitivity: 1},
+				{Type: "email", Value: "a@b.de", Position: 0, Confidence: 0.9, Sensitivity: 1},
+			},
+			want: []PIIEntity{
+				{Type: "email", Value: "a@b.de", Position: 0, Confidence: 0.9, Sensitivity: 1},
+			},
+		},
+		{
+			name: "overlap_higher_sensitivity_wins_and_span_extends",
+			text: "ID-12345-6789-X",
+			entities: []PIIEntity{
+				{Type: "custom_low", Value: "ID-12345", Position: 0, Confidence: 0.7, Sensitivity: 1},
+				{Type: "custom_high", Value: "12345-6789-X", Position: 3, Confidence: 0.6, Sensitivity: 3},
+			},
+			want: []PIIEntity{
+				// span extended to cover both, high-sensitivity type wins, max confidence kept
+				{Type: "custom_high", Value: "ID-12345-6789-X", Position: 0, Confidence: 0.7, Sensitivity: 3},
+			},
+		},
+		{
+			name: "contained_span_absorbed",
+			text: "DE89370400440532013000",
+			entities: []PIIEntity{
+				{Type: "iban", Value: "DE89370400440532013000", Position: 0, Confidence: 0.95, Sensitivity: 3},
+				{Type: "national_id", Value: "370400440532", Position: 4, Confidence: 0.5, Sensitivity: 2},
+			},
+			want: []PIIEntity{
+				{Type: "iban", Value: "DE89370400440532013000", Position: 0, Confidence: 0.95, Sensitivity: 3},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeEntitySpans(tt.text, tt.entities)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRedactBehaviorUnchangedAfterMergeExtraction guards the refactor that
+// moved span merging out of Redact into MergeEntitySpans: overlapping
+// detections must still produce a single placeholder.
+func TestRedactBehaviorUnchangedAfterMergeExtraction(t *testing.T) {
+	s := MustNewScanner()
+	text := "Contact john.doe@example.com or transfer to DE89370400440532013000."
+	out := s.Redact(context.Background(), text)
+	assert.NotContains(t, out, "john.doe@example.com")
+	assert.NotContains(t, out, "DE89370400440532013000")
+	assert.Contains(t, out, "[EMAIL]")
+	assert.Contains(t, out, "[IBAN]")
+}

--- a/internal/classifier/pii.go
+++ b/internal/classifier/pii.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"sort"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -53,6 +52,12 @@ const (
 )
 
 // PIIEntity represents a detected PII instance.
+//
+// Position is a BYTE offset into the analyzed text (Go regexp
+// FindAllStringIndex semantics), and the matched span is
+// [Position, Position+len(Value)). Adapters for engines that report
+// character/rune offsets (e.g. Microsoft Presidio) must convert to byte
+// offsets when producing PIIEntity values.
 type PIIEntity struct {
 	Type        string  `json:"type"`
 	Value       string  `json:"value"`
@@ -293,70 +298,15 @@ func (s *Scanner) Redact(ctx context.Context, text string) string {
 		return text
 	}
 
-	type match struct {
-		start       int
-		end         int
-		ptype       string
-		sensitivity int
-	}
-
-	matches := make([]match, len(classification.Entities))
-	for i, e := range classification.Entities {
-		matches[i] = match{
-			start:       e.Position,
-			end:         e.Position + len(e.Value),
-			ptype:       e.Type,
-			sensitivity: e.Sensitivity,
-		}
-	}
-
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].start != matches[j].start {
-			return matches[i].start < matches[j].start
-		}
-		lenI := matches[i].end - matches[i].start
-		lenJ := matches[j].end - matches[j].start
-		if lenI != lenJ {
-			return lenI > lenJ
-		}
-		return matches[i].sensitivity > matches[j].sensitivity
-	})
-
-	var merged []match
-	for _, m := range matches {
-		if len(merged) == 0 {
-			merged = append(merged, m)
-			continue
-		}
-		last := &merged[len(merged)-1]
-		if m.start < last.end {
-			if m.sensitivity > last.sensitivity {
-				last.ptype = m.ptype
-				last.sensitivity = m.sensitivity
-			}
-			if m.end > last.end {
-				last.end = m.end
-			}
-		} else {
-			merged = append(merged, m)
-		}
-	}
+	merged := MergeEntitySpans(text, classification.Entities)
 
 	// Semantic enrichment path: enricher + policy + XML-style placeholders
 	if s.enricher != nil && s.enrichmentConfig != nil && s.enrichmentConfig.Enabled && s.enrichmentConfig.Mode != "off" && s.enrichmentPolicy != nil {
 		mergedAsPII := make([]PIIEntity, 0, len(merged))
 		for _, m := range merged {
-			raw := ""
-			if m.start >= 0 && m.end <= len(text) {
-				raw = text[m.start:m.end]
-			}
-			mergedAsPII = append(mergedAsPII, PIIEntity{
-				Type:        m.ptype,
-				Value:       raw,
-				Position:    m.start,
-				Confidence:  0.8,
-				Sensitivity: m.sensitivity,
-			})
+			e := m
+			e.Confidence = 0.8
+			mergedAsPII = append(mergedAsPII, e)
 		}
 		canonical := PIIEntitiesToCanonical(mergedAsPII)
 		if len(canonical) > 0 {
@@ -393,7 +343,7 @@ func (s *Scanner) Redact(ctx context.Context, text string) string {
 				opts := &render.RedactOptions{UseEnriched: useEnriched, Allowed: func(id int) []string { return allowedMap[id] }}
 				out := render.RedactWithPlaceholders(text, enriched, opts)
 				for _, m := range merged {
-					RecordPIIRedaction(ctx, m.ptype, piiDirection(ctx))
+					RecordPIIRedaction(ctx, m.Type, piiDirection(ctx))
 				}
 				return out
 			}
@@ -404,9 +354,9 @@ func (s *Scanner) Redact(ctx context.Context, text string) string {
 	result := []byte(text)
 	for i := len(merged) - 1; i >= 0; i-- {
 		m := merged[i]
-		placeholder := "[" + strings.ToUpper(m.ptype) + "]"
-		result = append(result[:m.start], append([]byte(placeholder), result[m.end:]...)...)
-		RecordPIIRedaction(ctx, m.ptype, piiDirection(ctx))
+		placeholder := "[" + strings.ToUpper(m.Type) + "]"
+		result = append(result[:m.Position], append([]byte(placeholder), result[m.Position+len(m.Value):]...)...)
+		RecordPIIRedaction(ctx, m.Type, piiDirection(ctx))
 	}
 
 	return string(result)

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -322,6 +322,7 @@ func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 		"cache_hit", "cache_entry_id", "cost_saved",
 		"upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations",
 		"primary_explanation_code", "primary_explanation_reason", "primary_version_identity",
+		"flow_destinations", "flow_regions", "flow_entity_types",
 	}
 	if err := writer.Write(header); err != nil {
 		return err
@@ -364,6 +365,9 @@ func renderAuditExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 			r.PrimaryExplanationCode,
 			r.PrimaryExplanationReason,
 			r.PrimaryVersionIdentity,
+			r.FlowDestinationsCSV(),
+			r.FlowRegionsCSV(),
+			r.FlowEntityTypesCSV(),
 		}
 		if err := writer.Write(row); err != nil {
 			return err

--- a/internal/compliance/report.go
+++ b/internal/compliance/report.go
@@ -24,6 +24,20 @@ type Report struct {
 	TotalCostEUR      float64          `json:"total_cost_eur"`
 	Mappings          []ControlMapping `json:"mappings"`
 	SampleEvidenceIDs []string         `json:"sample_evidence_ids"`
+	// DataDestinations aggregates data-flow evidence per destination —
+	// supports evidence for GDPR Art. 30 records of processing (recipients)
+	// and EU AI Act Art. 13 transparency. Empty for evidence recorded before
+	// data-flow tracking was introduced.
+	DataDestinations []DestinationSummary `json:"data_destinations,omitempty"`
+}
+
+// DestinationSummary aggregates classified-data flows to one destination.
+type DestinationSummary struct {
+	Kind        string   `json:"kind"`             // llm_provider | mcp_tool | client | cache
+	Name        string   `json:"name"`             // e.g. "openai"
+	Region      string   `json:"region,omitempty"` // "EU" | "US" | "LOCAL" | "unknown"
+	RecordCount int      `json:"record_count"`     // evidence records with flows to this destination
+	EntityTypes []string `json:"entity_types,omitempty"`
 }
 
 func BuildReport(framework, tenantID, agentID, from, to string, list []evidence.Evidence) Report {
@@ -41,6 +55,7 @@ func BuildReport(framework, tenantID, agentID, from, to string, list []evidence.
 			r.Mappings = append(r.Mappings, m)
 		}
 	}
+	agg := newDestinationAggregator()
 	for i := range list {
 		ev := &list[i]
 		if framework != "" && !containsFramework(ev.Compliance.Frameworks, framework) {
@@ -57,9 +72,85 @@ func BuildReport(framework, tenantID, agentID, from, to string, list []evidence.
 		if len(r.SampleEvidenceIDs) < 20 {
 			r.SampleEvidenceIDs = append(r.SampleEvidenceIDs, ev.ID)
 		}
+		agg.addRecord(ev.DataFlow)
 	}
+	r.DataDestinations = agg.summaries()
 	sort.Strings(r.SampleEvidenceIDs)
 	return r
+}
+
+// destinationAggregator collapses data-flow items across evidence records
+// into one summary per (kind, name, region) destination.
+type destinationAggregator struct {
+	byKey map[string]*destinationAgg
+}
+
+type destinationAgg struct {
+	kind, name, region string
+	recordCount        int
+	entityTypes        map[string]struct{}
+}
+
+func newDestinationAggregator() *destinationAggregator {
+	return &destinationAggregator{byKey: make(map[string]*destinationAgg)}
+}
+
+// addRecord folds one evidence record's data flow into the aggregate.
+// Each destination counts at most once per record.
+func (a *destinationAggregator) addRecord(df *evidence.DataFlow) {
+	if df == nil {
+		return
+	}
+	seenInRecord := make(map[string]struct{})
+	for i := range df.Items {
+		item := &df.Items[i]
+		d := item.Destination
+		key := d.Kind + "\x1f" + d.Name + "\x1f" + d.Region
+		agg, ok := a.byKey[key]
+		if !ok {
+			agg = &destinationAgg{kind: d.Kind, name: d.Name, region: d.Region, entityTypes: map[string]struct{}{}}
+			a.byKey[key] = agg
+		}
+		if _, dup := seenInRecord[key]; !dup {
+			seenInRecord[key] = struct{}{}
+			agg.recordCount++
+		}
+		for _, t := range item.EntityTypes {
+			agg.entityTypes[t] = struct{}{}
+		}
+	}
+}
+
+// summaries returns deterministic, sorted destination summaries.
+func (a *destinationAggregator) summaries() []DestinationSummary {
+	out := make([]DestinationSummary, 0, len(a.byKey))
+	for _, agg := range a.byKey {
+		types := make([]string, 0, len(agg.entityTypes))
+		for t := range agg.entityTypes {
+			types = append(types, t)
+		}
+		sort.Strings(types)
+		out = append(out, DestinationSummary{
+			Kind:        agg.kind,
+			Name:        agg.name,
+			Region:      agg.region,
+			RecordCount: agg.recordCount,
+			EntityTypes: types,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Region < out[j].Region
+	})
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func RenderJSON(report Report) ([]byte, error) {
@@ -94,7 +185,12 @@ code { background: #f5f5f5; padding: 1px 4px; border-radius: 4px; }
 <table><thead><tr><th>Framework</th><th>Article</th><th>Control</th><th>Source</th></tr></thead><tbody>
 {{range .Mappings}}<tr><td>{{.Framework}}</td><td>{{.Article}}</td><td>{{.Control}}</td><td><code>{{.Source}}</code></td></tr>{{end}}
 </tbody></table>
-<h2>Sample Evidence IDs</h2>
+{{if .DataDestinations}}<h2>Data Destinations</h2>
+<p class="meta">Where classified data was sent (from signed data-flow evidence) — supports evidence for GDPR Art. 30 records of processing and EU AI Act Art. 13 transparency.</p>
+<table><thead><tr><th>Kind</th><th>Destination</th><th>Region</th><th>Records</th><th>Entity Types</th></tr></thead><tbody>
+{{range .DataDestinations}}<tr><td>{{.Kind}}</td><td><code>{{.Name}}</code></td><td>{{.Region}}</td><td>{{.RecordCount}}</td><td>{{range $i, $t := .EntityTypes}}{{if $i}}, {{end}}<code>{{$t}}</code>{{end}}</td></tr>{{end}}
+</tbody></table>
+{{end}}<h2>Sample Evidence IDs</h2>
 <table><thead><tr><th>ID</th></tr></thead><tbody>
 {{range .SampleEvidenceIDs}}<tr><td><code>{{.}}</code></td></tr>{{end}}
 </tbody></table>

--- a/internal/compliance/report_dataflow_test.go
+++ b/internal/compliance/report_dataflow_test.go
@@ -1,0 +1,94 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+func flowEvidence(id string, items []evidence.DataFlowItem) evidence.Evidence {
+	return evidence.Evidence{
+		ID:        id,
+		Timestamp: time.Now(),
+		TenantID:  "acme",
+		AgentID:   "support-bot",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: true,
+			Action:  "allow",
+		},
+		DataFlow: &evidence.DataFlow{Detector: "talon-regex", Items: items},
+	}
+}
+
+func TestBuildReport_AggregatesDataDestinations(t *testing.T) {
+	openaiUS := evidence.FlowDestination{Kind: evidence.FlowDestLLMProvider, Name: "openai", Region: "US"}
+	vendorEU := evidence.FlowDestination{Kind: evidence.FlowDestMCPTool, Name: "crm", Region: "EU"}
+
+	list := []evidence.Evidence{
+		flowEvidence("ev1", []evidence.DataFlowItem{
+			{Source: evidence.FlowSourcePrompt, EntityTypes: []string{"email", "iban"}, Destination: openaiUS},
+			// second item to the same destination in the same record: counts once
+			{Source: evidence.FlowSourceAttachment, EntityTypes: []string{"phone"}, Destination: openaiUS},
+		}),
+		flowEvidence("ev2", []evidence.DataFlowItem{
+			{Source: evidence.FlowSourcePrompt, EntityTypes: []string{"email"}, Destination: openaiUS},
+			{Source: evidence.FlowSourceToolArgs, EntityTypes: []string{"national_id"}, Destination: vendorEU},
+		}),
+		// legacy record without data flow: counted in totals, no destination
+		{ID: "ev3", Timestamp: time.Now(), TenantID: "acme", PolicyDecision: evidence.PolicyDecision{Allowed: true}},
+	}
+
+	r := BuildReport("", "acme", "", "", "", list)
+	assert.Equal(t, 3, r.EvidenceCount)
+	require.Len(t, r.DataDestinations, 2)
+
+	// sorted by kind: llm_provider before mcp_tool
+	openai := r.DataDestinations[0]
+	assert.Equal(t, evidence.FlowDestLLMProvider, openai.Kind)
+	assert.Equal(t, "openai", openai.Name)
+	assert.Equal(t, "US", openai.Region)
+	assert.Equal(t, 2, openai.RecordCount, "same destination in one record must count once")
+	assert.Equal(t, []string{"email", "iban", "phone"}, openai.EntityTypes)
+
+	crm := r.DataDestinations[1]
+	assert.Equal(t, evidence.FlowDestMCPTool, crm.Kind)
+	assert.Equal(t, "crm", crm.Name)
+	assert.Equal(t, "EU", crm.Region)
+	assert.Equal(t, 1, crm.RecordCount)
+	assert.Equal(t, []string{"national_id"}, crm.EntityTypes)
+}
+
+func TestBuildReport_NoDataFlowRecords(t *testing.T) {
+	list := []evidence.Evidence{
+		{ID: "old1", Timestamp: time.Now(), TenantID: "acme", PolicyDecision: evidence.PolicyDecision{Allowed: true}},
+	}
+	r := BuildReport("", "acme", "", "", "", list)
+	assert.Empty(t, r.DataDestinations, "pre-data-flow records must not fabricate destinations")
+}
+
+func TestRenderHTML_IncludesDataDestinations(t *testing.T) {
+	list := []evidence.Evidence{
+		flowEvidence("ev1", []evidence.DataFlowItem{
+			{Source: evidence.FlowSourcePrompt, EntityTypes: []string{"email"}, Destination: evidence.FlowDestination{Kind: evidence.FlowDestLLMProvider, Name: "openai", Region: "US"}},
+		}),
+	}
+	r := BuildReport("", "acme", "", "", "", list)
+	html, err := RenderHTML(r)
+	require.NoError(t, err)
+	out := string(html)
+	assert.Contains(t, out, "Data Destinations")
+	assert.Contains(t, out, "openai")
+	assert.True(t, strings.Contains(out, "GDPR Art. 30"), "report must phrase data flow as supporting evidence")
+}
+
+func TestRenderHTML_OmitsDataDestinationsWhenEmpty(t *testing.T) {
+	r := BuildReport("", "acme", "", "", "", nil)
+	html, err := RenderHTML(r)
+	require.NoError(t, err)
+	assert.NotContains(t, string(html), "Data Destinations")
+}

--- a/internal/evidence/dataflow.go
+++ b/internal/evidence/dataflow.go
@@ -1,0 +1,187 @@
+// Data-flow tracking: records which classified data was sent to which
+// destination (LLM provider, MCP tool, client output, cache) within one
+// governed request. Digests only — never raw values. Supports evidence for
+// GDPR Art. 30 (records of processing, incl. recipients) and EU AI Act Art. 13.
+package evidence
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/dativo-io/talon/internal/classifier"
+)
+
+// Data-flow source kinds: where the classified data appeared.
+const (
+	FlowSourcePrompt     = "prompt"
+	FlowSourceAttachment = "attachment"
+	FlowSourceToolArgs   = "tool_args"
+	FlowSourceToolResult = "tool_result"
+	FlowSourceResponse   = "response"
+)
+
+// Data-flow destination kinds: where the data went.
+const (
+	FlowDestLLMProvider = "llm_provider"
+	FlowDestMCPTool     = "mcp_tool"
+	FlowDestClient      = "client"
+	FlowDestCache       = "cache"
+)
+
+// Data-flow dispositions: what happened to the data on the way to the destination.
+const (
+	FlowDispositionForwarded = "forwarded"
+	FlowDispositionRedacted  = "redacted"
+	FlowDispositionBlocked   = "blocked"
+	FlowDispositionSurfaced  = "surfaced"
+)
+
+// FlowRegionUnknown is used when no region/jurisdiction could be resolved
+// from configuration or provider metadata. Talon never guesses a region.
+const FlowRegionUnknown = "unknown"
+
+// DataFlow records movement of classified data for one governed request.
+// It is an optional, signed section of the evidence record.
+type DataFlow struct {
+	// Detector identifies the analysis engine that produced the
+	// classifications (e.g. "talon-regex"; future: "presidio").
+	Detector string         `json:"detector,omitempty"`
+	Items    []DataFlowItem `json:"items"`
+}
+
+// DataFlowItem links one classified data source to one destination.
+type DataFlowItem struct {
+	Source       string          `json:"source"`                  // prompt | attachment | tool_args | tool_result | response
+	SourceDetail string          `json:"source_detail,omitempty"` // attachment filename, tool name
+	Tier         int             `json:"tier"`                    // 0-2
+	EntityTypes  []string        `json:"entity_types,omitempty"`  // deduped, sorted canonical types: ["email","iban"]
+	EntityCount  int             `json:"entity_count,omitempty"`  // merged (non-overlapping) entity spans
+	ValueDigests []string        `json:"value_digests,omitempty"` // per-request salted SHA-256 prefixes; never raw values
+	Disposition  string          `json:"disposition"`             // forwarded | redacted | blocked | surfaced
+	Destination  FlowDestination `json:"destination"`
+}
+
+// FlowDestination identifies where classified data was sent.
+type FlowDestination struct {
+	Kind     string `json:"kind"` // llm_provider | mcp_tool | client | cache
+	Name     string `json:"name"` // "openai", upstream vendor, caller name, cache entry ID
+	Model    string `json:"model,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"` // upstream host only (no path/query/credentials)
+	Region   string `json:"region,omitempty"`   // jurisdiction: "EU" | "US" | "LOCAL" | "unknown"
+}
+
+// flowDigestSeparator is an ASCII unit separator preventing ambiguity between
+// the concatenated digest inputs (tenant, correlation, type, value).
+const flowDigestSeparator = "\x1f"
+
+// FlowDigest returns a short, per-request salted digest of a classified value.
+// The salt (tenant_id + correlation_id) deliberately prevents cross-request
+// linkage while letting the same value in input and output of one request
+// produce the same digest ("classified item X surfaced in output Z").
+// The value is canonicalized (NFC + per-entity-type normalization) first so
+// formatting differences ("DE89 3704..." vs "DE893704...") do not break the trail.
+// Never returns or stores the raw value.
+func FlowDigest(tenantID, correlationID, entityType, value string) string {
+	canonical := CanonicalizeEntityValue(entityType, value)
+	h := sha256.Sum256([]byte(
+		tenantID + flowDigestSeparator +
+			correlationID + flowDigestSeparator +
+			entityType + flowDigestSeparator +
+			canonical))
+	return hex.EncodeToString(h[:])[:16]
+}
+
+// CanonicalizeEntityValue normalizes a matched entity value so that the same
+// logical value always produces the same digest regardless of formatting:
+// Unicode NFC normalization plus per-entity-type rules (separator stripping
+// for structured identifiers, lowercasing for emails, etc.).
+func CanonicalizeEntityValue(entityType, value string) string {
+	v := norm.NFC.String(value)
+	switch entityType {
+	case "iban", "credit_card", "national_id", "ssn", "tax_id", "vat_id", "passport":
+		// Structured identifiers: strip separators, uppercase.
+		return strings.ToUpper(stripFlowSeparators(v))
+	case "email":
+		return strings.ToLower(strings.TrimSpace(v))
+	case "phone":
+		// Keep leading + and digits; strip spaces, hyphens, dots, parentheses.
+		return stripFlowSeparators(v)
+	default:
+		return strings.TrimSpace(v)
+	}
+}
+
+// stripFlowSeparators removes common formatting separators from identifier values.
+func stripFlowSeparators(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case ' ', '-', '.', '(', ')', '\t':
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// NewDataFlowItem builds a flow item from merged (non-overlapping) entity
+// spans. Entity types and value digests are deduped and sorted so the signed
+// canonical JSON is deterministic. Callers must pass entities through
+// classifier.MergeEntitySpans first so counts are not inflated by
+// overlapping recognizers.
+func NewDataFlowItem(tenantID, correlationID, source, sourceDetail string, tier int, entities []classifier.PIIEntity, disposition string, dest FlowDestination) DataFlowItem {
+	typeSet := make(map[string]struct{}, len(entities))
+	digestSet := make(map[string]struct{}, len(entities))
+	for _, e := range entities {
+		typeSet[e.Type] = struct{}{}
+		if e.Value != "" {
+			digestSet[FlowDigest(tenantID, correlationID, e.Type, e.Value)] = struct{}{}
+		}
+	}
+	return DataFlowItem{
+		Source:       source,
+		SourceDetail: sourceDetail,
+		Tier:         tier,
+		EntityTypes:  sortedSetKeys(typeSet),
+		EntityCount:  len(entities),
+		ValueDigests: sortedSetKeys(digestSet),
+		Disposition:  disposition,
+		Destination:  dest,
+	}
+}
+
+// NewDataFlowItemFromTypes builds a flow item when only entity types are
+// available (e.g. attachment scans, which do not retain values or positions).
+// No value digests are produced.
+func NewDataFlowItemFromTypes(source, sourceDetail string, tier int, entityTypes []string, disposition string, dest FlowDestination) DataFlowItem {
+	typeSet := make(map[string]struct{}, len(entityTypes))
+	for _, t := range entityTypes {
+		typeSet[t] = struct{}{}
+	}
+	return DataFlowItem{
+		Source:       source,
+		SourceDetail: sourceDetail,
+		Tier:         tier,
+		EntityTypes:  sortedSetKeys(typeSet),
+		EntityCount:  len(typeSet),
+		Disposition:  disposition,
+		Destination:  dest,
+	}
+}
+
+func sortedSetKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/evidence/dataflow_test.go
+++ b/internal/evidence/dataflow_test.go
@@ -1,0 +1,184 @@
+package evidence
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+)
+
+func TestCanonicalizeEntityValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityType string
+		input      string
+		want       string
+	}{
+		{"iban_spaces_stripped", "iban", "DE89 3704 0044 0532 0130 00", "DE89370400440532013000"},
+		{"iban_lowercase_uppercased", "iban", "de89370400440532013000", "DE89370400440532013000"},
+		{"credit_card_hyphens_stripped", "credit_card", "4111-1111-1111-1111", "4111111111111111"},
+		{"email_lowercased", "email", " John.Doe@Example.COM ", "john.doe@example.com"},
+		{"phone_formatting_stripped", "phone", "+49 (170) 123-45.67", "+491701234567"},
+		{"default_trimmed_only", "name", "  Anna Schmidt  ", "Anna Schmidt"},
+		{"nfc_normalization", "name", "Mu\u0308ller", "M\u00fcller"}, // decomposed u+umlaut -> precomposed ü
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CanonicalizeEntityValue(tt.entityType, tt.input))
+		})
+	}
+}
+
+func TestFlowDigest(t *testing.T) {
+	const tenant, corr = "acme", "corr_1"
+
+	t.Run("deterministic", func(t *testing.T) {
+		a := FlowDigest(tenant, corr, "email", "john@example.com")
+		b := FlowDigest(tenant, corr, "email", "john@example.com")
+		assert.Equal(t, a, b)
+		assert.Len(t, a, 16)
+		assert.Equal(t, strings.ToLower(a), a, "digest must be lowercase hex")
+	})
+
+	t.Run("canonicalization_equates_formats", func(t *testing.T) {
+		spaced := FlowDigest(tenant, corr, "iban", "DE89 3704 0044 0532 0130 00")
+		compact := FlowDigest(tenant, corr, "iban", "DE89370400440532013000")
+		assert.Equal(t, spaced, compact, "spaced and compact IBAN must produce the same digest")
+
+		upper := FlowDigest(tenant, corr, "email", "John@Example.com")
+		lower := FlowDigest(tenant, corr, "email", "john@example.com")
+		assert.Equal(t, upper, lower, "email digests must be case-insensitive")
+	})
+
+	t.Run("entity_type_is_part_of_digest", func(t *testing.T) {
+		asEmail := FlowDigest(tenant, corr, "email", "same-value")
+		asName := FlowDigest(tenant, corr, "name", "same-value")
+		assert.NotEqual(t, asEmail, asName)
+	})
+
+	t.Run("salt_prevents_cross_request_linkage", func(t *testing.T) {
+		r1 := FlowDigest(tenant, "corr_1", "email", "john@example.com")
+		r2 := FlowDigest(tenant, "corr_2", "email", "john@example.com")
+		assert.NotEqual(t, r1, r2, "different correlation IDs must produce different digests")
+
+		t1 := FlowDigest("tenant-a", corr, "email", "john@example.com")
+		t2 := FlowDigest("tenant-b", corr, "email", "john@example.com")
+		assert.NotEqual(t, t1, t2, "different tenants must produce different digests")
+	})
+
+	t.Run("never_contains_raw_value", func(t *testing.T) {
+		d := FlowDigest(tenant, corr, "email", "john@example.com")
+		assert.NotContains(t, d, "john")
+		assert.NotContains(t, d, "@")
+	})
+}
+
+func TestNewDataFlowItem(t *testing.T) {
+	entities := []classifier.PIIEntity{
+		{Type: "iban", Value: "DE89370400440532013000", Sensitivity: 3},
+		{Type: "email", Value: "b@example.com", Sensitivity: 1},
+		{Type: "email", Value: "a@example.com", Sensitivity: 1},
+		{Type: "email", Value: "a@example.com", Sensitivity: 1}, // duplicate value
+	}
+	dest := FlowDestination{Kind: FlowDestLLMProvider, Name: "openai", Model: "gpt-4o-mini", Region: "US"}
+	item := NewDataFlowItem("acme", "corr_1", FlowSourcePrompt, "", 2, entities, FlowDispositionForwarded, dest)
+
+	assert.Equal(t, FlowSourcePrompt, item.Source)
+	assert.Equal(t, 2, item.Tier)
+	assert.Equal(t, []string{"email", "iban"}, item.EntityTypes, "entity types must be deduped and sorted")
+	assert.Equal(t, 4, item.EntityCount)
+	assert.Len(t, item.ValueDigests, 3, "duplicate values must collapse to one digest")
+	assert.True(t, sortedStrings(item.ValueDigests), "digests must be sorted for deterministic canonical JSON")
+	assert.Equal(t, dest, item.Destination)
+
+	for _, d := range item.ValueDigests {
+		assert.NotContains(t, d, "example.com")
+		assert.NotContains(t, d, "DE89")
+	}
+}
+
+func TestNewDataFlowItemFromTypes(t *testing.T) {
+	item := NewDataFlowItemFromTypes(FlowSourceAttachment, "report.pdf", 1,
+		[]string{"iban", "email", "email"}, FlowDispositionBlocked,
+		FlowDestination{Kind: FlowDestLLMProvider, Name: "openai"})
+	assert.Equal(t, "report.pdf", item.SourceDetail)
+	assert.Equal(t, []string{"email", "iban"}, item.EntityTypes)
+	assert.Equal(t, 2, item.EntityCount)
+	assert.Empty(t, item.ValueDigests, "type-only items must not carry digests")
+	assert.Equal(t, FlowDispositionBlocked, item.Disposition)
+}
+
+// fakeAnalyzer simulates a third-party engine (e.g. a Presidio adapter): it
+// implements classifier.Analyzer and produces a plain Classification. The
+// data-flow pipeline must consume it identically to the built-in scanner.
+type fakeAnalyzer struct{}
+
+func (fakeAnalyzer) Analyze(_ context.Context, text string) (*classifier.Classification, error) {
+	idx := strings.Index(text, "john@example.com")
+	if idx < 0 {
+		return &classifier.Classification{Tier: 0}, nil
+	}
+	return &classifier.Classification{
+		Tier:   1,
+		HasPII: true,
+		Entities: []classifier.PIIEntity{
+			{Type: "email", Value: "john@example.com", Position: idx, Confidence: 0.99, Sensitivity: 1},
+		},
+	}, nil
+}
+
+func (fakeAnalyzer) Detector() string { return "fake-presidio" }
+
+func TestPluggableAnalyzerProducesEquivalentFlowItems(t *testing.T) {
+	var a classifier.Analyzer = fakeAnalyzer{}
+	text := "contact john@example.com today"
+	cls, err := a.Analyze(context.Background(), text)
+	require.NoError(t, err)
+	require.True(t, cls.HasPII)
+
+	merged := classifier.MergeEntitySpans(text, cls.Entities)
+	item := NewDataFlowItem("acme", "corr_x", FlowSourcePrompt, "", cls.Tier, merged,
+		FlowDispositionForwarded, FlowDestination{Kind: FlowDestLLMProvider, Name: "openai"})
+
+	assert.Equal(t, []string{"email"}, item.EntityTypes)
+	require.Len(t, item.ValueDigests, 1)
+	// A different engine detecting the same canonical value yields the same digest.
+	assert.Equal(t, FlowDigest("acme", "corr_x", "email", "John@Example.com"), item.ValueDigests[0])
+	assert.Equal(t, "fake-presidio", a.Detector())
+}
+
+func TestDataFlowJSONRoundTrip(t *testing.T) {
+	df := &DataFlow{
+		Detector: "talon-regex",
+		Items: []DataFlowItem{
+			{
+				Source:       FlowSourcePrompt,
+				Tier:         2,
+				EntityTypes:  []string{"iban"},
+				EntityCount:  1,
+				ValueDigests: []string{"abcdef0123456789"},
+				Disposition:  FlowDispositionForwarded,
+				Destination:  FlowDestination{Kind: FlowDestLLMProvider, Name: "openai", Region: "US"},
+			},
+		},
+	}
+	b, err := json.Marshal(df)
+	require.NoError(t, err)
+	var back DataFlow
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, *df, back)
+}
+
+func sortedStrings(s []string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i] < s[i-1] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/evidence/export.go
+++ b/internal/evidence/export.go
@@ -53,6 +53,11 @@ type ExportRecord struct {
 	PrimaryExplanationCode   string   `json:"primary_explanation_code,omitempty"`
 	PrimaryExplanationReason string   `json:"primary_explanation_reason,omitempty"`
 	PrimaryVersionIdentity   string   `json:"primary_version_identity,omitempty"`
+	// Data-flow summary (trailing, backward-compatible): deduped+sorted
+	// destinations ("kind:name"), regions, and classified entity types.
+	FlowDestinations []string `json:"flow_destinations,omitempty"`
+	FlowRegions      []string `json:"flow_regions,omitempty"`
+	FlowEntityTypes  []string `json:"flow_entity_types,omitempty"`
 }
 
 // ExportMetadata wraps JSON export with context about the export run.
@@ -132,6 +137,24 @@ func ToExportRecord(e *Evidence) ExportRecord {
 	for _, sv := range e.ShadowViolations {
 		rec.ShadowViolationTypes = append(rec.ShadowViolationTypes, sv.Type)
 	}
+	if e.DataFlow != nil {
+		destSet := make(map[string]struct{})
+		regionSet := make(map[string]struct{})
+		typeSet := make(map[string]struct{})
+		for i := range e.DataFlow.Items {
+			item := &e.DataFlow.Items[i]
+			destSet[item.Destination.Kind+":"+item.Destination.Name] = struct{}{}
+			if item.Destination.Region != "" {
+				regionSet[item.Destination.Region] = struct{}{}
+			}
+			for _, t := range item.EntityTypes {
+				typeSet[t] = struct{}{}
+			}
+		}
+		rec.FlowDestinations = sortedSetKeys(destSet)
+		rec.FlowRegions = sortedSetKeys(regionSet)
+		rec.FlowEntityTypes = sortedSetKeys(typeSet)
+	}
 	return rec
 }
 
@@ -158,4 +181,19 @@ func (r *ExportRecord) ShadowViolationTypesCSV() string {
 // GatewayAnnotationsCSV returns comma-separated gateway annotations for CSV export.
 func (r *ExportRecord) GatewayAnnotationsCSV() string {
 	return strings.Join(r.GatewayAnnotations, ",")
+}
+
+// FlowDestinationsCSV returns comma-separated data-flow destinations for CSV export.
+func (r *ExportRecord) FlowDestinationsCSV() string {
+	return strings.Join(r.FlowDestinations, ",")
+}
+
+// FlowRegionsCSV returns comma-separated data-flow regions for CSV export.
+func (r *ExportRecord) FlowRegionsCSV() string {
+	return strings.Join(r.FlowRegions, ",")
+}
+
+// FlowEntityTypesCSV returns comma-separated data-flow entity types for CSV export.
+func (r *ExportRecord) FlowEntityTypesCSV() string {
+	return strings.Join(r.FlowEntityTypes, ",")
 }

--- a/internal/evidence/export_dataflow_test.go
+++ b/internal/evidence/export_dataflow_test.go
@@ -1,0 +1,62 @@
+package evidence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToExportRecord_DataFlowSummary(t *testing.T) {
+	ev := &Evidence{
+		ID:        "gw_flow",
+		Timestamp: time.Now(),
+		TenantID:  "acme",
+		AgentID:   "support-bot",
+		DataFlow: &DataFlow{
+			Detector: "talon-regex",
+			Items: []DataFlowItem{
+				{
+					Source:      FlowSourcePrompt,
+					Tier:        2,
+					EntityTypes: []string{"email", "iban"},
+					Disposition: FlowDispositionForwarded,
+					Destination: FlowDestination{Kind: FlowDestLLMProvider, Name: "openai", Region: "US"},
+				},
+				{
+					Source:      FlowSourceResponse,
+					Tier:        1,
+					EntityTypes: []string{"email"},
+					Disposition: FlowDispositionRedacted,
+					Destination: FlowDestination{Kind: FlowDestClient, Name: "openclaw-main", Region: ""},
+				},
+				{
+					// duplicate destination: must dedupe
+					Source:      FlowSourceAttachment,
+					Tier:        1,
+					EntityTypes: []string{"phone"},
+					Disposition: FlowDispositionForwarded,
+					Destination: FlowDestination{Kind: FlowDestLLMProvider, Name: "openai", Region: "US"},
+				},
+			},
+		},
+	}
+
+	rec := ToExportRecord(ev)
+	assert.Equal(t, []string{"client:openclaw-main", "llm_provider:openai"}, rec.FlowDestinations)
+	assert.Equal(t, []string{"US"}, rec.FlowRegions, "empty regions must be skipped, duplicates deduped")
+	assert.Equal(t, []string{"email", "iban", "phone"}, rec.FlowEntityTypes)
+
+	assert.Equal(t, "client:openclaw-main,llm_provider:openai", rec.FlowDestinationsCSV())
+	assert.Equal(t, "US", rec.FlowRegionsCSV())
+	assert.Equal(t, "email,iban,phone", rec.FlowEntityTypesCSV())
+}
+
+func TestToExportRecord_NoDataFlow(t *testing.T) {
+	ev := &Evidence{ID: "gw_legacy", Timestamp: time.Now(), TenantID: "acme"}
+	rec := ToExportRecord(ev)
+	assert.Empty(t, rec.FlowDestinations)
+	assert.Empty(t, rec.FlowRegions)
+	assert.Empty(t, rec.FlowEntityTypes)
+	assert.Equal(t, "", rec.FlowDestinationsCSV())
+}

--- a/internal/evidence/integrity_spec_test.go
+++ b/internal/evidence/integrity_spec_test.go
@@ -50,6 +50,28 @@ func TestEvidenceIntegritySpecRoundTrip(t *testing.T) {
 			Frameworks:   []string{"gdpr", "eu-ai-act"},
 			DataLocation: "eu-central-1",
 		},
+		// data_flow (spec §2 field 46, optional): exercised so the canonical
+		// serialization of the appended field is covered by the round trip.
+		DataFlow: &DataFlow{
+			Detector: "talon-regex",
+			Items: []DataFlowItem{
+				{
+					Source:       FlowSourcePrompt,
+					Tier:         2,
+					EntityTypes:  []string{"email", "iban"},
+					EntityCount:  2,
+					ValueDigests: []string{"0123456789abcdef", "fedcba9876543210"},
+					Disposition:  FlowDispositionForwarded,
+					Destination: FlowDestination{
+						Kind:     FlowDestLLMProvider,
+						Name:     "openai",
+						Model:    "gpt-4o-mini",
+						Endpoint: "api.openai.com",
+						Region:   "US",
+					},
+				},
+			},
+		},
 		// Signature is intentionally empty; it is set by the signing procedure.
 	}
 
@@ -98,4 +120,39 @@ func TestEvidenceIntegritySpecRoundTrip(t *testing.T) {
 	assert.False(t, store.VerifyRecord(ev), "mutating a signed field must invalidate the signature")
 	ev.Execution.ModelUsed = originalModel
 	assert.True(t, store.VerifyRecord(ev), "restoring the field must re-validate the signature")
+
+	// data_flow is covered by the signature too.
+	originalDest := ev.DataFlow.Items[0].Destination.Name
+	ev.DataFlow.Items[0].Destination.Name = "tampered-provider"
+	assert.False(t, store.VerifyRecord(ev), "mutating data_flow must invalidate the signature")
+	ev.DataFlow.Items[0].Destination.Name = originalDest
+	assert.True(t, store.VerifyRecord(ev), "restoring data_flow must re-validate the signature")
+}
+
+// TestEvidenceIntegrityWithoutDataFlow proves records without the optional
+// data_flow field (all pre-1.1 records) keep verifying: the omitempty field
+// contributes no bytes to the canonical form when absent.
+func TestEvidenceIntegrityWithoutDataFlow(t *testing.T) {
+	ev := &Evidence{
+		ID:             "evt_no_dataflow",
+		CorrelationID:  "corr_456",
+		Timestamp:      time.Date(2026, 6, 2, 21, 15, 2, 0, time.UTC),
+		TenantID:       "acme",
+		AgentID:        "support-bot",
+		InvocationType: "gateway",
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow", PolicyVersion: "v1"},
+	}
+	canonical, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(canonical), "data_flow",
+		"absent data_flow must not appear in canonical bytes")
+
+	signer, err := NewSigner(testSigningKey)
+	require.NoError(t, err)
+	sig, err := signer.Sign(canonical)
+	require.NoError(t, err)
+	ev.Signature = sig
+
+	store := newTestStore(t)
+	assert.True(t, store.VerifyRecord(ev), "record without data_flow must verify")
 }

--- a/internal/evidence/schema_compat_test.go
+++ b/internal/evidence/schema_compat_test.go
@@ -29,4 +29,7 @@ func TestEvidenceSchemaBackwardCompatible(t *testing.T) {
 	if len(ev.GatewayAnnotations) != 0 {
 		t.Fatalf("expected no gateway_annotations for legacy record, got %v", ev.GatewayAnnotations)
 	}
+	if ev.DataFlow != nil {
+		t.Fatalf("expected nil data_flow for legacy record, got %+v", ev.DataFlow)
+	}
 }

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -87,6 +87,10 @@ type Evidence struct {
 	Explanations    []explanation.Item `json:"explanations,omitempty"`
 	PlanID          string             `json:"plan_id,omitempty"`      // Execution plan ID for audit lineage
 	GraphRunID      string             `json:"graph_run_id,omitempty"` // External graph runtime run ID
+	// DataFlow links classified input data to its destination (digests only,
+	// never raw values). Appended last so pre-existing record signatures
+	// remain valid (see docs/reference/evidence-integrity-spec.md §2).
+	DataFlow *DataFlow `json:"data_flow,omitempty"`
 }
 
 // PlanReviewEvent captures human oversight actions performed on execution plans.

--- a/internal/gateway/attachment.go
+++ b/internal/gateway/attachment.go
@@ -34,6 +34,7 @@ type AttachmentScanResult struct {
 	TextExtracted   bool     `json:"text_extracted"`
 	PIIFound        bool     `json:"pii_found"`
 	PIITypes        []string `json:"pii_types,omitempty"`
+	Tier            int      `json:"tier,omitempty"` // classification tier of the file text (0-2)
 	InjectionsFound int      `json:"injections_found"`
 	ActionTaken     string   `json:"action_taken"`
 }
@@ -180,6 +181,7 @@ func scanSingleFileBlock(
 		cls := piiScanner.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), text)
 		if cls != nil && cls.HasPII {
 			result.PIIFound = true
+			result.Tier = cls.Tier
 			types := map[string]bool{}
 			for _, e := range cls.Entities {
 				types[e.Type] = true

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -59,8 +59,12 @@ type ProviderConfig struct {
 	// "secret" (default) reads provider credentials from Talon's secret store.
 	// "client_bearer" forwards the caller bearer token upstream and is intended
 	// for proxy quickstart mode only.
-	UpstreamAuthMode string   `yaml:"upstream_auth_mode,omitempty" json:"upstream_auth_mode,omitempty"` // secret | client_bearer
-	BaseURL          string   `yaml:"base_url" json:"base_url"`
+	UpstreamAuthMode string `yaml:"upstream_auth_mode,omitempty" json:"upstream_auth_mode,omitempty"` // secret | client_bearer
+	BaseURL          string `yaml:"base_url" json:"base_url"`
+	// Region is the jurisdiction of the upstream endpoint ("EU", "US",
+	// "LOCAL", ...) recorded in data-flow evidence. When empty, Talon falls
+	// back to registered provider metadata, then "unknown" — never a guess.
+	Region           string   `yaml:"region,omitempty" json:"region,omitempty"`
 	AllowedModels    []string `yaml:"allowed_models,omitempty" json:"allowed_models,omitempty"`
 	BlockedModels    []string `yaml:"blocked_models,omitempty" json:"blocked_models,omitempty"`
 	ForbiddenTools   []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`

--- a/internal/gateway/dataflow.go
+++ b/internal/gateway/dataflow.go
@@ -1,0 +1,219 @@
+package gateway
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/llm"
+)
+
+// dataFlowInputs carries the in-memory request state needed to build the
+// data-flow evidence section. Raw text and entity values never leave this
+// function chain — only digests reach the evidence record.
+type dataFlowInputs struct {
+	CorrelationID    string
+	TenantID         string
+	CallerName       string
+	Provider         string
+	Model            string
+	Allowed          bool
+	InputPIIRedacted bool
+	InputText        string // extracted request text (for span merging); in-memory only
+	Classification   *classifier.Classification
+	AttSummary       *AttachmentsScanSummary
+	ResponsePII      *ResponsePIIScanResult
+	CacheHit         bool
+	CacheEntryID     string
+	CacheStored      bool
+}
+
+// buildDataFlow builds the data_flow evidence section for a gateway request.
+// Returns nil when no classified data was detected (tier 0, no PII anywhere),
+// keeping records small. It consumes only the engine-neutral
+// classifier.Classification, so any Analyzer implementation plugs in unchanged.
+func (g *Gateway) buildDataFlow(in dataFlowInputs) *evidence.DataFlow {
+	providerDest := evidence.FlowDestination{
+		Kind:     evidence.FlowDestLLMProvider,
+		Name:     in.Provider,
+		Model:    in.Model,
+		Endpoint: g.providerEndpointHost(in.Provider),
+		Region:   g.providerRegion(in.Provider),
+	}
+	// On a cache hit nothing egresses to the provider: the prompt was matched
+	// against the tenant-scoped cache instead.
+	requestDest := providerDest
+	if in.CacheHit {
+		requestDest = evidence.FlowDestination{
+			Kind: evidence.FlowDestCache,
+			Name: in.CacheEntryID,
+		}
+	}
+
+	requestDisposition := evidence.FlowDispositionForwarded
+	switch {
+	case !in.Allowed:
+		requestDisposition = evidence.FlowDispositionBlocked
+	case in.InputPIIRedacted:
+		requestDisposition = evidence.FlowDispositionRedacted
+	}
+
+	var items []evidence.DataFlowItem
+
+	// Prompt -> provider (or cache).
+	if in.Classification != nil && in.Classification.HasPII {
+		merged := classifier.MergeEntitySpans(in.InputText, in.Classification.Entities)
+		items = append(items, evidence.NewDataFlowItem(
+			in.TenantID, in.CorrelationID,
+			evidence.FlowSourcePrompt, "",
+			in.Classification.Tier, merged,
+			requestDisposition, requestDest))
+	}
+
+	// PII-bearing attachments -> provider (or cache). Attachment scans retain
+	// entity types only (no values/positions), so no digests here.
+	if in.AttSummary != nil {
+		for _, r := range in.AttSummary.Results {
+			if !r.PIIFound {
+				continue
+			}
+			disposition := requestDisposition
+			if r.ActionTaken == "blocked" || r.ActionTaken == "stripped" {
+				disposition = evidence.FlowDispositionBlocked
+			}
+			items = append(items, evidence.NewDataFlowItemFromTypes(
+				evidence.FlowSourceAttachment, r.Filename,
+				r.Tier, r.PIITypes,
+				disposition, requestDest))
+		}
+	}
+
+	// Response -> client (and cache, when stored after a forward).
+	items = append(items, responseFlowItems(in)...)
+
+	if len(items) == 0 {
+		return nil
+	}
+	return &evidence.DataFlow{
+		Detector: g.classifier.Detector(),
+		Items:    items,
+	}
+}
+
+// responseFlowItems builds flow items for classified response content: one to
+// the client, plus one to the semantic cache when the response was stored.
+func responseFlowItems(in dataFlowInputs) []evidence.DataFlowItem {
+	if in.ResponsePII == nil || !in.ResponsePII.PIIDetected {
+		return nil
+	}
+	disposition := evidence.FlowDispositionSurfaced
+	switch {
+	case in.ResponsePII.Blocked:
+		disposition = evidence.FlowDispositionBlocked
+	case in.ResponsePII.Redacted:
+		disposition = evidence.FlowDispositionRedacted
+	}
+	items := []evidence.DataFlowItem{evidence.NewDataFlowItem(
+		in.TenantID, in.CorrelationID,
+		evidence.FlowSourceResponse, "",
+		in.ResponsePII.Tier, in.ResponsePII.Entities,
+		disposition, evidence.FlowDestination{
+			Kind: evidence.FlowDestClient,
+			Name: in.CallerName,
+		})}
+	if in.CacheStored {
+		items = append(items, evidence.NewDataFlowItem(
+			in.TenantID, in.CorrelationID,
+			evidence.FlowSourceResponse, "",
+			in.ResponsePII.Tier, in.ResponsePII.Entities,
+			disposition, evidence.FlowDestination{
+				Kind: evidence.FlowDestCache,
+			}))
+	}
+	return items
+}
+
+// emitDataFlowTelemetry attaches data-flow attributes to the current span and
+// emits a structured log line. Types, counts, and destinations only — never
+// raw values or digests.
+func (g *Gateway) emitDataFlowTelemetry(ctx context.Context, correlationID string, caller *CallerConfig, df *evidence.DataFlow) {
+	if df == nil || len(df.Items) == 0 {
+		return
+	}
+	destSet := make(map[string]struct{}, len(df.Items))
+	regionSet := make(map[string]struct{}, len(df.Items))
+	typeCount := 0
+	for i := range df.Items {
+		item := &df.Items[i]
+		destSet[item.Destination.Kind+":"+item.Destination.Name] = struct{}{}
+		if item.Destination.Region != "" {
+			regionSet[item.Destination.Region] = struct{}{}
+		}
+		typeCount += len(item.EntityTypes)
+	}
+	destinations := setToSortedCSV(destSet)
+	regions := setToSortedCSV(regionSet)
+
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("talon.data_flow.destinations", destinations),
+			attribute.String("talon.data_flow.regions", regions),
+			attribute.Int("talon.data_flow.item_count", len(df.Items)),
+			attribute.Int("talon.data_flow.entity_type_count", typeCount),
+		)
+	}
+	log.Info().
+		Str("correlation_id", correlationID).
+		Str("tenant_id", caller.TenantID).
+		Str("agent_id", caller.Name).
+		Str("flow_destinations", destinations).
+		Str("flow_regions", regions).
+		Int("flow_items", len(df.Items)).
+		Msg("data_flow_recorded")
+}
+
+func setToSortedCSV(set map[string]struct{}) string {
+	if len(set) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+// providerRegion resolves the jurisdiction of a gateway provider: explicit
+// gateway config region first, then registered provider metadata, then
+// "unknown". Talon never guesses a region.
+func (g *Gateway) providerRegion(provider string) string {
+	if prov, ok := g.config.Provider(provider); ok && prov.Region != "" {
+		return prov.Region
+	}
+	if j := llm.JurisdictionForProvider(provider); j != "" {
+		return j
+	}
+	return evidence.FlowRegionUnknown
+}
+
+// providerEndpointHost returns the host of the configured upstream base URL
+// (never path, query, or credentials).
+func (g *Gateway) providerEndpointHost(provider string) string {
+	prov, ok := g.config.Provider(provider)
+	if !ok || prov.BaseURL == "" {
+		return ""
+	}
+	u, err := url.Parse(prov.BaseURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}

--- a/internal/gateway/dataflow_test.go
+++ b/internal/gateway/dataflow_test.go
@@ -1,0 +1,227 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+const (
+	dataFlowTestEmail = "john.doe@example.com"
+	dataFlowTestIBAN  = "DE89370400440532013000"
+)
+
+func dataFlowRequestBody() string {
+	return `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Email ` +
+		dataFlowTestEmail + ` and IBAN ` + dataFlowTestIBAN + `"}]}`
+}
+
+// chatCompletionUpstream returns a chat completion whose content echoes the
+// given text (used to prove input->output digest correlation).
+func chatCompletionUpstream(content string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{
+			"id":    "chatcmpl-test",
+			"model": "gpt-4o-mini",
+			"choices": []interface{}{
+				map[string]interface{}{
+					"index":         0,
+					"message":       map[string]interface{}{"role": "assistant", "content": content},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]interface{}{"prompt_tokens": 10, "completion_tokens": 5},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func findFlowItem(t *testing.T, df *evidence.DataFlow, source string) *evidence.DataFlowItem {
+	t.Helper()
+	require.NotNil(t, df, "data_flow must be present")
+	for i := range df.Items {
+		if df.Items[i].Source == source {
+			return &df.Items[i]
+		}
+	}
+	t.Fatalf("no data_flow item with source %q (items: %+v)", source, df.Items)
+	return nil
+}
+
+func TestGatewayDataFlow_PromptToProviderAndResponseToClient(t *testing.T) {
+	gw, upstream, evStore := setupOpenClawGateway(t, "redact",
+		chatCompletionUpstream("Sure — I will reach out to "+dataFlowTestEmail+" shortly."))
+	prov := gw.config.Providers["openai"]
+	prov.Region = "US"
+	gw.config.Providers["openai"] = prov
+
+	w := makeGatewayRequest(gw, dataFlowRequestBody())
+	require.Equal(t, http.StatusOK, w.Code)
+
+	records, err := evStore.List(context.Background(), "test-tenant", "", time.Time{}, time.Time{}, 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	ev := &records[0]
+
+	require.NotNil(t, ev.DataFlow)
+	assert.Equal(t, "talon-regex", ev.DataFlow.Detector)
+
+	// Prompt -> provider: redacted before forwarding, full destination identity.
+	prompt := findFlowItem(t, ev.DataFlow, evidence.FlowSourcePrompt)
+	assert.Equal(t, evidence.FlowDispositionRedacted, prompt.Disposition)
+	assert.Equal(t, evidence.FlowDestLLMProvider, prompt.Destination.Kind)
+	assert.Equal(t, "openai", prompt.Destination.Name)
+	assert.Equal(t, "gpt-4o-mini", prompt.Destination.Model)
+	assert.Equal(t, "US", prompt.Destination.Region)
+	u, _ := url.Parse(upstream.URL)
+	assert.Equal(t, u.Host, prompt.Destination.Endpoint)
+	assert.Equal(t, 2, prompt.Tier, "IBAN must classify the prompt as tier 2")
+	assert.Contains(t, prompt.EntityTypes, "email")
+	assert.Contains(t, prompt.EntityTypes, "iban")
+	require.NotEmpty(t, prompt.ValueDigests)
+
+	// Response -> client: the same email surfaced in the output; redacted by
+	// response scanning, and the digest matches the prompt-side digest.
+	response := findFlowItem(t, ev.DataFlow, evidence.FlowSourceResponse)
+	assert.Equal(t, evidence.FlowDispositionRedacted, response.Disposition)
+	assert.Equal(t, evidence.FlowDestClient, response.Destination.Kind)
+	assert.Equal(t, "openclaw-main", response.Destination.Name)
+	assert.Contains(t, response.EntityTypes, "email")
+
+	emailDigest := evidence.FlowDigest(ev.TenantID, ev.CorrelationID, "email", dataFlowTestEmail)
+	assert.Contains(t, prompt.ValueDigests, emailDigest)
+	assert.Contains(t, response.ValueDigests, emailDigest,
+		"same classified value must produce the same digest in input and output")
+
+	// The signed record (including data_flow) must verify.
+	assert.True(t, evStore.VerifyRecord(ev), "signed record with data_flow must verify")
+}
+
+func TestGatewayDataFlow_NeverStoresRawPII(t *testing.T) {
+	gw, _, evStore := setupOpenClawGateway(t, "redact",
+		chatCompletionUpstream("Done, contacting "+dataFlowTestEmail+"."))
+
+	w := makeGatewayRequest(gw, dataFlowRequestBody())
+	require.Equal(t, http.StatusOK, w.Code)
+
+	records, err := evStore.List(context.Background(), "test-tenant", "", time.Time{}, time.Time{}, 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	raw, err := json.Marshal(&records[0])
+	require.NoError(t, err)
+	serialized := string(raw)
+	assert.NotContains(t, serialized, dataFlowTestEmail, "raw email must never reach evidence")
+	assert.NotContains(t, serialized, dataFlowTestIBAN, "raw IBAN must never reach evidence")
+	assert.NotContains(t, serialized, strings.Split(dataFlowTestEmail, "@")[0], "email local part must never reach evidence")
+}
+
+func TestGatewayDataFlow_BlockedRequestRecordsBlockedDisposition(t *testing.T) {
+	gw, _, evStore := setupOpenClawGateway(t, "block",
+		chatCompletionUpstream("never reached"))
+
+	w := makeGatewayRequest(gw, dataFlowRequestBody())
+	require.Equal(t, http.StatusBadRequest, w.Code, "PII block must reject the request")
+
+	records, err := evStore.List(context.Background(), "test-tenant", "", time.Time{}, time.Time{}, 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	ev := &records[0]
+
+	prompt := findFlowItem(t, ev.DataFlow, evidence.FlowSourcePrompt)
+	assert.Equal(t, evidence.FlowDispositionBlocked, prompt.Disposition,
+		"blocked egress must still leave a flow trail with disposition=blocked")
+	assert.Equal(t, evidence.FlowDestLLMProvider, prompt.Destination.Kind)
+	assert.False(t, ev.PolicyDecision.Allowed)
+}
+
+func TestGatewayBuildDataFlow_CacheHit(t *testing.T) {
+	gw, _, _ := setupOpenClawGateway(t, "warn", chatCompletionUpstream("unused"))
+
+	text := "Email " + dataFlowTestEmail
+	cls := gw.classifier.Scan(context.Background(), text)
+	require.True(t, cls.HasPII)
+
+	df := gw.buildDataFlow(dataFlowInputs{
+		CorrelationID:  "corr_cache",
+		TenantID:       "test-tenant",
+		CallerName:     "openclaw-main",
+		Provider:       "openai",
+		Model:          "gpt-4o-mini",
+		Allowed:        true,
+		InputText:      text,
+		Classification: cls,
+		CacheHit:       true,
+		CacheEntryID:   "entry-123",
+	})
+	require.NotNil(t, df)
+	require.Len(t, df.Items, 1)
+	item := df.Items[0]
+	assert.Equal(t, evidence.FlowSourcePrompt, item.Source)
+	assert.Equal(t, evidence.FlowDestCache, item.Destination.Kind,
+		"cache hit must record the cache, not the provider, as destination")
+	assert.Equal(t, "entry-123", item.Destination.Name)
+	for _, it := range df.Items {
+		assert.NotEqual(t, evidence.FlowDestLLMProvider, it.Destination.Kind,
+			"nothing egressed to the provider on a cache hit")
+	}
+}
+
+func TestGatewayBuildDataFlow_CacheStoreAfterForward(t *testing.T) {
+	gw, _, _ := setupOpenClawGateway(t, "warn", chatCompletionUpstream("unused"))
+
+	text := "Email " + dataFlowTestEmail
+	cls := gw.classifier.Scan(context.Background(), text)
+	require.True(t, cls.HasPII)
+
+	df := gw.buildDataFlow(dataFlowInputs{
+		CorrelationID:  "corr_store",
+		TenantID:       "test-tenant",
+		CallerName:     "openclaw-main",
+		Provider:       "openai",
+		Model:          "gpt-4o-mini",
+		Allowed:        true,
+		InputText:      text,
+		Classification: cls,
+		ResponsePII: &ResponsePIIScanResult{
+			PIIDetected: true,
+			PIITypes:    []string{"email"},
+			Redacted:    true,
+			Tier:        1,
+		},
+		CacheStored: true,
+	})
+	require.NotNil(t, df)
+
+	kinds := make(map[string]int)
+	for _, it := range df.Items {
+		kinds[it.Destination.Kind]++
+	}
+	assert.Equal(t, 1, kinds[evidence.FlowDestLLMProvider], "prompt egressed to the provider")
+	assert.Equal(t, 1, kinds[evidence.FlowDestClient], "response surfaced to the client")
+	assert.Equal(t, 1, kinds[evidence.FlowDestCache], "stored response adds a cache destination item")
+}
+
+func TestGatewayDataFlow_AbsentWhenNoClassifiedData(t *testing.T) {
+	gw, _, evStore := setupOpenClawGateway(t, "redact",
+		chatCompletionUpstream("All good."))
+
+	w := makeGatewayRequest(gw, `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is the weather like?"}]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	records, err := evStore.List(context.Background(), "test-tenant", "", time.Time{}, time.Time{}, 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Nil(t, records[0].DataFlow, "records without classified data must omit data_flow")
+}

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -57,6 +57,8 @@ type RecordGatewayEvidenceParams struct {
 	Stage                  string // "generation", "judge", or "commit"
 	CandidateIndex         int
 	ExplanationFacts       []explanation.Fact
+	// DataFlow links classified data to its destination (digests only).
+	DataFlow *evidence.DataFlow
 }
 
 // RecordGatewayEvidence creates and stores a signed evidence record for a gateway request.
@@ -128,6 +130,7 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 			SelectedProvider: params.Provider,
 			SelectedModel:    params.Model,
 		},
+		DataFlow: params.DataFlow,
 	}
 	if !params.PolicyAllowed {
 		ev.PolicyDecision.Action = "deny"

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -274,7 +274,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, nil, &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, false, nil, nil, nil, nil, false, "", 0, 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, "", &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -327,9 +327,9 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest,
 				"Request blocked: attachment violates policy")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
 				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, "", false,
-				[]string{"attachment policy block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
+				[]string{"attachment policy block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -363,7 +363,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -391,7 +391,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
-			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, []string{"PII block"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
+			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
 				return
@@ -442,7 +442,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, 0)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -464,7 +464,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			} else {
 				durationMS := time.Since(start).Milliseconds()
 				WriteProviderError(w, route.Provider, http.StatusForbidden, reasons[0])
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, 0, "", false, reasons, false, false, nil, attSummary, nil, nil, false, "", 0, 0, 0, 0, estimatedCost)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -498,8 +498,8 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Msg("gateway_tool_blocked")
 				WriteProviderError(w, route.Provider, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0, estimatedCost)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
+					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -516,8 +516,8 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						Msg("gateway_tool_filter_failed")
 					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body,
-						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, false, nil, attSummary, toolResult, nil, false, "", 0, 0, 0, 0, estimatedCost)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
+						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -597,7 +597,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", true, nil, false, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, 0, 0, estimatedCost)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, false, 0, 0, estimatedCost)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return
@@ -673,7 +673,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
 				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
-				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, 0, 0, estimatedCost)
+				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, false, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
@@ -698,6 +698,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var responsePII *ResponsePIIScanResult
 	needsResponseScan := responsePIIAction != "allow" && responsePIIAction != ""
 	var forwardErr error
+	cacheStored := false
 
 	var streamingMetrics StreamingMetrics
 	fwdParams := ForwardParams{
@@ -743,7 +744,9 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							Model: extracted.Model, DataTier: "public", PIIScrubbed: true,
 							CreatedAt: now, ExpiresAt: now.Add(ttl),
 						}
-						_ = g.cacheStore.Insert(ctx, entry)
+						if insertErr := g.cacheStore.Insert(ctx, entry); insertErr == nil {
+							cacheStored = true
+						}
 					}
 				}
 			}
@@ -784,18 +787,11 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 10: Evidence
-	var outputPIIDetected bool
-	var outputPIITypes []string
-	if responsePII != nil {
-		outputPIIDetected = responsePII.PIIDetected
-		outputPIITypes = responsePII.PIITypes
-	}
-
 	var forwardErrStr string
 	if forwardErr != nil {
 		forwardErrStr = forwardErr.Error()
 	}
-	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, body, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, outputPIIDetected, outputPIITypes, attSummary, toolResult, shadowViolations, false, "", 0, 0, ttftMS, tpotMS, estimatedCost)
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, responsePII, attSummary, toolResult, shadowViolations, false, "", 0, 0, cacheStored, ttftMS, tpotMS, estimatedCost)
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
@@ -810,7 +806,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, _ []byte, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, outputPIIDetected bool, outputPIITypes []string, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, ttftMS int64, tpotMS float64, estimatedCost float64) (*evidence.Evidence, error) {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, inputText string, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, responsePII *ResponsePIIScanResult, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, cacheStored bool, ttftMS int64, tpotMS float64, estimatedCost float64) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -826,7 +822,31 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	for _, e := range classification.Entities {
 		piiDetected = append(piiDetected, e.Type)
 	}
+	var outputPIIDetected bool
+	var outputPIITypes []string
+	if responsePII != nil {
+		outputPIIDetected = responsePII.PIIDetected
+		outputPIITypes = responsePII.PIITypes
+	}
 	execErr := resolveExecutionError(executionError, reasons)
+
+	dataFlow := g.buildDataFlow(dataFlowInputs{
+		CorrelationID:    correlationID,
+		TenantID:         caller.TenantID,
+		CallerName:       caller.Name,
+		Provider:         provider,
+		Model:            model,
+		Allowed:          allowed,
+		InputPIIRedacted: inputPIIRedacted,
+		InputText:        inputText,
+		Classification:   classification,
+		AttSummary:       attSummary,
+		ResponsePII:      responsePII,
+		CacheHit:         cacheHit,
+		CacheEntryID:     cacheEntryID,
+		CacheStored:      cacheStored,
+	})
+	g.emitDataFlowTelemetry(ctx, correlationID, caller, dataFlow)
 
 	var attScan *evidence.AttachmentScan
 	if attSummary != nil && attSummary.FilesScanned > 0 {
@@ -876,6 +896,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 		Stage:                   stageFromContext(ctx),
 		CandidateIndex:          candidateIndexFromContext(ctx),
 		ExplanationFacts:        buildGatewayExplanationFacts(allowed, reasons, outputPIIDetected, outputPIITypes, stageFromContext(ctx)),
+		DataFlow:                dataFlow,
 	}
 	if toolResult != nil {
 		params.ToolsRequested = toolResult.Requested

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -597,7 +597,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					_ = g.cacheStore.IncrementHitCount(ctx, hit.ID)
 					costSaved := g.costEstimate(extracted.Model, 300, 300)
 					durationMS := time.Since(start).Milliseconds()
-					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", true, nil, false, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, false, 0, 0, estimatedCost)
+					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", true, nil, inputPIIRedacted, nil, attSummary, toolResult, shadowViolations, true, hit.ID, lookupResult.Similarity, costSaved, false, 0, 0, estimatedCost)
 					if err != nil {
 						g.handleEvidenceWriteFailure(ctx, err)
 						return

--- a/internal/gateway/response_pii.go
+++ b/internal/gateway/response_pii.go
@@ -13,10 +13,18 @@ import (
 )
 
 // ResponsePIIScanResult captures what the response PII scanner found.
+// Entities and Tier stay in memory only (used to build data-flow evidence
+// digests); they are never serialized or persisted with raw values.
 type ResponsePIIScanResult struct {
 	PIIDetected bool
 	PIITypes    []string
 	Redacted    bool
+	Blocked     bool
+	// Entities are the merged (non-overlapping) entity spans from the
+	// response content scan. In-memory only.
+	Entities []classifier.PIIEntity
+	// Tier is the response content classification tier (0-2).
+	Tier int
 }
 
 // responseCapture wraps an http.ResponseWriter to capture the response body
@@ -87,6 +95,8 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 	}
 
 	result.PIIDetected = true
+	result.Entities = classifier.MergeEntitySpans(contentText, cls.Entities)
+	result.Tier = cls.Tier
 	types := make(map[string]bool)
 	for _, e := range cls.Entities {
 		types[e.Type] = true
@@ -113,6 +123,7 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 		}
 		blocked, _ := json.Marshal(safeErr)
 		result.Redacted = true
+		result.Blocked = true
 		log.Warn().
 			Strs("pii_types", result.PIITypes).
 			Msg("response_pii_blocked")
@@ -414,7 +425,12 @@ func handleStreamingPIIScan(
 	for t := range types {
 		piiTypes = append(piiTypes, t)
 	}
-	result := &ResponsePIIScanResult{PIIDetected: true, PIITypes: piiTypes}
+	result := &ResponsePIIScanResult{
+		PIIDetected: true,
+		PIITypes:    piiTypes,
+		Entities:    classifier.MergeEntitySpans(contentText, cls.Entities),
+		Tier:        cls.Tier,
+	}
 
 	switch action {
 	case "warn":
@@ -439,6 +455,7 @@ func handleStreamingPIIScan(
 	case "block":
 		forwardBlockedResponse(w)
 		result.Redacted = true
+		result.Blocked = true
 		log.Warn().
 			Strs("pii_types", piiTypes).
 			Msg("response_pii_blocked_stream")

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -84,6 +84,21 @@ func AllRegisteredProviders() []Provider {
 	return result
 }
 
+// JurisdictionForProvider returns the registered provider's jurisdiction
+// ("EU", "US", "LOCAL", ...) from its static metadata, or "" when the
+// provider type is not registered. No network calls.
+func JurisdictionForProvider(providerType string) string {
+	factory, ok := registry[providerType]
+	if !ok {
+		return ""
+	}
+	p, err := factory(nil) // nil config — metadata only
+	if err != nil || p == nil {
+		return ""
+	}
+	return p.Metadata().Jurisdiction
+}
+
 // RegisteredTypes returns the list of registered provider type names (sorted).
 func RegisteredTypes() []string {
 	return registeredTypes()

--- a/internal/mcp/dataflow_test.go
+++ b/internal/mcp/dataflow_test.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+const proxyFlowEmail = "anna.schmidt@example.com"
+
+// proxyFlowUpstream answers any JSON-RPC request with a result containing PII.
+func proxyFlowUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonrpcRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]interface{}{
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Contact is " + proxyFlowEmail},
+				},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func proxyFlowHandler(t *testing.T, upstreamURL string, withRedactionRule bool) (*ProxyHandler, *evidence.Store) {
+	t.Helper()
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "flow-proxy", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode: "intercept",
+			Upstream: policy.UpstreamConfig{
+				Vendor: "testvendor",
+				URL:    upstreamURL,
+				Region: "EU",
+			},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+	}
+	if withRedactionRule {
+		cfg.PIIHandling = policy.PIIHandlingConfig{
+			RedactionRules: []policy.RedactionRule{{Field: "email", Method: "hash"}},
+		}
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner()), store
+}
+
+func callProxyTool(t *testing.T, h *ProxyHandler, arguments string) *jsonrpcResponse {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"crm_lookup","arguments":` + arguments + `}}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp jsonrpcResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	return &resp
+}
+
+func proxyEvidenceByType(t *testing.T, store *evidence.Store, invocationType string) *evidence.Evidence {
+	t.Helper()
+	records, err := store.List(context.Background(), "default", "", time.Time{}, time.Time{}, 20)
+	require.NoError(t, err)
+	for i := range records {
+		if records[i].InvocationType == invocationType {
+			return &records[i]
+		}
+	}
+	t.Fatalf("no evidence record with invocation type %q", invocationType)
+	return nil
+}
+
+func TestProxyDataFlow_ToolArgsToVendorAndResultToClient(t *testing.T) {
+	upstream := proxyFlowUpstream(t)
+	h, store := proxyFlowHandler(t, upstream.URL, true)
+
+	resp := callProxyTool(t, h, `{"query":"lookup `+proxyFlowEmail+`"}`)
+	require.Nil(t, resp.Error)
+
+	ev := proxyEvidenceByType(t, store, "proxy_tool_call")
+	require.NotNil(t, ev.DataFlow)
+	assert.Equal(t, "talon-regex", ev.DataFlow.Detector)
+
+	// Classification block must be populated too.
+	assert.Contains(t, ev.Classification.PIIDetected, "email")
+	assert.True(t, ev.Classification.OutputPIIDetected)
+	assert.Contains(t, ev.Classification.OutputPIITypes, "email")
+	assert.True(t, ev.Classification.PIIRedacted)
+
+	var args, result *evidence.DataFlowItem
+	for i := range ev.DataFlow.Items {
+		switch ev.DataFlow.Items[i].Source {
+		case evidence.FlowSourceToolArgs:
+			args = &ev.DataFlow.Items[i]
+		case evidence.FlowSourceToolResult:
+			result = &ev.DataFlow.Items[i]
+		}
+	}
+	require.NotNil(t, args, "tool_args flow item missing")
+	require.NotNil(t, result, "tool_result flow item missing")
+
+	assert.Equal(t, "crm_lookup", args.SourceDetail)
+	assert.Equal(t, evidence.FlowDispositionForwarded, args.Disposition)
+	assert.Equal(t, evidence.FlowDestMCPTool, args.Destination.Kind)
+	assert.Equal(t, "testvendor", args.Destination.Name)
+	assert.Equal(t, "EU", args.Destination.Region)
+	u, _ := url.Parse(upstream.URL)
+	assert.Equal(t, u.Host, args.Destination.Endpoint)
+	assert.Contains(t, args.EntityTypes, "email")
+	assert.NotEmpty(t, args.ValueDigests)
+
+	assert.Equal(t, evidence.FlowDispositionRedacted, result.Disposition)
+	assert.Equal(t, evidence.FlowDestClient, result.Destination.Kind)
+	assert.Contains(t, result.EntityTypes, "email")
+
+	// Same logical value in args and result -> same digest within the record.
+	digest := evidence.FlowDigest(ev.TenantID, ev.CorrelationID, "email", proxyFlowEmail)
+	assert.Contains(t, args.ValueDigests, digest)
+	assert.Contains(t, result.ValueDigests, digest)
+
+	// No raw PII anywhere in the serialized record.
+	raw, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), proxyFlowEmail)
+
+	assert.True(t, store.VerifyRecord(ev), "signed proxy record with data_flow must verify")
+}
+
+func TestProxyDataFlow_BlockedPIIRequest(t *testing.T) {
+	upstream := proxyFlowUpstream(t)
+	// No redaction rules: intercept mode fails closed on detected PII.
+	h, store := proxyFlowHandler(t, upstream.URL, false)
+
+	resp := callProxyTool(t, h, `{"query":"lookup `+proxyFlowEmail+`"}`)
+	require.NotNil(t, resp.Error, "intercept mode must block PII without redaction rules")
+
+	ev := proxyEvidenceByType(t, store, "proxy_pii_request_detected")
+	require.NotNil(t, ev.DataFlow)
+	require.Len(t, ev.DataFlow.Items, 1)
+	item := ev.DataFlow.Items[0]
+	assert.Equal(t, evidence.FlowSourceToolArgs, item.Source)
+	assert.Equal(t, evidence.FlowDispositionBlocked, item.Disposition,
+		"blocked egress must leave a flow trail with disposition=blocked")
+	assert.Equal(t, "EU", item.Destination.Region)
+	assert.False(t, ev.PolicyDecision.Allowed)
+}
+
+func TestProxyDataFlow_AbsentWhenNoPII(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonrpcRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]interface{}{"content": []interface{}{map[string]interface{}{"type": "text", "text": "no findings"}}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	h, store := proxyFlowHandler(t, srv.URL, true)
+
+	resp := callProxyTool(t, h, `{"query":"weekly report"}`)
+	require.Nil(t, resp.Error)
+
+	ev := proxyEvidenceByType(t, store, "proxy_tool_call")
+	assert.Nil(t, ev.DataFlow, "records without classified data must omit data_flow")
+}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
@@ -133,7 +136,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 	// intercept = block; shadow = audit then block; passthrough = log only then forward.
 	for _, f := range h.config.Proxy.ForbiddenTools {
 		if f == toolName || (strings.HasSuffix(f, "*") && strings.HasPrefix(toolName, strings.TrimSuffix(f, "*"))) {
-			h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, "forbidden_tools")
+			h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, "forbidden_tools", nil)
 			span.SetAttributes(attribute.String("proxy.blocked", "forbidden"))
 			switch h.config.Proxy.Mode {
 			case "intercept", "shadow":
@@ -149,7 +152,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 	proxyInput := &policy.ProxyInput{
 		ToolName:       toolName,
 		Vendor:         h.config.Proxy.Upstream.Vendor,
-		UpstreamRegion: "eu",
+		UpstreamRegion: h.upstreamRegion(),
 		Arguments:      paramsToMap(params.Arguments),
 	}
 	decision, err := h.proxyEngine.EvaluateProxyToolAccess(ctx, proxyInput)
@@ -158,28 +161,33 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
 	}
 	if !decision.Allowed && h.config.Proxy.Mode == "intercept" {
-		h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, strings.Join(decision.Reasons, "; "))
+		h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, strings.Join(decision.Reasons, "; "), nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: strings.Join(decision.Reasons, "; ")}}
 	}
 
 	// PII scan on arguments
+	var flow proxyFlowState
 	if h.classifier != nil {
 		argStr := string(params.Arguments)
 		result := h.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), argStr)
 		if result != nil && len(result.Entities) > 0 {
+			flow.requestEntities = classifier.MergeEntitySpans(argStr, result.Entities)
+			flow.requestTier = result.Tier
 			for _, e := range result.Entities {
 				proxyInput.DetectedPII = append(proxyInput.DetectedPII, e.Type)
 			}
 			piiDecision, piiErr := h.proxyEngine.EvaluateProxyPII(ctx, proxyInput)
 			if piiErr != nil && h.config.Proxy.Mode == "intercept" {
-				h.recordEvidence(ctx, tenantID, "proxy_pii_eval_error", toolName, nil, piiErr.Error())
+				flow.requestBlocked = true
+				h.recordEvidence(ctx, tenantID, "proxy_pii_eval_error", toolName, nil, piiErr.Error(), &flow)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII policy evaluation failed (fail-closed)"}}
 			}
 			if piiDecision != nil && !piiDecision.Allowed && h.config.Proxy.Mode == "intercept" {
-				h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "pii_detected_in_request")
+				flow.requestBlocked = true
+				h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "pii_detected_in_request", &flow)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII detected in request"}}
 			}
-			h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "")
+			h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "", &flow)
 		}
 	}
 
@@ -216,18 +224,22 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			span.SetAttributes(
 				attribute.Bool("proxy.output_pii_detected", true),
 				attribute.StringSlice("proxy.output_pii_types", piiTypes),
+				attribute.String("proxy.upstream_region", h.upstreamRegion()),
 			)
+			flow.responseEntities = classifier.MergeEntitySpans(resultStr, cls.Entities)
+			flow.responseTier = cls.Tier
+			flow.responseRedacted = true
 			redacted := h.classifier.Redact(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), resultStr)
 			var redactedResult interface{}
 			if err := json.Unmarshal([]byte(redacted), &redactedResult); err == nil {
 				out.Result = redactedResult
 			}
-			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_pii_redacted")
+			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_pii_redacted", &flow)
 		} else {
-			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "")
+			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "", &flow)
 		}
 	} else {
-		h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "")
+		h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "", &flow)
 	}
 
 	return &out
@@ -416,7 +428,37 @@ func (h *ProxyHandler) doUpstreamRequest(ctx context.Context, body []byte) (*htt
 	return h.httpClient.Do(req)
 }
 
-func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, toolName string, result []byte, reason string) {
+// proxyFlowState carries in-memory classification results across the proxy
+// pipeline so evidence records get classification and data-flow sections.
+// Entity values stay in memory only — evidence carries digests.
+type proxyFlowState struct {
+	requestEntities  []classifier.PIIEntity // merged (non-overlapping) spans from tool arguments
+	requestTier      int
+	requestBlocked   bool                   // arguments were not forwarded upstream
+	responseEntities []classifier.PIIEntity // merged spans from the tool result
+	responseTier     int
+	responseRedacted bool
+}
+
+// upstreamRegion returns the configured jurisdiction of the upstream vendor
+// endpoint, or "unknown" when not configured. Never a guess.
+func (h *ProxyHandler) upstreamRegion() string {
+	if r := strings.TrimSpace(h.config.Proxy.Upstream.Region); r != "" {
+		return r
+	}
+	return evidence.FlowRegionUnknown
+}
+
+// upstreamEndpointHost returns the host of the upstream URL (no path/query).
+func (h *ProxyHandler) upstreamEndpointHost() string {
+	u, err := url.Parse(h.config.Proxy.Upstream.URL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, toolName string, result []byte, reason string, flow *proxyFlowState) {
 	if h.evidenceStore == nil {
 		return
 	}
@@ -429,9 +471,10 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, 
 	if reason != "" {
 		reasons = []string{reason}
 	}
+	correlationID := "mcp_proxy_" + uuid.New().String()[:8]
 	ev := &evidence.Evidence{
 		ID:              "proxy_" + uuid.New().String()[:8],
-		CorrelationID:   "mcp_proxy_" + uuid.New().String()[:8],
+		CorrelationID:   correlationID,
 		Timestamp:       time.Now(),
 		TenantID:        tenantID,
 		AgentID:         "mcp-proxy",
@@ -443,8 +486,90 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, 
 			Error:       reason,
 		},
 	}
+	if flow != nil {
+		ev.Classification = evidence.Classification{
+			InputTier:         flow.requestTier,
+			OutputTier:        flow.responseTier,
+			PIIDetected:       entityTypeSet(flow.requestEntities),
+			OutputPIIDetected: len(flow.responseEntities) > 0,
+			OutputPIITypes:    entityTypeSet(flow.responseEntities),
+			PIIRedacted:       flow.responseRedacted,
+		}
+		ev.DataFlow = h.buildProxyDataFlow(tenantID, correlationID, toolName, flow)
+		if ev.DataFlow != nil {
+			log.Info().
+				Str("correlation_id", correlationID).
+				Str("tenant_id", tenantID).
+				Str("agent_id", "mcp-proxy").
+				Str("flow_destination", evidence.FlowDestMCPTool+":"+h.config.Proxy.Upstream.Vendor).
+				Str("flow_region", h.upstreamRegion()).
+				Int("flow_items", len(ev.DataFlow.Items)).
+				Msg("data_flow_recorded")
+		}
+	}
 	ev.Explanations = explanation.BuildFromFacts(proxyExplanationFacts(eventType, reason, toolName, allowed))
 	_ = h.evidenceStore.Store(ctx, ev)
+}
+
+// buildProxyDataFlow links classified tool arguments to the upstream vendor
+// and classified tool results to the client. Digests only, never raw values.
+func (h *ProxyHandler) buildProxyDataFlow(tenantID, correlationID, toolName string, flow *proxyFlowState) *evidence.DataFlow {
+	var items []evidence.DataFlowItem
+	if len(flow.requestEntities) > 0 {
+		disposition := evidence.FlowDispositionForwarded
+		if flow.requestBlocked {
+			disposition = evidence.FlowDispositionBlocked
+		}
+		items = append(items, evidence.NewDataFlowItem(
+			tenantID, correlationID,
+			evidence.FlowSourceToolArgs, toolName,
+			flow.requestTier, flow.requestEntities,
+			disposition, evidence.FlowDestination{
+				Kind:     evidence.FlowDestMCPTool,
+				Name:     h.config.Proxy.Upstream.Vendor,
+				Endpoint: h.upstreamEndpointHost(),
+				Region:   h.upstreamRegion(),
+			}))
+	}
+	if len(flow.responseEntities) > 0 {
+		disposition := evidence.FlowDispositionSurfaced
+		if flow.responseRedacted {
+			disposition = evidence.FlowDispositionRedacted
+		}
+		items = append(items, evidence.NewDataFlowItem(
+			tenantID, correlationID,
+			evidence.FlowSourceToolResult, toolName,
+			flow.responseTier, flow.responseEntities,
+			disposition, evidence.FlowDestination{
+				Kind: evidence.FlowDestClient,
+				Name: tenantID,
+			}))
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	detector := ""
+	if h.classifier != nil {
+		detector = h.classifier.Detector()
+	}
+	return &evidence.DataFlow{Detector: detector, Items: items}
+}
+
+// entityTypeSet returns the deduped, sorted entity types of merged spans.
+func entityTypeSet(entities []classifier.PIIEntity) []string {
+	if len(entities) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(entities))
+	for _, e := range entities {
+		set[e.Type] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func proxyExplanationFacts(eventType, reason, toolName string, allowed bool) []explanation.Fact {

--- a/internal/policy/proxy.go
+++ b/internal/policy/proxy.go
@@ -49,6 +49,10 @@ type ProxyConfig struct {
 type UpstreamConfig struct {
 	Vendor string `yaml:"vendor,omitempty" json:"vendor,omitempty"`
 	URL    string `yaml:"url" json:"url"`
+	// Region is the jurisdiction of the upstream endpoint ("EU", "US", ...)
+	// used for policy input and data-flow evidence. When empty, Talon
+	// records "unknown" — it never guesses a region.
+	Region string `yaml:"region,omitempty" json:"region,omitempty"`
 }
 
 // ToolMapping maps a Talon-facing tool name to the vendor's upstream name.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -585,7 +585,7 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		cw := csv.NewWriter(w)
-		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "policy_action", "cost", "model_used", "provider", "input_tokens", "output_tokens", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity"})
+		_ = cw.Write([]string{"id", "timestamp", "tenant_id", "agent_id", "invocation_type", "allowed", "policy_action", "cost", "model_used", "provider", "input_tokens", "output_tokens", "duration_ms", "has_error", "input_tier", "output_tier", "pii_detected", "pii_redacted", "policy_reasons", "tools_called", "input_hash", "output_hash", "upstream_auth_mode", "upstream_key_source", "upstream_key_fingerprint", "gateway_annotations", "primary_explanation_code", "primary_explanation_reason", "primary_version_identity", "flow_destinations", "flow_regions", "flow_entity_types"})
 		for i := range records {
 			rec := &records[i]
 			pii := rec.PIIDetectedCSV()
@@ -598,6 +598,7 @@ func (s *Server) handleEvidenceExport(w http.ResponseWriter, r *http.Request) {
 				strconv.FormatInt(rec.DurationMS, 10), strconv.FormatBool(rec.HasError),
 				strconv.Itoa(rec.InputTier), strconv.Itoa(rec.OutputTier), pii, strconv.FormatBool(rec.PIIRedacted),
 				reasons, tools, rec.InputHash, rec.OutputHash, rec.UpstreamAuthMode, rec.UpstreamKeySource, rec.UpstreamKeyFingerprint, rec.GatewayAnnotationsCSV(), rec.PrimaryExplanationCode, rec.PrimaryExplanationReason, rec.PrimaryVersionIdentity,
+				rec.FlowDestinationsCSV(), rec.FlowRegionsCSV(), rec.FlowEntityTypesCSV(),
 			})
 		}
 		cw.Flush()


### PR DESCRIPTION
## Summary

- Adds optional signed `data_flow` to evidence records (integrity spec v1.1), linking classified data sources to destinations via tier, entity types, and per-request salted digests — never raw PII.
- Gateway and MCP proxy paths populate flow trails (prompt/attachment/response and tool args/results), with configurable `region` on provider/upstream config and `"unknown"` fallback.
- Export CSV gains trailing `flow_destinations` / `flow_regions` / `flow_entity_types` columns; compliance reports aggregate a Data Destinations section for GDPR Art. 30 / EU AI Act evidence support.

Closes #131

## Test plan

- [x] `make test`
- [x] `make check`
- [x] `make lint`
- [x] Gateway e2e: IBAN prompt → provider + response → client flow trail, signature verifies
- [x] MCP proxy: PII tool args → vendor, result → client
- [x] Legacy evidence fixture still parses; records without `data_flow` still verify
- [x] Marshaled evidence never contains raw email/IBAN values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed evidence schema and hot paths (gateway/MCP evidence recording); additive and tested for backward compatibility, but verifiers and exports must understand spec 1.1 for new records.
> 
> **Overview**
> Adds **signed optional `data_flow`** to evidence (integrity spec **v1.1**), recording how classified data moves between sources (prompt, attachment, tool args/results, response) and destinations (LLM provider, MCP tool, client, cache) using tiers, entity types, disposition, and **per-request salted digests**—never raw PII.
> 
> **Gateway** and **MCP proxy** populate flow items at evidence time (including cache hit/store and blocked/redacted paths). **Classifier** gains a pluggable `Analyzer` interface and shared `MergeEntitySpans` (used by redaction and digests). Configurable **`region`** on gateway providers and proxy upstream resolves to metadata or `"unknown"`.
> 
> **Exports** add trailing CSV columns `flow_destinations`, `flow_regions`, `flow_entity_types`; **compliance reports** aggregate a Data Destinations section. Legacy records without `data_flow` keep verifying unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de11b7fd9eea4018b90030599f143486749fdaad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->