### PR TITLE
feat(server): compliance HTTP API for coverage and auditor exports (#129)

### DIFF
--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,20 +189,27 @@ func runAuditorDocument(cmd *cobra.Command, generate auditorDocumentGenerator) e
 	return os.WriteFile(complianceOutput, out, 0o600)
 }
 
-// loadDeclarations gathers declared facts: controller identity from operator
-// config, processing/system declarations from the agent policy file. Both are
-// optional — missing declarations surface as document warnings, not errors.
+// loadDeclarations gathers declared facts for the compliance CLI commands.
 func loadDeclarations(ctx context.Context, cmd *cobra.Command) compliance.Declarations {
+	return loadComplianceDeclarations(ctx, compliancePolicyFile, cmd.ErrOrStderr())
+}
+
+// loadComplianceDeclarations gathers declared facts: controller identity from
+// operator config, processing/system declarations from the agent policy file.
+// Both are optional — missing declarations surface as document warnings, not
+// errors. Shared by the compliance CLI and the `talon serve` compliance API.
+// Load warnings are written to warn (use io.Discard to suppress).
+func loadComplianceDeclarations(ctx context.Context, policyFile string, warn io.Writer) compliance.Declarations {
 	var decl compliance.Declarations
 
 	cfg, err := config.Load()
 	if err != nil {
-		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: could not load talon.config.yaml:", err)
+		fmt.Fprintln(warn, "WARNING: could not load talon.config.yaml:", err)
 	} else {
 		decl.Controller = cfg.ControllerDeclarations()
 	}
 
-	policyPath := compliancePolicyFile
+	policyPath := policyFile
 	if policyPath == "" && cfg != nil {
 		policyPath = cfg.DefaultPolicy
 	}
@@ -211,7 +219,7 @@ func loadDeclarations(ctx context.Context, cmd *cobra.Command) compliance.Declar
 	}
 	pol, err := policy.LoadPolicy(ctx, policyPath, false, filepath.Dir(policyPath))
 	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: could not load agent policy %s: %v\n", policyPath, err)
+		fmt.Fprintf(warn, "WARNING: could not load agent policy %s: %v\n", policyPath, err)
 		return decl
 	}
 	if pol.Compliance != nil {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/dativo-io/talon/internal/attachment"
 	"github.com/dativo-io/talon/internal/cache"
 	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/gateway"
@@ -309,6 +311,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		server.WithOverrideStore(overrideStore),
 		server.WithToolApprovalStore(toolApprovalStore),
 		server.WithGraphEventsHandler(policyEngine, evidenceGen, evidenceStore),
+		// Declared compliance facts for /v1/compliance/* auditor exports.
+		// Loaded per request (like the compliance CLI) so config edits are
+		// picked up without a restart; load warnings surface as document
+		// warnings, not log noise.
+		server.WithComplianceDeclarations(func(ctx context.Context) compliance.Declarations {
+			return loadComplianceDeclarations(ctx, policyPath, io.Discard)
+		}),
 	}
 	if serveDashboard {
 		opts = append(opts, server.WithDashboard(web.DashboardHTML))

--- a/internal/server/handlers_compliance.go
+++ b/internal/server/handlers_compliance.go
@@ -281,5 +281,6 @@ func writeComplianceAttachment(w http.ResponseWriter, format, filename string, o
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename+"."+ext))
 	w.WriteHeader(http.StatusOK)
+	//nolint:gosec // G705: document produced by compliance.RenderDocumentHTML/RenderHTML, which html-escapes all dynamic values (covered by golden tests); JSON variant is json.Marshal output
 	_, _ = w.Write(out)
 }

--- a/internal/server/handlers_compliance.go
+++ b/internal/server/handlers_compliance.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dativo-io/talon/internal/compliance"
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+// complianceEvidenceQueryLimit caps the evidence records loaded for one
+// document generation. Mirrors the cap used by the compliance CLI.
+const complianceEvidenceQueryLimit = 200000
+
+// complianceScope is the parsed, validated query scope shared by all
+// /v1/compliance/* handlers. These routes are admin-only, so tenant/agent are
+// plain filters: empty means all (same semantics as the compliance CLI).
+type complianceScope struct {
+	TenantID string
+	AgentID  string
+	From     time.Time
+	To       time.Time
+	FromStr  string // display form, YYYY-MM-DD
+	ToStr    string
+	Format   string // "html" or "json"
+}
+
+// parseComplianceScope extracts tenant/agent/date/format query parameters.
+// Dates use YYYY-MM-DD (UTC) like the CLI; the end date is inclusive.
+func parseComplianceScope(r *http.Request) (complianceScope, error) {
+	q := r.URL.Query()
+	scope := complianceScope{
+		TenantID: strings.TrimSpace(q.Get("tenant")),
+		AgentID:  strings.TrimSpace(q.Get("agent")),
+		FromStr:  strings.TrimSpace(q.Get("from")),
+		ToStr:    strings.TrimSpace(q.Get("to")),
+		Format:   strings.ToLower(strings.TrimSpace(q.Get("format"))),
+	}
+	if scope.Format == "" {
+		scope.Format = "html"
+	}
+	if scope.Format != "html" && scope.Format != "json" {
+		return scope, fmt.Errorf("unsupported format %q; use html or json", scope.Format)
+	}
+	if scope.FromStr != "" {
+		from, err := time.ParseInLocation("2006-01-02", scope.FromStr, time.UTC)
+		if err != nil {
+			return scope, fmt.Errorf("invalid from date (use YYYY-MM-DD): %w", err)
+		}
+		scope.From = from
+	}
+	if scope.ToStr != "" {
+		to, err := time.ParseInLocation("2006-01-02", scope.ToStr, time.UTC)
+		if err != nil {
+			return scope, fmt.Errorf("invalid to date (use YYYY-MM-DD): %w", err)
+		}
+		scope.To = to.Add(24 * time.Hour) // inclusive end date
+	}
+	return scope, nil
+}
+
+// complianceDeclarations resolves declared facts via the configured loader.
+// Without a loader the zero value is used: generators render flagged
+// placeholder sections, never errors.
+func (s *Server) complianceDeclarations(ctx context.Context) compliance.Declarations {
+	if s.declarationsLoader == nil {
+		return compliance.Declarations{}
+	}
+	return s.declarationsLoader(ctx)
+}
+
+// listComplianceEvidence queries evidence for one document generation.
+func (s *Server) listComplianceEvidence(ctx context.Context, scope complianceScope) ([]evidence.Evidence, error) {
+	if s.evidenceStore == nil {
+		return nil, nil
+	}
+	return s.evidenceStore.List(ctx, scope.TenantID, scope.AgentID, scope.From, scope.To, complianceEvidenceQueryLimit)
+}
+
+// frameworkCoverage is the per-framework summary in the coverage response.
+type frameworkCoverage struct {
+	Framework      string                      `json:"framework"`
+	EvidenceCount  int                         `json:"evidence_count"`
+	DeniedCount    int                         `json:"denied_count"`
+	PIIRecordCount int                         `json:"pii_record_count"`
+	TotalCostEUR   float64                     `json:"total_cost_eur"`
+	Controls       []compliance.ControlMapping `json:"controls"`
+}
+
+// handleComplianceCoverage returns per-framework control coverage for the
+// dashboard compliance mode: built-in control mappings, evidence counts per
+// framework, and declaration warnings for the auditor exports.
+func (s *Server) handleComplianceCoverage(w http.ResponseWriter, r *http.Request) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	// Distinct frameworks in first-appearance order of the built-in mappings.
+	var order []string
+	seen := map[string]bool{}
+	for _, m := range compliance.DefaultMappings() {
+		if !seen[m.Framework] {
+			seen[m.Framework] = true
+			order = append(order, m.Framework)
+		}
+	}
+	frameworks := make([]frameworkCoverage, 0, len(order))
+	for _, fw := range order {
+		rep := compliance.BuildReport(fw, scope.TenantID, scope.AgentID, scope.FromStr, scope.ToStr, list)
+		controls := rep.Mappings
+		if controls == nil {
+			controls = []compliance.ControlMapping{}
+		}
+		frameworks = append(frameworks, frameworkCoverage{
+			Framework:      fw,
+			EvidenceCount:  rep.EvidenceCount,
+			DeniedCount:    rep.DeniedCount,
+			PIIRecordCount: rep.PIIRecordCount,
+			TotalCostEUR:   rep.TotalCostEUR,
+			Controls:       controls,
+		})
+	}
+
+	decl := s.complianceDeclarations(r.Context())
+	ropaWarnings := decl.ValidateForRoPA()
+	if ropaWarnings == nil {
+		ropaWarnings = []string{}
+	}
+	annexWarnings := decl.ValidateForAnnexIV()
+	if annexWarnings == nil {
+		annexWarnings = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"generated_at":         time.Now().UTC().Format(time.RFC3339),
+		"tenant_id":            scope.TenantID,
+		"agent_id":             scope.AgentID,
+		"from":                 scope.FromStr,
+		"to":                   scope.ToStr,
+		"evidence_count_total": len(list),
+		"frameworks":           frameworks,
+		"declaration_warnings": map[string][]string{
+			"ropa":     ropaWarnings,
+			"annex_iv": annexWarnings,
+		},
+		"claim_note": compliance.ClaimNoteFor("GDPR, EU AI Act, NIS2, DORA and ISO 27001 controls"),
+	})
+}
+
+// auditorDocumentGenerator builds one auditor document from declarations,
+// evidence, and the request scope.
+type auditorDocumentGenerator func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error)
+
+// handleComplianceRoPA serves a GDPR Art. 30 Record of Processing Activities
+// as a one-click download (supporting records, not a legal filing).
+func (s *Server) handleComplianceRoPA(w http.ResponseWriter, r *http.Request) {
+	s.serveAuditorDocument(w, r, "ropa", "talon-ropa",
+		func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error) {
+			return compliance.GenerateRoPA(ctx, decl, list, compliance.RoPAOptions{
+				TenantID: scope.TenantID,
+				AgentID:  scope.AgentID,
+				From:     scope.FromStr,
+				To:       scope.ToStr,
+			})
+		})
+}
+
+// handleComplianceAnnexIV serves an EU AI Act Annex IV technical-documentation
+// pack as a one-click download (supporting records, not a legal filing).
+func (s *Server) handleComplianceAnnexIV(w http.ResponseWriter, r *http.Request) {
+	s.serveAuditorDocument(w, r, "annex_iv", "talon-annex-iv",
+		func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error) {
+			return compliance.GenerateAnnexIV(ctx, decl, list, compliance.AnnexIVOptions{
+				TenantID: scope.TenantID,
+				AgentID:  scope.AgentID,
+				From:     scope.FromStr,
+				To:       scope.ToStr,
+			})
+		})
+}
+
+// serveAuditorDocument is the shared handler body for the RoPA and Annex IV
+// endpoints: parse scope, load declarations, query evidence, generate, render,
+// and record control-plane evidence for the export itself.
+func (s *Server) serveAuditorDocument(w http.ResponseWriter, r *http.Request, kind, filename string, generate auditorDocumentGenerator) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	decl := s.complianceDeclarations(r.Context())
+	doc, err := generate(r.Context(), decl, list, scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	var out []byte
+	switch scope.Format {
+	case "json":
+		out, err = compliance.RenderDocumentJSON(doc)
+	default:
+		out, err = compliance.RenderDocumentHTML(doc)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	s.recordControlPlaneAction(r.Context(), scope.TenantID, "compliance_export_"+kind, "admin_api",
+		exportDetail(scope, len(list)))
+	writeComplianceAttachment(w, scope.Format, filename, out)
+}
+
+// handleComplianceReport serves the framework-mapped compliance report
+// (control mappings + evidence aggregates) as a one-click download.
+func (s *Server) handleComplianceReport(w http.ResponseWriter, r *http.Request) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	framework := strings.TrimSpace(r.URL.Query().Get("framework"))
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	report := compliance.BuildReport(framework, scope.TenantID, scope.AgentID, scope.FromStr, scope.ToStr, list)
+	var out []byte
+	switch scope.Format {
+	case "json":
+		out, err = compliance.RenderJSON(report)
+	default:
+		out, err = compliance.RenderHTML(report)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	s.recordControlPlaneAction(r.Context(), scope.TenantID, "compliance_export_report", "admin_api",
+		exportDetail(scope, report.EvidenceCount))
+	writeComplianceAttachment(w, scope.Format, "talon-compliance-report", out)
+}
+
+func exportDetail(scope complianceScope, evidenceCount int) string {
+	detail := fmt.Sprintf("format=%s evidence_count=%d", scope.Format, evidenceCount)
+	if scope.AgentID != "" {
+		detail += " agent=" + scope.AgentID
+	}
+	if scope.FromStr != "" || scope.ToStr != "" {
+		detail += fmt.Sprintf(" range=%s..%s", scope.FromStr, scope.ToStr)
+	}
+	return detail
+}
+
+func writeComplianceAttachment(w http.ResponseWriter, format, filename string, out []byte) {
+	ext := "html"
+	contentType := "text/html; charset=utf-8"
+	if format == "json" {
+		ext = "json"
+		contentType = "application/json"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename+"."+ext))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}

--- a/internal/server/handlers_compliance_test.go
+++ b/internal/server/handlers_compliance_test.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/compliance"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// newComplianceTestServer builds a routed server with an evidence store seeded
+// with records for two tenants, an admin key, one tenant key, and a static
+// declarations loader.
+func newComplianceTestServer(t *testing.T) (http.Handler, *evidence.Store) {
+	t.Helper()
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	gen := evidence.NewGenerator(store)
+	seed := []evidence.GenerateParams{
+		{
+			CorrelationID:  "corr_compliance_a1",
+			TenantID:       "tenant-a",
+			AgentID:        "agent-a",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr", "eu-ai-act"}},
+			Cost:           0.5,
+		},
+		{
+			CorrelationID:  "corr_compliance_a2",
+			TenantID:       "tenant-a",
+			AgentID:        "agent-a",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: false, Action: "deny", Reasons: []string{"budget"}},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr"}},
+		},
+		{
+			CorrelationID:  "corr_compliance_b1",
+			TenantID:       "tenant-b",
+			AgentID:        "agent-b",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr"}},
+		},
+	}
+	for i := range seed {
+		_, err := gen.Generate(context.Background(), seed[i])
+		require.NoError(t, err)
+	}
+
+	srv := NewServer(
+		nil, store, nil, engine, pol, "", nil,
+		"admin-secret",
+		map[string]string{"tenant-secret": "tenant-a"},
+		WithComplianceDeclarations(func(context.Context) compliance.Declarations {
+			return compliance.Declarations{
+				Controller: compliance.ControllerDeclarations{
+					Name:    "Example GmbH",
+					Contact: "privacy@example.eu",
+				},
+			}
+		}),
+	)
+	return srv.Routes(), store
+}
+
+func doComplianceRequest(t *testing.T, h http.Handler, path string, header map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	for k, v := range header {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+var adminHeader = map[string]string{"X-Talon-Admin-Key": "admin-secret"}
+
+func TestComplianceEndpoints_AuthMatrix(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	paths := []string{
+		"/v1/compliance/coverage",
+		"/v1/compliance/ropa",
+		"/v1/compliance/annex-iv",
+		"/v1/compliance/report",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			// Missing credentials.
+			rec := doComplianceRequest(t, srv, path, nil)
+			assert.Equal(t, http.StatusUnauthorized, rec.Code, "missing key must be rejected")
+
+			// Tenant bearer must be rejected: compliance exports are admin-only.
+			rec = doComplianceRequest(t, srv, path, map[string]string{"Authorization": "Bearer tenant-secret"})
+			assert.Equal(t, http.StatusUnauthorized, rec.Code, "tenant key must be rejected")
+
+			// Admin key is accepted.
+			rec = doComplianceRequest(t, srv, path, adminHeader)
+			assert.Equal(t, http.StatusOK, rec.Code, "admin key must be accepted")
+		})
+	}
+}
+
+func TestComplianceCoverage_FrameworksAndWarnings(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/coverage", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		EvidenceCountTotal int `json:"evidence_count_total"`
+		Frameworks         []struct {
+			Framework     string                      `json:"framework"`
+			EvidenceCount int                         `json:"evidence_count"`
+			DeniedCount   int                         `json:"denied_count"`
+			Controls      []compliance.ControlMapping `json:"controls"`
+		} `json:"frameworks"`
+		DeclarationWarnings map[string][]string `json:"declaration_warnings"`
+		ClaimNote           string              `json:"claim_note"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+
+	assert.Equal(t, 3, out.EvidenceCountTotal)
+	byFramework := map[string]int{}
+	for _, fw := range out.Frameworks {
+		byFramework[fw.Framework] = fw.EvidenceCount
+		assert.NotEmpty(t, fw.Controls, "framework %s must list its controls", fw.Framework)
+	}
+	for _, expected := range []string{"gdpr", "eu-ai-act", "nis2", "dora", "iso-27001"} {
+		_, ok := byFramework[expected]
+		assert.True(t, ok, "coverage must include framework %s", expected)
+	}
+	assert.Equal(t, 3, byFramework["gdpr"])
+	assert.Equal(t, 1, byFramework["eu-ai-act"])
+
+	// Controller is declared but processing declarations are not: RoPA warnings
+	// must flag the processing fields, Annex IV the system fields.
+	require.Contains(t, out.DeclarationWarnings, "ropa")
+	require.Contains(t, out.DeclarationWarnings, "annex_iv")
+	assert.NotEmpty(t, out.DeclarationWarnings["ropa"])
+	assert.NotEmpty(t, out.DeclarationWarnings["annex_iv"])
+	for _, w := range out.DeclarationWarnings["ropa"] {
+		assert.NotContains(t, w, "controller.name", "declared controller must not be flagged")
+	}
+
+	assert.Contains(t, out.ClaimNote, "not a completed legal filing")
+}
+
+func TestComplianceRoPA_HTMLDownload(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-ropa.html")
+	body := rec.Body.String()
+	assert.Contains(t, body, "Record of Processing Activities")
+	assert.Contains(t, body, "Example GmbH", "declared controller must render")
+	assert.Contains(t, body, "not a completed legal filing", "claims-discipline footer required")
+}
+
+func TestComplianceRoPA_JSONTenantScoped(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?format=json&tenant=tenant-a", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-ropa.json")
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.Equal(t, "gdpr", doc.Framework)
+	assert.Equal(t, "tenant-a", doc.TenantID)
+	assert.Equal(t, 2, doc.Linkage.EvidenceCount, "tenant filter must exclude tenant-b records")
+	assert.Equal(t, "Example GmbH", findDocTableValue(doc, "Controller"))
+}
+
+func TestComplianceAnnexIV_JSON(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/annex-iv?format=json", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.Equal(t, "eu-ai-act", doc.Framework)
+	assert.Equal(t, 3, doc.Linkage.EvidenceCount)
+	assert.NotEmpty(t, doc.Warnings, "missing system declarations must surface as warnings")
+}
+
+func TestComplianceReport_FrameworkFilter(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/report?format=json&framework=gdpr", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-compliance-report.json")
+
+	var report compliance.Report
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&report))
+	assert.Equal(t, "gdpr", report.Framework)
+	assert.Equal(t, 3, report.EvidenceCount)
+	assert.Equal(t, 1, report.DeniedCount)
+	for _, m := range report.Mappings {
+		assert.Equal(t, "gdpr", m.Framework)
+	}
+}
+
+func TestComplianceExport_InvalidParams(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?format=pdf", adminHeader)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = doComplianceRequest(t, srv, "/v1/compliance/report?from=12-31-2026", adminHeader)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestComplianceExport_RecordsControlPlaneEvidence(t *testing.T) {
+	srv, store := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?tenant=tenant-a", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	list, err := store.List(context.Background(), "tenant-a", "", time.Time{}, time.Time{}, 100)
+	require.NoError(t, err)
+	var found bool
+	for i := range list {
+		if list[i].InvocationType == "control_plane" &&
+			list[i].PolicyDecision.Action == "compliance_export_ropa" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "compliance export must generate a signed control-plane evidence record")
+}
+
+func TestComplianceEndpoints_NoDeclarationsLoaderStillWorks(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	srv := NewServer(nil, store, nil, engine, pol, "", nil, "admin-secret", map[string]string{})
+	rec := doComplianceRequest(t, srv.Routes(), "/v1/compliance/ropa?format=json", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.NotEmpty(t, doc.Warnings, "zero declarations must surface as warnings, not errors")
+}
+
+// findDocTableValue returns the second cell of the first table row whose first
+// cell equals label, searching all document sections.
+func findDocTableValue(doc compliance.Document, label string) string {
+	for _, sec := range doc.Sections {
+		if sec.Table == nil {
+			continue
+		}
+		for _, row := range sec.Table.Rows {
+			if len(row) >= 2 && strings.EqualFold(row[0], label) {
+				return row[1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/dativo-io/talon/internal/agent"
 	"github.com/dativo-io/talon/internal/agent/graphadapter"
+	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/memory"
 	"github.com/dativo-io/talon/internal/metrics"
@@ -57,7 +59,13 @@ type Server struct {
 	eventsReplayBacklog  int
 	eventsRecentMaxLimit int
 	eventsPollInterval   time.Duration
+	declarationsLoader   DeclarationsLoader
 }
+
+// DeclarationsLoader returns the declared compliance facts (controller
+// identity, processing/system declarations) used by the auditor-document
+// endpoints. Loaded per request so config edits are picked up without restart.
+type DeclarationsLoader func(ctx context.Context) compliance.Declarations
 
 // Option configures the Server.
 type Option func(*Server)
@@ -153,6 +161,12 @@ func WithGatewayDashboard(html string) Option {
 // WithMetricsCollector sets the metrics collector for the gateway dashboard API.
 func WithMetricsCollector(c *metrics.Collector) Option {
 	return func(s *Server) { s.metricsCollector = c }
+}
+
+// WithComplianceDeclarations sets the loader for declared compliance facts
+// used by the /v1/compliance/* auditor-document endpoints.
+func WithComplianceDeclarations(loader DeclarationsLoader) Option {
+	return func(s *Server) { s.declarationsLoader = loader }
 }
 
 // WithEventStreamLimits configures SSE stream limits and polling behavior.
@@ -360,6 +374,13 @@ func (s *Server) Routes() http.Handler {
 		// CoPaw dashboard: stats and alerts for CoPaw gateway callers.
 		r.Get("/v1/copaw/stats", s.handleCoPawStats)
 		r.Get("/v1/copaw/alerts", s.handleCoPawAlerts)
+
+		// Compliance: framework coverage and one-click auditor exports
+		// (RoPA, Annex IV, framework report) around internal/compliance.
+		r.Get("/v1/compliance/coverage", s.handleComplianceCoverage)
+		r.Get("/v1/compliance/ropa", s.handleComplianceRoPA)
+		r.Get("/v1/compliance/annex-iv", s.handleComplianceAnnexIV)
+		r.Get("/v1/compliance/report", s.handleComplianceReport)
 	})
 
 	// Dashboard (no auth for same-origin MVP; optional to protect later).


### PR DESCRIPTION
## Summary
- Part 1 of closing #129 / epic #109: expose the `internal/compliance` Go API (built in #173) over admin-authenticated HTTP, so the dashboard can offer framework coverage + one-click RoPA / Annex IV / report exports without the CLI.
- New admin-only endpoints: `GET /v1/compliance/coverage`, `GET /v1/compliance/ropa`, `GET /v1/compliance/annex-iv`, `GET /v1/compliance/report` (`format=html|json`, optional `tenant`, `agent`, `from`, `to` in `YYYY-MM-DD`).
- Every export records a signed control-plane evidence record (evidence-by-default).
- Declarations loading extracted from the cobra command into a shared loader (`loadComplianceDeclarations`) and wired into `talon serve` via `server.WithComplianceDeclarations`, loaded per request to mirror CLI semantics.

## Test plan
- [x] Handler auth matrix: missing key 401, tenant Bearer 401, admin key 200 on all four endpoints
- [x] Coverage payload: all five frameworks with controls, per-framework evidence counts, declaration warnings
- [x] RoPA HTML download contains declared controller + claims-discipline footer; JSON is tenant-scoped (tenant filter excludes other tenants)
- [x] Annex IV + report JSON shapes; invalid format/date → 400
- [x] Control-plane evidence row written per export
- [x] `go test ./internal/server/... ./internal/cmd/... ./internal/compliance/...` and `golangci-lint run` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin APIs read up to 200k evidence records and emit GDPR/EU AI Act auditor documents; access is admin-key gated and tested, but exports are sensitive compliance artifacts.
> 
> **Overview**
> Adds **admin-only HTTP APIs** so the dashboard can drive the same compliance flows as the CLI: framework **coverage** (JSON) and downloadable **RoPA**, **Annex IV**, and **framework report** exports (`format=html|json`, optional `tenant`, `agent`, `from`, `to`).
> 
> Declaration loading is **factored out** of the cobra commands into `loadComplianceDeclarations` (config + policy, warnings to a configurable `io.Writer`). `talon serve` wires it via `server.WithComplianceDeclarations`, reloading **per request** with warnings suppressed (`io.Discard`) so config changes apply without restart.
> 
> Each export records a **signed control-plane evidence** row; routes sit in the existing admin middleware group (tenant bearer rejected). Tests cover auth, payloads, tenant scoping, invalid params, and evidence recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263c78cbee98e41c83c42263e7359bce83874c5e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->