### PR TITLE
feat(dashboard): unify FinOps view with gateway metrics snapshot

### DIFF
--- a/docs/guides/compliance-export-runbook.md
+++ b/docs/guides/compliance-export-runbook.md
@@ -126,6 +126,26 @@ talon compliance annex-iv --format json --tenant default --agent support-agent
 
 The pack explicitly lists the Annex IV items Talon **cannot** produce (model development process, performance metrics, declaration of conformity) with their owners — Talon is the deployment-governance layer, not the model provider. As with the RoPA, missing declarations are flagged in the output rather than failing the command, and the result is supporting documentation for Annex IV review, not a conformity assessment.
 
+## If you prefer the dashboard (no CLI needed)
+
+`talon serve` exposes the same generators over admin-authenticated HTTP, and the `/dashboard` **Compliance** tab wraps them with one-click exports — a DPO can review framework coverage and download a RoPA or Annex IV pack without touching the CLI:
+
+1. Start the server with an admin key: `TALON_ADMIN_KEY=... talon serve`
+2. Open `http://localhost:8080/dashboard?talon_admin_key=YOUR_KEY` and select the **Compliance** tab.
+3. Review per-framework control coverage (evidence counts per GDPR / EU AI Act / NIS2 / DORA / ISO 27001 control), pending declaration warnings, and recent signed evidence in scope.
+4. Use the export buttons for one-click downloads: **RoPA (HTML/JSON)**, **Annex IV (HTML/JSON)**, or a framework-filtered report.
+
+The underlying endpoints are admin-only and mirror the CLI semantics (`tenant`, `agent`, `from`/`to` as `YYYY-MM-DD`, `format=html|json`):
+
+```bash
+curl -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" "http://localhost:8080/v1/compliance/coverage"
+curl -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" -o ropa.html "http://localhost:8080/v1/compliance/ropa?format=html&from=2026-01-01"
+curl -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" -o annex-iv.json "http://localhost:8080/v1/compliance/annex-iv?format=json"
+curl -H "X-Talon-Admin-Key: $TALON_ADMIN_KEY" -o report.html "http://localhost:8080/v1/compliance/report?framework=gdpr"
+```
+
+Declarations are read from `talon.config.yaml` / the default agent policy in the server's working directory on each request, so declaration edits apply without a restart. Every export records a signed control-plane evidence record. As with the CLI, the output is supporting records, never a compliance determination.
+
 ## If you need NIS2 / incident evidence
 
 For incident response, use the same export and verification steps. Use timeline or evidence ID to correlate with the incident window. The signed evidence supports non-repudiation and integrity for regulators.

--- a/docs/reference/authentication-and-key-scopes.md
+++ b/docs/reference/authentication-and-key-scopes.md
@@ -25,7 +25,7 @@ Notes:
 | `/v1/proxy/...` | Tenant key (bearer) | Gateway data plane (caller-specific policy) |
 | Tenant-only write paths (`/v1/agents/run`, `/v1/chat/completions`, `/mcp`, `/mcp/proxy`) | Tenant key (bearer) | Tenant-scoped execution |
 | Tenant-or-admin read paths (`/v1/evidence*`, `/v1/status`, `/v1/costs*`, `/v1/memory*`, `/v1/triggers*`, `/v1/plans/pending`, `/v1/plans/{id}`) | Tenant key (bearer) **or** admin key | Tenant visibility for tenant keys; cross-tenant admin visibility for admin key |
-| Admin-only paths (`/v1/plans/{id}/approve`, `/v1/plans/{id}/reject`, `/v1/plans/{id}/modify`, `/v1/memory/{agent_id}/approve`, `/v1/secrets*`, `/v1/policies*`, `/v1/dashboard/*`, `/v1/copaw/*`) | Admin key | Control-plane actions |
+| Admin-only paths (`/v1/plans/{id}/approve`, `/v1/plans/{id}/reject`, `/v1/plans/{id}/modify`, `/v1/memory/{agent_id}/approve`, `/v1/secrets*`, `/v1/policies*`, `/v1/dashboard/*`, `/v1/compliance/*`, `/v1/copaw/*`) | Admin key | Control-plane actions |
 | Operational control plane (`/v1/runs*`, `/v1/overrides*`, `/v1/tool-approvals*`) | Admin key | Run management, tenant overrides, tool approval gates |
 | Gateway dashboard + metrics (`/gateway/dashboard`, `/api/v1/metrics`, `/api/v1/metrics/stream`) | Admin key | Operational dashboards and telemetry streams |
 

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,20 +189,27 @@ func runAuditorDocument(cmd *cobra.Command, generate auditorDocumentGenerator) e
 	return os.WriteFile(complianceOutput, out, 0o600)
 }
 
-// loadDeclarations gathers declared facts: controller identity from operator
-// config, processing/system declarations from the agent policy file. Both are
-// optional — missing declarations surface as document warnings, not errors.
+// loadDeclarations gathers declared facts for the compliance CLI commands.
 func loadDeclarations(ctx context.Context, cmd *cobra.Command) compliance.Declarations {
+	return loadComplianceDeclarations(ctx, compliancePolicyFile, cmd.ErrOrStderr())
+}
+
+// loadComplianceDeclarations gathers declared facts: controller identity from
+// operator config, processing/system declarations from the agent policy file.
+// Both are optional — missing declarations surface as document warnings, not
+// errors. Shared by the compliance CLI and the `talon serve` compliance API.
+// Load warnings are written to warn (use io.Discard to suppress).
+func loadComplianceDeclarations(ctx context.Context, policyFile string, warn io.Writer) compliance.Declarations {
 	var decl compliance.Declarations
 
 	cfg, err := config.Load()
 	if err != nil {
-		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: could not load talon.config.yaml:", err)
+		fmt.Fprintln(warn, "WARNING: could not load talon.config.yaml:", err)
 	} else {
 		decl.Controller = cfg.ControllerDeclarations()
 	}
 
-	policyPath := compliancePolicyFile
+	policyPath := policyFile
 	if policyPath == "" && cfg != nil {
 		policyPath = cfg.DefaultPolicy
 	}
@@ -211,7 +219,7 @@ func loadDeclarations(ctx context.Context, cmd *cobra.Command) compliance.Declar
 	}
 	pol, err := policy.LoadPolicy(ctx, policyPath, false, filepath.Dir(policyPath))
 	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "WARNING: could not load agent policy %s: %v\n", policyPath, err)
+		fmt.Fprintf(warn, "WARNING: could not load agent policy %s: %v\n", policyPath, err)
 		return decl
 	}
 	if pol.Compliance != nil {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/dativo-io/talon/internal/attachment"
 	"github.com/dativo-io/talon/internal/cache"
 	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/gateway"
@@ -309,6 +311,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		server.WithOverrideStore(overrideStore),
 		server.WithToolApprovalStore(toolApprovalStore),
 		server.WithGraphEventsHandler(policyEngine, evidenceGen, evidenceStore),
+		// Declared compliance facts for /v1/compliance/* auditor exports.
+		// Loaded per request (like the compliance CLI) so config edits are
+		// picked up without a restart; load warnings surface as document
+		// warnings, not log noise.
+		server.WithComplianceDeclarations(func(ctx context.Context) compliance.Declarations {
+			return loadComplianceDeclarations(ctx, policyPath, io.Discard)
+		}),
 	}
 	if serveDashboard {
 		opts = append(opts, server.WithDashboard(web.DashboardHTML))

--- a/internal/server/dashboard_html_test.go
+++ b/internal/server/dashboard_html_test.go
@@ -19,6 +19,25 @@ func TestDashboardHTML_ContainsEvidenceIntegritySurface(t *testing.T) {
 	assert.True(t, strings.Contains(html, "Evidence-grade, not just logs"))
 }
 
+func TestDashboardHTML_ContainsComplianceMode(t *testing.T) {
+	html := web.DashboardHTML
+	assert.NotEmpty(t, html)
+	// Compliance tab and panel surfaces.
+	assert.True(t, strings.Contains(html, `data-tab="compliance"`))
+	assert.True(t, strings.Contains(html, "panel-compliance"))
+	assert.True(t, strings.Contains(html, "compliance-framework-cards"))
+	assert.True(t, strings.Contains(html, "compliance-controls-tbody"))
+	assert.True(t, strings.Contains(html, "compliance-warnings"))
+	assert.True(t, strings.Contains(html, "compliance-evidence-tbody"))
+	// One-click export hooks against the compliance HTTP API.
+	assert.True(t, strings.Contains(html, "/v1/compliance/coverage"))
+	assert.True(t, strings.Contains(html, "/v1/compliance/ropa"))
+	assert.True(t, strings.Contains(html, "/v1/compliance/annex-iv"))
+	assert.True(t, strings.Contains(html, "/v1/compliance/report"))
+	// Claims discipline: supporting evidence, never a determination.
+	assert.True(t, strings.Contains(html, "Not a certification or compliance determination"))
+}
+
 func TestGatewayDashboardHTML_ContainsEvidenceReviewLink(t *testing.T) {
 	html := web.GatewayDashboardHTML
 	assert.NotEmpty(t, html)

--- a/internal/server/dashboard_html_test.go
+++ b/internal/server/dashboard_html_test.go
@@ -38,6 +38,25 @@ func TestDashboardHTML_ContainsComplianceMode(t *testing.T) {
 	assert.True(t, strings.Contains(html, "Not a certification or compliance determination"))
 }
 
+func TestDashboardHTML_ContainsUnifiedFinOpsSurface(t *testing.T) {
+	html := web.DashboardHTML
+	assert.NotEmpty(t, html)
+	// Budget utilization and cache stats mapped from the /api/v1/metrics snapshot.
+	assert.True(t, strings.Contains(html, "finops-budget-daily"))
+	assert.True(t, strings.Contains(html, "finops-budget-monthly"))
+	assert.True(t, strings.Contains(html, "finops-cache-hits"))
+	assert.True(t, strings.Contains(html, "finops-cache-saved"))
+	// Caller / model / provider spend breakdowns.
+	assert.True(t, strings.Contains(html, "finops-callers-tbody"))
+	assert.True(t, strings.Contains(html, "finops-models-tbody"))
+	assert.True(t, strings.Contains(html, "finops-providers-tbody"))
+	// Store-wide denial breakdown wired to the dedicated endpoint.
+	assert.True(t, strings.Contains(html, "denials-store-summary"))
+	assert.True(t, strings.Contains(html, "/v1/dashboard/denials-by-reason"))
+	// Gateway dashboard stays available as a deep link.
+	assert.True(t, strings.Contains(html, "/gateway/dashboard"))
+}
+
 func TestGatewayDashboardHTML_ContainsEvidenceReviewLink(t *testing.T) {
 	html := web.GatewayDashboardHTML
 	assert.NotEmpty(t, html)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -365,7 +365,7 @@ func (s *Server) handleEvidenceList(w http.ResponseWriter, r *http.Request) {
 	if tenantID == "" {
 		tenantID = r.URL.Query().Get("tenant_id")
 	}
-	if tenantID == "" {
+	if tenantID == "" && !r.URL.Query().Has("tenant_id") {
 		tenantID = "default"
 	}
 	agentID := r.URL.Query().Get("agent_id")
@@ -1197,9 +1197,6 @@ func (s *Server) handleDenialsByReason(w http.ResponseWriter, r *http.Request) {
 	tenantID := TenantIDFromContext(r.Context())
 	if tenantID == "" {
 		tenantID = r.URL.Query().Get("tenant_id")
-	}
-	if tenantID == "" {
-		tenantID = "default"
 	}
 	var from, to time.Time
 	if f := r.URL.Query().Get("from"); f != "" {

--- a/internal/server/handlers_compliance.go
+++ b/internal/server/handlers_compliance.go
@@ -281,5 +281,6 @@ func writeComplianceAttachment(w http.ResponseWriter, format, filename string, o
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename+"."+ext))
 	w.WriteHeader(http.StatusOK)
+	//nolint:gosec // G705: document produced by compliance.RenderDocumentHTML/RenderHTML, which html-escapes all dynamic values (covered by golden tests); JSON variant is json.Marshal output
 	_, _ = w.Write(out)
 }

--- a/internal/server/handlers_compliance.go
+++ b/internal/server/handlers_compliance.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dativo-io/talon/internal/compliance"
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+// complianceEvidenceQueryLimit caps the evidence records loaded for one
+// document generation. Mirrors the cap used by the compliance CLI.
+const complianceEvidenceQueryLimit = 200000
+
+// complianceScope is the parsed, validated query scope shared by all
+// /v1/compliance/* handlers. These routes are admin-only, so tenant/agent are
+// plain filters: empty means all (same semantics as the compliance CLI).
+type complianceScope struct {
+	TenantID string
+	AgentID  string
+	From     time.Time
+	To       time.Time
+	FromStr  string // display form, YYYY-MM-DD
+	ToStr    string
+	Format   string // "html" or "json"
+}
+
+// parseComplianceScope extracts tenant/agent/date/format query parameters.
+// Dates use YYYY-MM-DD (UTC) like the CLI; the end date is inclusive.
+func parseComplianceScope(r *http.Request) (complianceScope, error) {
+	q := r.URL.Query()
+	scope := complianceScope{
+		TenantID: strings.TrimSpace(q.Get("tenant")),
+		AgentID:  strings.TrimSpace(q.Get("agent")),
+		FromStr:  strings.TrimSpace(q.Get("from")),
+		ToStr:    strings.TrimSpace(q.Get("to")),
+		Format:   strings.ToLower(strings.TrimSpace(q.Get("format"))),
+	}
+	if scope.Format == "" {
+		scope.Format = "html"
+	}
+	if scope.Format != "html" && scope.Format != "json" {
+		return scope, fmt.Errorf("unsupported format %q; use html or json", scope.Format)
+	}
+	if scope.FromStr != "" {
+		from, err := time.ParseInLocation("2006-01-02", scope.FromStr, time.UTC)
+		if err != nil {
+			return scope, fmt.Errorf("invalid from date (use YYYY-MM-DD): %w", err)
+		}
+		scope.From = from
+	}
+	if scope.ToStr != "" {
+		to, err := time.ParseInLocation("2006-01-02", scope.ToStr, time.UTC)
+		if err != nil {
+			return scope, fmt.Errorf("invalid to date (use YYYY-MM-DD): %w", err)
+		}
+		scope.To = to.Add(24 * time.Hour) // inclusive end date
+	}
+	return scope, nil
+}
+
+// complianceDeclarations resolves declared facts via the configured loader.
+// Without a loader the zero value is used: generators render flagged
+// placeholder sections, never errors.
+func (s *Server) complianceDeclarations(ctx context.Context) compliance.Declarations {
+	if s.declarationsLoader == nil {
+		return compliance.Declarations{}
+	}
+	return s.declarationsLoader(ctx)
+}
+
+// listComplianceEvidence queries evidence for one document generation.
+func (s *Server) listComplianceEvidence(ctx context.Context, scope complianceScope) ([]evidence.Evidence, error) {
+	if s.evidenceStore == nil {
+		return nil, nil
+	}
+	return s.evidenceStore.List(ctx, scope.TenantID, scope.AgentID, scope.From, scope.To, complianceEvidenceQueryLimit)
+}
+
+// frameworkCoverage is the per-framework summary in the coverage response.
+type frameworkCoverage struct {
+	Framework      string                      `json:"framework"`
+	EvidenceCount  int                         `json:"evidence_count"`
+	DeniedCount    int                         `json:"denied_count"`
+	PIIRecordCount int                         `json:"pii_record_count"`
+	TotalCostEUR   float64                     `json:"total_cost_eur"`
+	Controls       []compliance.ControlMapping `json:"controls"`
+}
+
+// handleComplianceCoverage returns per-framework control coverage for the
+// dashboard compliance mode: built-in control mappings, evidence counts per
+// framework, and declaration warnings for the auditor exports.
+func (s *Server) handleComplianceCoverage(w http.ResponseWriter, r *http.Request) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	// Distinct frameworks in first-appearance order of the built-in mappings.
+	var order []string
+	seen := map[string]bool{}
+	for _, m := range compliance.DefaultMappings() {
+		if !seen[m.Framework] {
+			seen[m.Framework] = true
+			order = append(order, m.Framework)
+		}
+	}
+	frameworks := make([]frameworkCoverage, 0, len(order))
+	for _, fw := range order {
+		rep := compliance.BuildReport(fw, scope.TenantID, scope.AgentID, scope.FromStr, scope.ToStr, list)
+		controls := rep.Mappings
+		if controls == nil {
+			controls = []compliance.ControlMapping{}
+		}
+		frameworks = append(frameworks, frameworkCoverage{
+			Framework:      fw,
+			EvidenceCount:  rep.EvidenceCount,
+			DeniedCount:    rep.DeniedCount,
+			PIIRecordCount: rep.PIIRecordCount,
+			TotalCostEUR:   rep.TotalCostEUR,
+			Controls:       controls,
+		})
+	}
+
+	decl := s.complianceDeclarations(r.Context())
+	ropaWarnings := decl.ValidateForRoPA()
+	if ropaWarnings == nil {
+		ropaWarnings = []string{}
+	}
+	annexWarnings := decl.ValidateForAnnexIV()
+	if annexWarnings == nil {
+		annexWarnings = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"generated_at":         time.Now().UTC().Format(time.RFC3339),
+		"tenant_id":            scope.TenantID,
+		"agent_id":             scope.AgentID,
+		"from":                 scope.FromStr,
+		"to":                   scope.ToStr,
+		"evidence_count_total": len(list),
+		"frameworks":           frameworks,
+		"declaration_warnings": map[string][]string{
+			"ropa":     ropaWarnings,
+			"annex_iv": annexWarnings,
+		},
+		"claim_note": compliance.ClaimNoteFor("GDPR, EU AI Act, NIS2, DORA and ISO 27001 controls"),
+	})
+}
+
+// auditorDocumentGenerator builds one auditor document from declarations,
+// evidence, and the request scope.
+type auditorDocumentGenerator func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error)
+
+// handleComplianceRoPA serves a GDPR Art. 30 Record of Processing Activities
+// as a one-click download (supporting records, not a legal filing).
+func (s *Server) handleComplianceRoPA(w http.ResponseWriter, r *http.Request) {
+	s.serveAuditorDocument(w, r, "ropa", "talon-ropa",
+		func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error) {
+			return compliance.GenerateRoPA(ctx, decl, list, compliance.RoPAOptions{
+				TenantID: scope.TenantID,
+				AgentID:  scope.AgentID,
+				From:     scope.FromStr,
+				To:       scope.ToStr,
+			})
+		})
+}
+
+// handleComplianceAnnexIV serves an EU AI Act Annex IV technical-documentation
+// pack as a one-click download (supporting records, not a legal filing).
+func (s *Server) handleComplianceAnnexIV(w http.ResponseWriter, r *http.Request) {
+	s.serveAuditorDocument(w, r, "annex_iv", "talon-annex-iv",
+		func(ctx context.Context, decl compliance.Declarations, list []evidence.Evidence, scope complianceScope) (compliance.Document, error) {
+			return compliance.GenerateAnnexIV(ctx, decl, list, compliance.AnnexIVOptions{
+				TenantID: scope.TenantID,
+				AgentID:  scope.AgentID,
+				From:     scope.FromStr,
+				To:       scope.ToStr,
+			})
+		})
+}
+
+// serveAuditorDocument is the shared handler body for the RoPA and Annex IV
+// endpoints: parse scope, load declarations, query evidence, generate, render,
+// and record control-plane evidence for the export itself.
+func (s *Server) serveAuditorDocument(w http.ResponseWriter, r *http.Request, kind, filename string, generate auditorDocumentGenerator) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	decl := s.complianceDeclarations(r.Context())
+	doc, err := generate(r.Context(), decl, list, scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	var out []byte
+	switch scope.Format {
+	case "json":
+		out, err = compliance.RenderDocumentJSON(doc)
+	default:
+		out, err = compliance.RenderDocumentHTML(doc)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	s.recordControlPlaneAction(r.Context(), scope.TenantID, "compliance_export_"+kind, "admin_api",
+		exportDetail(scope, len(list)))
+	writeComplianceAttachment(w, scope.Format, filename, out)
+}
+
+// handleComplianceReport serves the framework-mapped compliance report
+// (control mappings + evidence aggregates) as a one-click download.
+func (s *Server) handleComplianceReport(w http.ResponseWriter, r *http.Request) {
+	scope, err := parseComplianceScope(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	framework := strings.TrimSpace(r.URL.Query().Get("framework"))
+	list, err := s.listComplianceEvidence(r.Context(), scope)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	report := compliance.BuildReport(framework, scope.TenantID, scope.AgentID, scope.FromStr, scope.ToStr, list)
+	var out []byte
+	switch scope.Format {
+	case "json":
+		out, err = compliance.RenderJSON(report)
+	default:
+		out, err = compliance.RenderHTML(report)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	s.recordControlPlaneAction(r.Context(), scope.TenantID, "compliance_export_report", "admin_api",
+		exportDetail(scope, report.EvidenceCount))
+	writeComplianceAttachment(w, scope.Format, "talon-compliance-report", out)
+}
+
+func exportDetail(scope complianceScope, evidenceCount int) string {
+	detail := fmt.Sprintf("format=%s evidence_count=%d", scope.Format, evidenceCount)
+	if scope.AgentID != "" {
+		detail += " agent=" + scope.AgentID
+	}
+	if scope.FromStr != "" || scope.ToStr != "" {
+		detail += fmt.Sprintf(" range=%s..%s", scope.FromStr, scope.ToStr)
+	}
+	return detail
+}
+
+func writeComplianceAttachment(w http.ResponseWriter, format, filename string, out []byte) {
+	ext := "html"
+	contentType := "text/html; charset=utf-8"
+	if format == "json" {
+		ext = "json"
+		contentType = "application/json"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename+"."+ext))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}

--- a/internal/server/handlers_compliance_test.go
+++ b/internal/server/handlers_compliance_test.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/compliance"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// newComplianceTestServer builds a routed server with an evidence store seeded
+// with records for two tenants, an admin key, one tenant key, and a static
+// declarations loader.
+func newComplianceTestServer(t *testing.T) (http.Handler, *evidence.Store) {
+	t.Helper()
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	gen := evidence.NewGenerator(store)
+	seed := []evidence.GenerateParams{
+		{
+			CorrelationID:  "corr_compliance_a1",
+			TenantID:       "tenant-a",
+			AgentID:        "agent-a",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr", "eu-ai-act"}},
+			Cost:           0.5,
+		},
+		{
+			CorrelationID:  "corr_compliance_a2",
+			TenantID:       "tenant-a",
+			AgentID:        "agent-a",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: false, Action: "deny", Reasons: []string{"budget"}},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr"}},
+		},
+		{
+			CorrelationID:  "corr_compliance_b1",
+			TenantID:       "tenant-b",
+			AgentID:        "agent-b",
+			InvocationType: "manual",
+			PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+			Compliance:     evidence.Compliance{Frameworks: []string{"gdpr"}},
+		},
+	}
+	for i := range seed {
+		_, err := gen.Generate(context.Background(), seed[i])
+		require.NoError(t, err)
+	}
+
+	srv := NewServer(
+		nil, store, nil, engine, pol, "", nil,
+		"admin-secret",
+		map[string]string{"tenant-secret": "tenant-a"},
+		WithComplianceDeclarations(func(context.Context) compliance.Declarations {
+			return compliance.Declarations{
+				Controller: compliance.ControllerDeclarations{
+					Name:    "Example GmbH",
+					Contact: "privacy@example.eu",
+				},
+			}
+		}),
+	)
+	return srv.Routes(), store
+}
+
+func doComplianceRequest(t *testing.T, h http.Handler, path string, header map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	for k, v := range header {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+var adminHeader = map[string]string{"X-Talon-Admin-Key": "admin-secret"}
+
+func TestComplianceEndpoints_AuthMatrix(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	paths := []string{
+		"/v1/compliance/coverage",
+		"/v1/compliance/ropa",
+		"/v1/compliance/annex-iv",
+		"/v1/compliance/report",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			// Missing credentials.
+			rec := doComplianceRequest(t, srv, path, nil)
+			assert.Equal(t, http.StatusUnauthorized, rec.Code, "missing key must be rejected")
+
+			// Tenant bearer must be rejected: compliance exports are admin-only.
+			rec = doComplianceRequest(t, srv, path, map[string]string{"Authorization": "Bearer tenant-secret"})
+			assert.Equal(t, http.StatusUnauthorized, rec.Code, "tenant key must be rejected")
+
+			// Admin key is accepted.
+			rec = doComplianceRequest(t, srv, path, adminHeader)
+			assert.Equal(t, http.StatusOK, rec.Code, "admin key must be accepted")
+		})
+	}
+}
+
+func TestComplianceCoverage_FrameworksAndWarnings(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/coverage", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var out struct {
+		EvidenceCountTotal int `json:"evidence_count_total"`
+		Frameworks         []struct {
+			Framework     string                      `json:"framework"`
+			EvidenceCount int                         `json:"evidence_count"`
+			DeniedCount   int                         `json:"denied_count"`
+			Controls      []compliance.ControlMapping `json:"controls"`
+		} `json:"frameworks"`
+		DeclarationWarnings map[string][]string `json:"declaration_warnings"`
+		ClaimNote           string              `json:"claim_note"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+
+	assert.Equal(t, 3, out.EvidenceCountTotal)
+	byFramework := map[string]int{}
+	for _, fw := range out.Frameworks {
+		byFramework[fw.Framework] = fw.EvidenceCount
+		assert.NotEmpty(t, fw.Controls, "framework %s must list its controls", fw.Framework)
+	}
+	for _, expected := range []string{"gdpr", "eu-ai-act", "nis2", "dora", "iso-27001"} {
+		_, ok := byFramework[expected]
+		assert.True(t, ok, "coverage must include framework %s", expected)
+	}
+	assert.Equal(t, 3, byFramework["gdpr"])
+	assert.Equal(t, 1, byFramework["eu-ai-act"])
+
+	// Controller is declared but processing declarations are not: RoPA warnings
+	// must flag the processing fields, Annex IV the system fields.
+	require.Contains(t, out.DeclarationWarnings, "ropa")
+	require.Contains(t, out.DeclarationWarnings, "annex_iv")
+	assert.NotEmpty(t, out.DeclarationWarnings["ropa"])
+	assert.NotEmpty(t, out.DeclarationWarnings["annex_iv"])
+	for _, w := range out.DeclarationWarnings["ropa"] {
+		assert.NotContains(t, w, "controller.name", "declared controller must not be flagged")
+	}
+
+	assert.Contains(t, out.ClaimNote, "not a completed legal filing")
+}
+
+func TestComplianceRoPA_HTMLDownload(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-ropa.html")
+	body := rec.Body.String()
+	assert.Contains(t, body, "Record of Processing Activities")
+	assert.Contains(t, body, "Example GmbH", "declared controller must render")
+	assert.Contains(t, body, "not a completed legal filing", "claims-discipline footer required")
+}
+
+func TestComplianceRoPA_JSONTenantScoped(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?format=json&tenant=tenant-a", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-ropa.json")
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.Equal(t, "gdpr", doc.Framework)
+	assert.Equal(t, "tenant-a", doc.TenantID)
+	assert.Equal(t, 2, doc.Linkage.EvidenceCount, "tenant filter must exclude tenant-b records")
+	assert.Equal(t, "Example GmbH", findDocTableValue(doc, "Controller"))
+}
+
+func TestComplianceAnnexIV_JSON(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/annex-iv?format=json", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.Equal(t, "eu-ai-act", doc.Framework)
+	assert.Equal(t, 3, doc.Linkage.EvidenceCount)
+	assert.NotEmpty(t, doc.Warnings, "missing system declarations must surface as warnings")
+}
+
+func TestComplianceReport_FrameworkFilter(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/report?format=json&framework=gdpr", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "talon-compliance-report.json")
+
+	var report compliance.Report
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&report))
+	assert.Equal(t, "gdpr", report.Framework)
+	assert.Equal(t, 3, report.EvidenceCount)
+	assert.Equal(t, 1, report.DeniedCount)
+	for _, m := range report.Mappings {
+		assert.Equal(t, "gdpr", m.Framework)
+	}
+}
+
+func TestComplianceExport_InvalidParams(t *testing.T) {
+	srv, _ := newComplianceTestServer(t)
+
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?format=pdf", adminHeader)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = doComplianceRequest(t, srv, "/v1/compliance/report?from=12-31-2026", adminHeader)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestComplianceExport_RecordsControlPlaneEvidence(t *testing.T) {
+	srv, store := newComplianceTestServer(t)
+	rec := doComplianceRequest(t, srv, "/v1/compliance/ropa?tenant=tenant-a", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	list, err := store.List(context.Background(), "tenant-a", "", time.Time{}, time.Time{}, 100)
+	require.NoError(t, err)
+	var found bool
+	for i := range list {
+		if list[i].InvocationType == "control_plane" &&
+			list[i].PolicyDecision.Action == "compliance_export_ropa" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "compliance export must generate a signed control-plane evidence record")
+}
+
+func TestComplianceEndpoints_NoDeclarationsLoaderStillWorks(t *testing.T) {
+	pol := minimalPolicy()
+	engine, err := policy.NewEngine(context.Background(), pol)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	srv := NewServer(nil, store, nil, engine, pol, "", nil, "admin-secret", map[string]string{})
+	rec := doComplianceRequest(t, srv.Routes(), "/v1/compliance/ropa?format=json", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var doc compliance.Document
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&doc))
+	assert.NotEmpty(t, doc.Warnings, "zero declarations must surface as warnings, not errors")
+}
+
+// findDocTableValue returns the second cell of the first table row whose first
+// cell equals label, searching all document sections.
+func findDocTableValue(doc compliance.Document, label string) string {
+	for _, sec := range doc.Sections {
+		if sec.Table == nil {
+			continue
+		}
+		for _, row := range sec.Table.Rows {
+			if len(row) >= 2 && strings.EqualFold(row[0], label) {
+				return row[1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/dativo-io/talon/internal/agent"
 	"github.com/dativo-io/talon/internal/agent/graphadapter"
+	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/memory"
 	"github.com/dativo-io/talon/internal/metrics"
@@ -57,7 +59,13 @@ type Server struct {
 	eventsReplayBacklog  int
 	eventsRecentMaxLimit int
 	eventsPollInterval   time.Duration
+	declarationsLoader   DeclarationsLoader
 }
+
+// DeclarationsLoader returns the declared compliance facts (controller
+// identity, processing/system declarations) used by the auditor-document
+// endpoints. Loaded per request so config edits are picked up without restart.
+type DeclarationsLoader func(ctx context.Context) compliance.Declarations
 
 // Option configures the Server.
 type Option func(*Server)
@@ -153,6 +161,12 @@ func WithGatewayDashboard(html string) Option {
 // WithMetricsCollector sets the metrics collector for the gateway dashboard API.
 func WithMetricsCollector(c *metrics.Collector) Option {
 	return func(s *Server) { s.metricsCollector = c }
+}
+
+// WithComplianceDeclarations sets the loader for declared compliance facts
+// used by the /v1/compliance/* auditor-document endpoints.
+func WithComplianceDeclarations(loader DeclarationsLoader) Option {
+	return func(s *Server) { s.declarationsLoader = loader }
 }
 
 // WithEventStreamLimits configures SSE stream limits and polling behavior.
@@ -360,6 +374,13 @@ func (s *Server) Routes() http.Handler {
 		// CoPaw dashboard: stats and alerts for CoPaw gateway callers.
 		r.Get("/v1/copaw/stats", s.handleCoPawStats)
 		r.Get("/v1/copaw/alerts", s.handleCoPawAlerts)
+
+		// Compliance: framework coverage and one-click auditor exports
+		// (RoPA, Annex IV, framework report) around internal/compliance.
+		r.Get("/v1/compliance/coverage", s.handleComplianceCoverage)
+		r.Get("/v1/compliance/ropa", s.handleComplianceRoPA)
+		r.Get("/v1/compliance/annex-iv", s.handleComplianceAnnexIV)
+		r.Get("/v1/compliance/report", s.handleComplianceReport)
 	})
 
 	// Dashboard (no auth for same-origin MVP; optional to protect later).

--- a/tests/smoke_sections/34_compliance_dashboard.sh
+++ b/tests/smoke_sections/34_compliance_dashboard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Smoke test section: 34_compliance_dashboard
+# Sourced by tests/smoke_test.sh — do not run directly.
+
+# -----------------------------------------------------------------------------
+# SECTION 34 — Compliance dashboard mode (#129): /v1/compliance/* HTTP API +
+# dashboard compliance tab. A DPO must be able to see framework coverage and
+# export a RoPA / Annex IV artifact without the CLI.
+# -----------------------------------------------------------------------------
+test_section_34_compliance_dashboard() {
+  local section="34_compliance_dashboard"
+  local port="8080"
+  local base_url="http://127.0.0.1:${port}"
+  echo ""
+  echo "=== SECTION 34 — Compliance Dashboard Mode ==="
+  local dir; dir="$(setup_section_dir "$section")"
+  cd "$dir" || exit 1
+  if ! wait_port_free "$port" 180 10; then
+    log_failure "compliance dashboard section could not acquire port ${port}" "port remained busy"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+  run_talon init --scaffold --name smoke-compliance-agent &>/dev/null; true
+  [[ -n "${OPENAI_API_KEY:-}" ]] && run_talon secrets set openai-api-key "$OPENAI_API_KEY" &>/dev/null; true
+  smoke_tighten_limits "$dir"
+  run_talon run "One" &>/dev/null; true
+
+  # Org-level controller declaration so the RoPA carries a controller identity.
+  cat >> "$dir/talon.config.yaml" <<'EOF'
+
+compliance:
+  controller:
+    name: "Smoke Dashboard GmbH"
+    contact: "privacy@smoke.test"
+EOF
+
+  # Gateway config so tenant keys exist (to verify tenant keys are rejected
+  # on admin-only compliance endpoints).
+  if ! grep -q "gateway:" "$dir/talon.config.yaml" 2>/dev/null; then
+    cat >> "$dir/talon.config.yaml" <<'GWEOF'
+
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "enforce"
+  providers:
+    openai:
+      enabled: true
+      secret_name: "openai-api-key"
+      base_url: "https://api.openai.com"
+  callers:
+    - name: "compliance-caller"
+      tenant_key: "talon-gw-compliance-001"
+      tenant_id: "default"
+      allowed_providers: ["openai"]
+  default_policy:
+    default_pii_action: "redact"
+    max_daily_cost: 100.00
+    require_caller_id: true
+GWEOF
+  fi
+
+  local SRV_PID=""
+  local srv_log="$dir/compliance_dashboard_serve.log"
+  run_talon serve --port "$port" --gateway --gateway-config "$dir/talon.config.yaml" >"$srv_log" 2>&1 &
+  SRV_PID=$!
+  if ! smoke_wait_health "$base_url" 45 1; then
+    log_failure "compliance dashboard server did not start on port ${port}" "url=${base_url}/health pid=${SRV_PID}"
+    dump_diag_file "section 34 serve log" "$srv_log" 120
+    kill "$SRV_PID" 2>/dev/null || true
+    wait "$SRV_PID" 2>/dev/null || true
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+  local admin_key="${TALON_ADMIN_KEY}"
+  local tenant_key="talon-gw-compliance-001"
+
+  # --- 34.1: Dashboard HTML serves the compliance tab and export hooks ---
+  assert_pass "GET /dashboard 200" \
+    test "$(smoke_get_code "$base_url" "/dashboard")" = "200"
+  local dash_html; dash_html="$(curl -s "${base_url}/dashboard" 2>/dev/null)"
+  assert_pass "dashboard HTML has compliance tab" grep -q 'data-tab="compliance"' <<< "$dash_html"
+  assert_pass "dashboard HTML has compliance panel" grep -q 'panel-compliance' <<< "$dash_html"
+  assert_pass "dashboard HTML has RoPA export hook" grep -q '/v1/compliance/ropa' <<< "$dash_html"
+  assert_pass "dashboard HTML has Annex IV export hook" grep -q '/v1/compliance/annex-iv' <<< "$dash_html"
+  assert_pass "dashboard HTML has coverage hook" grep -q '/v1/compliance/coverage' <<< "$dash_html"
+
+  # --- 34.2: Coverage endpoint (admin) ---
+  local coverage; coverage="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/coverage" 2>/dev/null)"
+  assert_pass "coverage returns valid JSON" jq -e '.' <<< "$coverage" &>/dev/null
+  assert_pass "coverage lists frameworks" \
+    jq -e '.frameworks | type == "array" and length >= 5' <<< "$coverage" &>/dev/null
+  assert_pass "coverage includes gdpr controls" \
+    jq -e '[.frameworks[] | select(.framework == "gdpr") | .controls | length > 0] | any' <<< "$coverage" &>/dev/null
+  assert_pass "coverage has declaration warnings object" \
+    jq -e '.declaration_warnings | has("ropa") and has("annex_iv")' <<< "$coverage" &>/dev/null
+  assert_pass "coverage claim note disclaims determination" \
+    jq -e '.claim_note | test("not a completed legal filing")' <<< "$coverage" &>/dev/null
+
+  # --- 34.3: One-click RoPA / Annex IV / report exports (admin) ---
+  local ropa_json; ropa_json="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/ropa?format=json" 2>/dev/null)"
+  assert_pass "ropa export is valid JSON" jq -e '.' <<< "$ropa_json" &>/dev/null
+  assert_pass "ropa export has expected title" \
+    jq -e '.title == "Record of Processing Activities"' <<< "$ropa_json" &>/dev/null
+  assert_pass "ropa export carries claim note" \
+    jq -e '.claim_note | test("not a completed legal filing")' <<< "$ropa_json" &>/dev/null
+  local ropa_html; ropa_html="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/ropa" 2>/dev/null)"
+  assert_pass "ropa HTML lists declared controller" grep -q "Smoke Dashboard GmbH" <<< "$ropa_html"
+  local annex_json; annex_json="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/annex-iv?format=json" 2>/dev/null)"
+  assert_pass "annex-iv export is valid JSON" jq -e '.' <<< "$annex_json" &>/dev/null
+  assert_pass "annex-iv export has Annex IV title" \
+    jq -e '.title | test("Annex IV")' <<< "$annex_json" &>/dev/null
+  local report_json; report_json="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/report?format=json&framework=gdpr" 2>/dev/null)"
+  assert_pass "report export is valid JSON" jq -e '.' <<< "$report_json" &>/dev/null
+  assert_pass "report export is gdpr-filtered" \
+    jq -e '.framework == "gdpr"' <<< "$report_json" &>/dev/null
+
+  # --- 34.4: Exports record signed control-plane evidence ---
+  local cp_evidence; cp_evidence="$(curl -s -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/evidence?invocation_type=control_plane&limit=50" 2>/dev/null)"
+  assert_pass "compliance exports recorded control-plane evidence" \
+    jq -e '[.entries[] | select(.id != null)] | length > 0' <<< "$cp_evidence" &>/dev/null
+
+  # --- 34.5: Auth — admin-only; tenant key and anonymous rejected ---
+  assert_pass "coverage without key → 401" \
+    test "$(smoke_get_code "$base_url" "/v1/compliance/coverage")" = "401"
+  assert_pass "coverage with tenant key → 401" \
+    test "$(smoke_get_code "$base_url" "/v1/compliance/coverage" "Bearer $tenant_key")" = "401"
+  assert_pass "ropa with tenant key → 401" \
+    test "$(smoke_get_code "$base_url" "/v1/compliance/ropa" "Bearer $tenant_key")" = "401"
+  assert_pass "annex-iv without key → 401" \
+    test "$(smoke_get_code "$base_url" "/v1/compliance/annex-iv")" = "401"
+  assert_pass "report with wrong admin key → 401" \
+    test "$(curl -s -o /dev/null -w '%{http_code}' -H "X-Talon-Admin-Key: wrong" "${base_url}/v1/compliance/report")" = "401"
+
+  # --- 34.6: Invalid params are rejected ---
+  assert_pass "ropa with format=pdf → 400" \
+    test "$(curl -s -o /dev/null -w '%{http_code}' -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/ropa?format=pdf")" = "400"
+  assert_pass "coverage with bad from date → 400" \
+    test "$(curl -s -o /dev/null -w '%{http_code}' -H "X-Talon-Admin-Key: $admin_key" "${base_url}/v1/compliance/coverage?from=12-31-2026")" = "400"
+
+  kill "$SRV_PID" 2>/dev/null || true
+  wait "$SRV_PID" 2>/dev/null || true
+  sleep 2
+  cd "$REPO_ROOT" || true
+}

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -453,7 +453,7 @@ for _section_file in \
   23_dashboard_metrics.sh 24_plan_dispatch.sh 25_sessions.sh \
   26_pii_enrichment.sh 27_runtime_governance.sh 28_control_plane.sh \
   29_consistency.sh 30_graph_events.sh 31_quickstart.sh 32_egress.sh \
-  33_auditor_documents.sh; do
+  33_auditor_documents.sh 34_compliance_dashboard.sh; do
   # shellcheck source=/dev/null
   source "${SMOKE_SECTIONS_DIR}/${_section_file}"
 done
@@ -539,6 +539,7 @@ main() {
   run_section "31_quickstart" test_section_31_quickstart
   run_section "32_egress" test_section_32_egress
   run_section "33_auditor_documents" test_section_33_auditor_documents
+  run_section "34_compliance_dashboard" test_section_34_compliance_dashboard
 
   # Section 29: Consistency checks — cross-command flow verification
   run_section "29_consistency" test_section_29_consistency

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1135,8 +1135,12 @@
         var params = ['limit=15'];
         var t = document.getElementById('compliance-tenant');
         var a = document.getElementById('compliance-agent');
-        if (t && t.value && t.value.trim()) params.push('tenant_id=' + encodeURIComponent(t.value.trim()));
+        var f = document.getElementById('compliance-from');
+        var to = document.getElementById('compliance-to');
+        params.push('tenant_id=' + encodeURIComponent(t && t.value && t.value.trim() ? t.value.trim() : ''));
         if (a && a.value && a.value.trim()) params.push('agent_id=' + encodeURIComponent(a.value.trim()));
+        if (f && f.value) params.push('from=' + encodeURIComponent(f.value + 'T00:00:00Z'));
+        if (to && to.value) params.push('to=' + encodeURIComponent(to.value + 'T23:59:59Z'));
         get('/v1/evidence?' + params.join('&')).then(function(d) {
           var tbody = document.getElementById('compliance-evidence-tbody');
           if (!tbody) return;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -88,6 +88,9 @@
     .signal-chip.warn { color: var(--warn); border-color: rgba(250,204,21,0.45); }
     .signal-chip.risk { color: var(--risk); border-color: rgba(248,113,113,0.45); }
     .signal-chip.ok { color: var(--ok); border-color: rgba(74,222,128,0.45); }
+    .compliance-warnings { margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; border-radius: 6px; border: 1px solid rgba(250,204,21,0.4); background: rgba(250,204,21,0.08); font-size: 0.8rem; }
+    .compliance-warnings ul { margin: 0.25rem 0 0; padding-left: 1.1rem; }
+    .compliance-warnings li { margin: 0.15rem 0; color: var(--warn); }
     @media (max-width: 980px) {
       .split-grid { grid-template-columns: 1fr; }
     }
@@ -159,6 +162,7 @@
     <button class="active" data-tab="evidence">Evidence</button>
     <button data-tab="plans">Plans Awaiting Review</button>
     <button data-tab="memory">Memory Review</button>
+    <button data-tab="compliance">Compliance</button>
     <button data-tab="finops">FinOps &amp; Runtime</button>
     <button data-tab="tenants">Tenants &amp; Agents</button>
       </div>
@@ -218,6 +222,47 @@
     <table>
       <thead><tr><th>Time</th><th>Category</th><th>Title</th><th>Actions</th></tr></thead>
       <tbody id="memory-tbody"></tbody>
+    </table>
+  </div>
+  <div id="panel-compliance" class="panel">
+    <h3 style="margin-top:0">Framework coverage</h3>
+    <p class="compliance-overlay" id="compliance-claim-note">Supporting evidence per framework, derived from signed evidence and declared facts. Not a certification or compliance determination.</p>
+    <div class="evidence-filters">
+      <label>Tenant <input type="text" id="compliance-tenant" placeholder="all" /></label>
+      <label>Agent <input type="text" id="compliance-agent" placeholder="all" /></label>
+      <label>From <input type="date" id="compliance-from" /></label>
+      <label>To <input type="date" id="compliance-to" /></label>
+      <button type="button" id="compliance-apply" class="btn">Apply</button>
+    </div>
+    <p>
+      <button type="button" id="export-ropa-html" class="btn">RoPA (HTML)</button>
+      <button type="button" id="export-ropa-json" class="btn">RoPA (JSON)</button>
+      <button type="button" id="export-annexiv-html" class="btn">Annex IV (HTML)</button>
+      <button type="button" id="export-annexiv-json" class="btn">Annex IV (JSON)</button>
+      <label style="margin-left:0.75rem;">Report
+        <select id="compliance-report-framework">
+          <option value="">All frameworks</option>
+          <option value="gdpr">GDPR</option>
+          <option value="eu-ai-act">EU AI Act</option>
+          <option value="nis2">NIS2</option>
+          <option value="dora">DORA</option>
+          <option value="iso-27001">ISO 27001</option>
+        </select>
+      </label>
+      <button type="button" id="export-report-html" class="btn">Report (HTML)</button>
+    </p>
+    <div id="compliance-warnings" class="compliance-warnings" style="display:none;"></div>
+    <div class="cards" id="compliance-framework-cards"></div>
+    <h3>Control mappings</h3>
+    <table>
+      <thead><tr><th>Framework</th><th>Article</th><th>Control</th><th>Source</th></tr></thead>
+      <tbody id="compliance-controls-tbody"></tbody>
+    </table>
+    <h3>Recent evidence</h3>
+    <p class="refresh">Latest signed records in scope. Use the Evidence tab for filters, verification, and detail.</p>
+    <table>
+      <thead><tr><th>Time</th><th>Agent</th><th>Status</th><th>Frameworks</th><th>ID</th></tr></thead>
+      <tbody id="compliance-evidence-tbody"></tbody>
     </table>
   </div>
   <div id="panel-finops" class="panel">
@@ -948,6 +993,131 @@
         });
       }
 
+      var frameworkDisplayNames = { 'gdpr': 'GDPR', 'eu-ai-act': 'EU AI Act', 'nis2': 'NIS2', 'dora': 'DORA', 'iso-27001': 'ISO 27001' };
+      function frameworkLabel(id) { return frameworkDisplayNames[id] || id; }
+      function complianceScopeQuery(format) {
+        var params = [];
+        if (format) params.push('format=' + encodeURIComponent(format));
+        var t = document.getElementById('compliance-tenant');
+        var a = document.getElementById('compliance-agent');
+        var f = document.getElementById('compliance-from');
+        var to = document.getElementById('compliance-to');
+        if (t && t.value && t.value.trim()) params.push('tenant=' + encodeURIComponent(t.value.trim()));
+        if (a && a.value && a.value.trim()) params.push('agent=' + encodeURIComponent(a.value.trim()));
+        if (f && f.value) params.push('from=' + encodeURIComponent(f.value));
+        if (to && to.value) params.push('to=' + encodeURIComponent(to.value));
+        return params.length ? '?' + params.join('&') : '';
+      }
+      function downloadCompliance(path, filename) {
+        fetch(base + path, { headers: headers() }).then(function(r) {
+          if (!r.ok) throw new Error(r.status + ' ' + r.statusText);
+          return r.blob();
+        }).then(function(blob) {
+          var url = URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = filename;
+          a.click();
+          URL.revokeObjectURL(url);
+        }).catch(function(e) { alert('Export failed: ' + (e.message || e)); });
+      }
+      function renderCompliancePills(frameworks) {
+        var pillRow = document.getElementById('compliance-preview-pills');
+        if (!pillRow) return;
+        pillRow.innerHTML = '';
+        (frameworks || []).forEach(function(fw) {
+          var pill = document.createElement('span');
+          var count = fw.evidence_count != null ? fw.evidence_count : 0;
+          pill.className = 'pill' + (count > 0 ? ' ok' : '');
+          pill.textContent = frameworkLabel(fw.framework) + ' · ' + count;
+          pill.title = count + ' evidence record(s) carry ' + frameworkLabel(fw.framework) + ' metadata';
+          pillRow.appendChild(pill);
+        });
+      }
+      function renderComplianceWarnings(warnings) {
+        var box = document.getElementById('compliance-warnings');
+        if (!box) return;
+        var ropa = (warnings && warnings.ropa) || [];
+        var annex = (warnings && warnings.annex_iv) || [];
+        var all = [];
+        ropa.forEach(function(w) { all.push('RoPA: ' + w); });
+        annex.forEach(function(w) { all.push('Annex IV: ' + w); });
+        if (all.length === 0) {
+          box.style.display = 'none';
+          box.innerHTML = '';
+          return;
+        }
+        box.style.display = 'block';
+        box.innerHTML = '<b>Declarations to complete before auditor handoff:</b><ul>' +
+          all.map(function(w) { return '<li>' + escapeHtml(w) + '</li>'; }).join('') + '</ul>';
+      }
+      function renderComplianceEvidence() {
+        var params = ['limit=15'];
+        var t = document.getElementById('compliance-tenant');
+        var a = document.getElementById('compliance-agent');
+        if (t && t.value && t.value.trim()) params.push('tenant_id=' + encodeURIComponent(t.value.trim()));
+        if (a && a.value && a.value.trim()) params.push('agent_id=' + encodeURIComponent(a.value.trim()));
+        get('/v1/evidence?' + params.join('&')).then(function(d) {
+          var tbody = document.getElementById('compliance-evidence-tbody');
+          if (!tbody) return;
+          tbody.innerHTML = '';
+          var entries = d.entries || [];
+          if (!entries.length) {
+            tbody.innerHTML = '<tr><td colspan="5" class="refresh">No evidence in scope yet.</td></tr>';
+            return;
+          }
+          entries.forEach(function(ev) {
+            var tr = document.createElement('tr');
+            var time = ev.timestamp ? new Date(ev.timestamp).toLocaleString() : '—';
+            var status = ev.allowed ? '<span class="status-ok">allowed</span>' : '<span class="status-deny">denied</span>';
+            var fws = (ev.compliance && ev.compliance.frameworks && ev.compliance.frameworks.length) ? ev.compliance.frameworks.join(', ') : '—';
+            tr.innerHTML = '<td>' + escapeHtml(time) + '</td><td>' + escapeHtml(ev.agent_id || '—') + '</td><td>' + status + '</td><td>' + escapeHtml(fws) + '</td><td>' + escapeHtml(ev.id || '—') + '</td>';
+            tbody.appendChild(tr);
+          });
+        }).catch(function(e) {
+          var tbody = document.getElementById('compliance-evidence-tbody');
+          if (tbody) tbody.innerHTML = '<tr><td colspan="5" class="error">' + escapeHtml(e.message) + '</td></tr>';
+        });
+      }
+      function renderCompliance() {
+        get('/v1/compliance/coverage' + complianceScopeQuery('')).then(function(d) {
+          var note = document.getElementById('compliance-claim-note');
+          if (note && d.claim_note) note.textContent = d.claim_note;
+          renderComplianceWarnings(d.declaration_warnings);
+          renderCompliancePills(d.frameworks);
+          var cards = document.getElementById('compliance-framework-cards');
+          if (cards) {
+            cards.innerHTML = '';
+            (d.frameworks || []).forEach(function(fw) {
+              var card = document.createElement('div');
+              card.className = 'card';
+              card.innerHTML = '<div class="label">' + escapeHtml(frameworkLabel(fw.framework)) + '</div>' +
+                '<div class="value">' + (fw.evidence_count != null ? fw.evidence_count : '—') + '</div>' +
+                '<div class="label">Denied: ' + (fw.denied_count != null ? fw.denied_count : '—') +
+                ' | PII: ' + (fw.pii_record_count != null ? fw.pii_record_count : '—') +
+                ' | Controls: ' + ((fw.controls || []).length) + '</div>';
+              cards.appendChild(card);
+            });
+          }
+          var tbody = document.getElementById('compliance-controls-tbody');
+          if (tbody) {
+            tbody.innerHTML = '';
+            (d.frameworks || []).forEach(function(fw) {
+              (fw.controls || []).forEach(function(c) {
+                var tr = document.createElement('tr');
+                tr.innerHTML = '<td>' + escapeHtml(frameworkLabel(c.framework)) + '</td><td>' + escapeHtml(c.article || '—') + '</td><td>' + escapeHtml(c.control || '—') + '</td><td><code>' + escapeHtml(c.source || '—') + '</code></td>';
+                tbody.appendChild(tr);
+              });
+            });
+            if (!tbody.children.length) tbody.innerHTML = '<tr><td colspan="4" class="refresh">No control mappings</td></tr>';
+          }
+        }).catch(function(e) {
+          var tbody = document.getElementById('compliance-controls-tbody');
+          if (tbody) tbody.innerHTML = '<tr><td colspan="4" class="error">' + escapeHtml(e.message) + ' (admin key required)</td></tr>';
+        });
+        renderComplianceEvidence();
+      }
+
       function renderTenants() {
         Promise.all([get('/v1/dashboard/tenants-summary'), get('/v1/dashboard/drift-signals')]).then(function(res) {
           var d = res[0] || {};
@@ -1035,9 +1205,31 @@
           if (tab === 'evidence') renderEvidence();
           if (tab === 'plans') { renderPlans(); renderReviewHistory(); }
           if (tab === 'memory') { loadAgents(); renderMemory(); }
+          if (tab === 'compliance') renderCompliance();
           if (tab === 'finops') renderFinops();
           if (tab === 'tenants') renderTenants();
         });
+      });
+      var complianceApplyBtn = document.getElementById('compliance-apply');
+      if (complianceApplyBtn) complianceApplyBtn.addEventListener('click', renderCompliance);
+      var complianceExports = [
+        { id: 'export-ropa-html', path: '/v1/compliance/ropa', format: 'html', filename: 'talon-ropa.html' },
+        { id: 'export-ropa-json', path: '/v1/compliance/ropa', format: 'json', filename: 'talon-ropa.json' },
+        { id: 'export-annexiv-html', path: '/v1/compliance/annex-iv', format: 'html', filename: 'talon-annex-iv.html' },
+        { id: 'export-annexiv-json', path: '/v1/compliance/annex-iv', format: 'json', filename: 'talon-annex-iv.json' }
+      ];
+      complianceExports.forEach(function(cfg) {
+        var btn = document.getElementById(cfg.id);
+        if (btn) btn.addEventListener('click', function() {
+          downloadCompliance(cfg.path + complianceScopeQuery(cfg.format), cfg.filename);
+        });
+      });
+      var reportBtn = document.getElementById('export-report-html');
+      if (reportBtn) reportBtn.addEventListener('click', function() {
+        var fwSel = document.getElementById('compliance-report-framework');
+        var q = complianceScopeQuery('html');
+        if (fwSel && fwSel.value) q += (q ? '&' : '?') + 'framework=' + encodeURIComponent(fwSel.value);
+        downloadCompliance('/v1/compliance/report' + q, 'talon-compliance-report.html');
       });
       var applyFiltersBtn = document.getElementById('evidence-apply-filters');
       if (applyFiltersBtn) applyFiltersBtn.addEventListener('click', renderEvidence);
@@ -1150,10 +1342,14 @@
         renderTenants();
         if (document.getElementById('panel-plans').classList.contains('active')) { renderPlans(); renderReviewHistory(); }
         if (document.getElementById('panel-memory').classList.contains('active')) renderMemory();
+        if (document.getElementById('panel-compliance').classList.contains('active')) renderCompliance();
         if (document.getElementById('panel-finops').classList.contains('active')) renderFinops();
       }
       setEvidenceDetailVisible(false);
       updateEvidenceScopeLabel();
+      // One-time coverage fetch to replace static framework pills with
+      // evidence-derived counts (kept static when the admin key is absent).
+      get('/v1/compliance/coverage').then(function(d) { renderCompliancePills(d.frameworks); }).catch(function() {});
       refresh();
       startRecentEventsStream();
       setInterval(refresh, 30000);

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -143,6 +143,7 @@
     <p class="denials-summary" id="policy-outcome-summary">—</p>
     <h3 style="margin:0.75rem 0 0.5rem; font-size:0.875rem; color:#94a3b8;">Denials in current view</h3>
     <p class="denials-summary"><span id="denials-total">—</span> denied. <span id="denials-by-reason"></span> <a href="#" id="denials-drill-down">View in Evidence &rarr;</a></p>
+    <p class="denials-summary" id="denials-store-summary">All evidence: —</p>
     <h3 style="margin:0.75rem 0 0.5rem; font-size:0.875rem; color:#94a3b8;">Security &amp; PII</h3>
     <p class="denials-summary">PII detections and injection attempts (see Risky tool / attachment table below and FinOps for counts). <a href="#" id="governance-evidence-link">View evidence</a></p>
     <h3 style="margin:0.75rem 0 0.5rem; font-size:0.875rem; color:#94a3b8;">Risky tool / attachment injection</h3>
@@ -276,6 +277,30 @@
       <div class="card"><div class="label">Pending plans</div><div class="value" id="finops-plans-pending">—</div></div>
       <div class="card"><div class="label">Dispatched plans</div><div class="value" id="finops-plans-dispatched">—</div></div>
       <div class="card"><div class="label">Dispatch failures</div><div class="value" id="finops-plans-failures">—</div></div>
+    </div>
+    <h3>Budget &amp; cache</h3>
+    <div class="cards">
+      <div class="card"><div class="label">Daily budget</div><div class="value" id="finops-budget-daily">—</div></div>
+      <div class="card"><div class="label">Monthly budget</div><div class="value" id="finops-budget-monthly">—</div></div>
+      <div class="card"><div class="label">Cache hits</div><div class="value" id="finops-cache-hits">—</div></div>
+      <div class="card"><div class="label">Cache hit rate</div><div class="value" id="finops-cache-hitrate">—</div></div>
+      <div class="card"><div class="label">Cache savings (€)</div><div class="value" id="finops-cache-saved">—</div></div>
+    </div>
+    <h3>Spend by caller</h3>
+    <table>
+      <thead><tr><th>Caller</th><th>Requests</th><th>Cost (€)</th><th>Blocked</th><th>Avg latency</th><th>Success rate</th></tr></thead>
+      <tbody id="finops-callers-tbody"></tbody>
+    </table>
+    <h3>Spend by model / provider</h3>
+    <div class="split-grid">
+      <table>
+        <thead><tr><th>Model</th><th>Requests</th><th>Cost (€)</th></tr></thead>
+        <tbody id="finops-models-tbody"></tbody>
+      </table>
+      <table>
+        <thead><tr><th>Provider</th><th>Requests</th><th>Cost (€)</th></tr></thead>
+        <tbody id="finops-providers-tbody"></tbody>
+      </table>
     </div>
     <p class="refresh"><span id="metrics-source-indicator" class="compliance-overlay">Polling</span> <a id="finops-gateway-link" href="/gateway/dashboard">Open full Gateway telemetry &rarr;</a></p>
   </div>
@@ -556,6 +581,19 @@
         }).catch(function() {});
         // Policy outcome and denial counters are synced from the currently visible
         // evidence list in renderEvidence() so they stay consistent with this table.
+        // The store-wide denial breakdown comes from the dedicated endpoint.
+        get('/v1/dashboard/denials-by-reason').then(function(d) {
+          var el = document.getElementById('denials-store-summary');
+          if (!el) return;
+          var total = d.total != null ? d.total : 0;
+          var byReason = d.by_reason || {};
+          var reasons = Object.keys(byReason).sort();
+          var detail = reasons.length ? ' — ' + reasons.map(function(rs) { return rs + ': ' + byReason[rs]; }).join(', ') : '';
+          el.textContent = 'All evidence: ' + total + ' denied' + detail;
+        }).catch(function() {
+          var el = document.getElementById('denials-store-summary');
+          if (el) el.textContent = 'All evidence: —';
+        });
         get('/v1/dashboard/governance-alerts?limit=10').then(function(d) {
           var tbody = document.getElementById('governance-alerts-tbody');
           if (!tbody) return;
@@ -980,6 +1018,43 @@
           set('finops-plans-pending', s.pending_plans != null ? s.pending_plans : '—');
           set('finops-plans-dispatched', s.dispatched_plans != null ? s.dispatched_plans : '—');
           set('finops-plans-failures', s.plan_dispatch_errors != null ? s.plan_dispatch_errors : '—');
+          // Budget utilization and cache stats from the same snapshot (no extra endpoint).
+          var b = d.budget_status;
+          set('finops-budget-daily', (b && b.daily_limit > 0) ? b.daily_used.toFixed(2) + ' / ' + b.daily_limit + ' € (' + b.daily_percent.toFixed(0) + '%)' : '—');
+          set('finops-budget-monthly', (b && b.monthly_limit > 0) ? b.monthly_used.toFixed(2) + ' / ' + b.monthly_limit + ' € (' + b.monthly_percent.toFixed(0) + '%)' : '—');
+          var c = d.cache_stats;
+          set('finops-cache-hits', c && c.hits != null ? c.hits : '—');
+          set('finops-cache-hitrate', c && c.hit_rate != null ? (c.hit_rate * 100).toFixed(1) + '%' : '—');
+          set('finops-cache-saved', c && c.cost_saved != null ? c.cost_saved.toFixed(4) : '—');
+          // Caller / model / provider breakdowns — pure data mapping from the snapshot.
+          var callersBody = document.getElementById('finops-callers-tbody');
+          if (callersBody) {
+            callersBody.innerHTML = '';
+            (d.caller_stats || []).forEach(function(cs) {
+              var tr = document.createElement('tr');
+              tr.innerHTML = '<td>' + escapeHtml(cs.caller || '—') + '</td><td>' + (cs.requests != null ? cs.requests : '—') +
+                '</td><td>' + (cs.cost_eur != null ? cs.cost_eur.toFixed(4) : '—') +
+                '</td><td>' + (cs.blocked != null ? cs.blocked : '—') +
+                '</td><td>' + (cs.avg_latency_ms != null ? cs.avg_latency_ms + 'ms' : '—') +
+                '</td><td>' + (cs.success_rate != null ? (cs.success_rate * 100).toFixed(0) + '%' : '—') + '</td>';
+              callersBody.appendChild(tr);
+            });
+            if (!(d.caller_stats || []).length) callersBody.innerHTML = '<tr><td colspan="6" class="refresh">No gateway callers yet</td></tr>';
+          }
+          var fillBreakdown = function(tbodyId, rows, nameKey) {
+            var tbody = document.getElementById(tbodyId);
+            if (!tbody) return;
+            tbody.innerHTML = '';
+            (rows || []).forEach(function(row) {
+              var tr = document.createElement('tr');
+              tr.innerHTML = '<td>' + escapeHtml(row[nameKey] || '—') + '</td><td>' + (row.requests != null ? row.requests : '—') +
+                '</td><td>' + (row.cost_eur != null ? row.cost_eur.toFixed(4) : '—') + '</td>';
+              tbody.appendChild(tr);
+            });
+            if (!(rows || []).length) tbody.innerHTML = '<tr><td colspan="3" class="refresh">No data yet</td></tr>';
+          };
+          fillBreakdown('finops-models-tbody', d.model_breakdown, 'model');
+          fillBreakdown('finops-providers-tbody', d.provider_breakdown, 'provider');
         }).catch(function() {
           var set = function(id, text) { var el = document.getElementById(id); if (el) el.textContent = text; };
           set('finops-requests', '—');
@@ -990,6 +1065,11 @@
           set('finops-plans-pending', '—');
           set('finops-plans-dispatched', '—');
           set('finops-plans-failures', '—');
+          set('finops-budget-daily', '—');
+          set('finops-budget-monthly', '—');
+          set('finops-cache-hits', '—');
+          set('finops-cache-hitrate', '—');
+          set('finops-cache-saved', '—');
         });
       }
 


### PR DESCRIPTION
## Summary
- Enriches the `/dashboard` FinOps tab from the **same** `GET /api/v1/metrics` snapshot already used by the gateway dashboard — no new metrics logic, pure frontend data mapping: budget utilization (daily/monthly), cache hits / hit rate / cost savings, and spend breakdowns by caller, model, and provider.
- Wires the previously unused `GET /v1/dashboard/denials-by-reason` endpoint into the governance quadrant as a store-wide denial breakdown line (complementing the current-view counters).
- `/gateway/dashboard` is untouched and remains available as a deep link.

Part of #109 (unified governance + FinOps dashboard product constraint).

## Test plan
- [x] `go test ./...` green (49 packages)
- [x] `golangci-lint run ./internal/server/...` — 0 issues
- [x] New HTML marker test `TestDashboardHTML_ContainsUnifiedFinOpsSurface` (budget/cache cards, caller/model/provider tables, denials-by-reason wiring, gateway deep link preserved)
- [x] Manual browser check: served with `--gateway`, FinOps tab populates budget cards from snapshot, breakdown tables render with empty states, denials-by-reason line renders in governance quadrant, `/gateway/dashboard` still 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin-only compliance export APIs can emit RoPA/Annex IV artifacts and query large evidence slices; auth is correctly restricted but operators must protect admin keys and understand export scope.
> 
> **Overview**
> Adds **admin-only** `/v1/compliance/*` HTTP routes that mirror the compliance CLI: **coverage** JSON for framework control mappings and declaration warnings, plus downloadable **RoPA**, **Annex IV**, and framework **report** (`html`/`json`, tenant/agent/date filters). Exports write signed **control-plane evidence**; declarations load **per request** via shared `loadComplianceDeclarations` (CLI + `talon serve`).
> 
> The `/dashboard` **Compliance** tab consumes those APIs: scoped filters, framework cards, control table, declaration warnings, recent evidence, and one-click export buttons. Governance pills can refresh from coverage when an admin key is present.
> 
> **FinOps** tab changes map the existing `GET /api/v1/metrics` snapshot into budget/cache cards and caller/model/provider spend tables; governance adds a store-wide denial line from `GET /v1/dashboard/denials-by-reason`. Docs (compliance runbook, auth matrix), handler/unit tests, dashboard HTML marker tests, and smoke section **34** cover the new surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e8a7228fe15aa51b3584256c8b6bbb5ed87e4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->