### PR TITLE
feat(sovereignty): air-gap deployment mode with egress guard (#132)

### DIFF
--- a/docs/guides/air-gapped-deployment.md
+++ b/docs/guides/air-gapped-deployment.md
@@ -4,21 +4,41 @@ Deploy Talon with **provable in-region operation**: no surprise outbound traffic
 
 This guide implements [feature bet 5.3](https://github.com/dativo-io/talon/issues/111) / issue [#132](https://github.com/dativo-io/talon/issues/132). It supports EU regulated buyers who need evidence that AI traffic stays inside Europe — Talon's structural advantage as a single self-hosted Go binary.
 
-## What air_gap mode does
+## `sovereignty.mode` is the single source of truth
 
-When `sovereignty.deployment_mode: air_gap` is set in `talon.config.yaml`:
+`sovereignty.mode` (`eu_strict` | `eu_preferred` | `global`) is the one knob that
+defines your data-sovereignty posture. When set, it:
 
-1. **Routing** — forces `llm.routing.data_sovereignty_mode: eu_strict` (or requires it if you set it explicitly).
-2. **Gateway egress** — applies deny-by-default egress rules allowing only `EU` and `LOCAL` regions when no custom `gateway.default_policy.egress` block is present.
-3. **Transport guard** — wraps the gateway upstream HTTP client with an allowlist derived from:
+1. **Supersedes** `llm.routing.data_sovereignty_mode` — you set the mode once at the
+   top level; the routing engine inherits it. A conflicting routing value is
+   overridden with a warning.
+2. **Gates providers (fail closed)** — under `eu_strict`, only providers whose
+   jurisdiction is `EU`/`LOCAL` (or that expose an EU region, e.g. Bedrock
+   `eu-central-1`) are allowed. Any other **declared** provider is rejected at
+   startup:
+   - an enabled gateway provider in a non-EU/LOCAL region,
+   - an operator-keyed provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`),
+   - a non-sovereign entry in the `llm.providers` block.
+   Non-sovereign providers that were *not* explicitly configured are simply
+   filtered out of the available set so routing cannot select them.
+
+`eu_preferred` and `global` impose no hard provider gate (routing still applies EU
+preference under `eu_preferred`).
+
+## What air_gap mode adds
+
+`sovereignty.deployment_mode: air_gap` is a **stricter sub-mode**. It implies
+`sovereignty.mode: eu_strict` (setting a looser `mode` is rejected) and adds:
+
+1. **Gateway egress** — applies deny-by-default egress rules allowing only `EU` and `LOCAL` regions when no custom `gateway.default_policy.egress` block is present.
+2. **Transport guard** — wraps the gateway upstream HTTP client with an allowlist derived from:
    - `ollama_base_url`
    - enabled gateway provider `base_url` values
    - optional `sovereignty.allowed_egress_hosts`
    - loopback (`localhost`, `127.0.0.1`, `::1`)
-4. **Crypto hardening** — rejects startup when `TALON_SECRETS_KEY` / `TALON_SIGNING_KEY` are generated defaults (air-gap deployments must use explicit keys).
-5. **Provider regions** — rejects gateway providers whose `region` is not `EU` or `LOCAL`.
+3. **Crypto hardening** — rejects startup when `TALON_SECRETS_KEY` / `TALON_SIGNING_KEY` are generated defaults (air-gap deployments must use explicit keys).
 
-Defense in depth: policy egress blocks disallowed destinations **before** forward; the transport guard catches misconfiguration or code paths that would otherwise surprise-egress.
+Defense in depth: the sovereignty gate rejects non-EU providers at config load; policy egress blocks disallowed destinations **before** forward; the transport guard catches misconfiguration or code paths that would otherwise surprise-egress.
 
 ## Quick start
 
@@ -59,12 +79,15 @@ Point your OpenAI-compatible client at `http://127.0.0.1:8080/v1/proxy/ollama/v1
 
 ```yaml
 sovereignty:
-  deployment_mode: air_gap          # standard | air_gap
+  mode: eu_strict                   # eu_strict | eu_preferred | global (source of truth)
+  deployment_mode: air_gap          # standard | air_gap (air_gap implies eu_strict)
   allowed_egress_hosts:             # optional extension to auto allowlist
     - "llm.internal.example"
 ```
 
-Mirror `llm.routing.data_sovereignty_mode: eu_strict` in agent policies when using `talon run` — gateway and agent paths are configured separately today. See [configuration reference](../reference/configuration.md).
+You no longer need to mirror `llm.routing.data_sovereignty_mode` — it is derived
+from `sovereignty.mode` for both the gateway and `talon run` paths. See
+[configuration reference](../reference/configuration.md).
 
 ## Secrets vault rotation (air-gap hardening)
 

--- a/docs/guides/air-gapped-deployment.md
+++ b/docs/guides/air-gapped-deployment.md
@@ -1,0 +1,105 @@
+# Air-gapped deployment
+
+Deploy Talon with **provable in-region operation**: no surprise outbound traffic except endpoints you explicitly declare (local Ollama or chosen EU LLM providers).
+
+This guide implements [feature bet 5.3](https://github.com/dativo-io/talon/issues/111) / issue [#132](https://github.com/dativo-io/talon/issues/132). It supports EU regulated buyers who need evidence that AI traffic stays inside Europe — Talon's structural advantage as a single self-hosted Go binary.
+
+## What air_gap mode does
+
+When `sovereignty.deployment_mode: air_gap` is set in `talon.config.yaml`:
+
+1. **Routing** — forces `llm.routing.data_sovereignty_mode: eu_strict` (or requires it if you set it explicitly).
+2. **Gateway egress** — applies deny-by-default egress rules allowing only `EU` and `LOCAL` regions when no custom `gateway.default_policy.egress` block is present.
+3. **Transport guard** — wraps the gateway upstream HTTP client with an allowlist derived from:
+   - `ollama_base_url`
+   - enabled gateway provider `base_url` values
+   - optional `sovereignty.allowed_egress_hosts`
+   - loopback (`localhost`, `127.0.0.1`, `::1`)
+4. **Crypto hardening** — rejects startup when `TALON_SECRETS_KEY` / `TALON_SIGNING_KEY` are generated defaults (air-gap deployments must use explicit keys).
+5. **Provider regions** — rejects gateway providers whose `region` is not `EU` or `LOCAL`.
+
+Defense in depth: policy egress blocks disallowed destinations **before** forward; the transport guard catches misconfiguration or code paths that would otherwise surprise-egress.
+
+## Quick start
+
+1. Copy the example config:
+
+   ```bash
+   cp examples/airgap/talon.config.airgap.yaml ~/.talon/talon.config.yaml
+   ```
+
+2. Set explicit crypto keys (required for air_gap):
+
+   ```bash
+   export TALON_SECRETS_KEY="$(openssl rand -hex 16)"
+   export TALON_SIGNING_KEY="$(openssl rand -hex 32)"
+   ```
+
+3. Store local provider credentials in the vault (even for Ollama, use a placeholder if your endpoint has no auth):
+
+   ```bash
+   talon secrets set ollama-api-key 'local-only' --tenant default --agent '*'
+   ```
+
+4. Validate before serving:
+
+   ```bash
+   talon doctor --gateway-config ~/.talon/talon.config.yaml --skip-upstream
+   ```
+
+5. Start the gateway:
+
+   ```bash
+   talon serve --gateway --gateway-config ~/.talon/talon.config.yaml
+   ```
+
+Point your OpenAI-compatible client at `http://127.0.0.1:8080/v1/proxy/ollama/v1/...` with caller bearer `talon-airgap` (from the example config).
+
+## Configuration reference
+
+```yaml
+sovereignty:
+  deployment_mode: air_gap          # standard | air_gap
+  allowed_egress_hosts:             # optional extension to auto allowlist
+    - "llm.internal.example"
+```
+
+Mirror `llm.routing.data_sovereignty_mode: eu_strict` in agent policies when using `talon run` — gateway and agent paths are configured separately today. See [configuration reference](../reference/configuration.md).
+
+## Secrets vault rotation (air-gap hardening)
+
+Rotate secrets on a schedule without plaintext exposure:
+
+```bash
+# Re-encrypt a single secret with a fresh nonce (audited as reason=rotate)
+talon secrets rotate <secret-name>
+
+# Verify vault access audit trail
+talon secrets audit
+```
+
+Every rotation is logged in the vault audit table. Combine with explicit `TALON_SECRETS_KEY` rotation only during a planned maintenance window (re-encrypting the vault requires the current key).
+
+## Verification
+
+CI runs `tests/integration/airgap_test.go` which:
+
+- wires a full gateway in `air_gap` mode;
+- proves allowed LOCAL upstream traffic succeeds;
+- proves a non-allowlisted host is blocked by the egress guard with **zero** upstream calls.
+
+Run locally:
+
+```bash
+go test -race -tags=integration ./tests/integration/ -run AirGap
+```
+
+## Compliance language
+
+Air-gap controls provide **supporting evidence for data-residency and egress discipline**. They do not, by themselves, make a deployment GDPR-, NIS2-, or EU AI Act–compliant. Use `talon compliance ropa` and the sovereignty posture report ([#133](https://github.com/dativo-io/talon/issues/133)) for auditor-facing artifacts.
+
+## Related
+
+- [EU routing and egress policy cookbook](policy-cookbook.md)
+- [Configuration reference](../reference/configuration.md)
+- Example: `examples/airgap/`

--- a/docs/guides/air-gapped-deployment.md
+++ b/docs/guides/air-gapped-deployment.md
@@ -51,14 +51,14 @@ Defense in depth: the sovereignty gate rejects non-EU providers at config load; 
 2. Set explicit crypto keys (required for air_gap):
 
    ```bash
-   export TALON_SECRETS_KEY="$(openssl rand -hex 16)"
-   export TALON_SIGNING_KEY="$(openssl rand -hex 32)"
+   export TALON_SECRETS_KEY="$(openssl rand -hex 32)"   # AES-256: 64 hex chars (32 bytes)
+   export TALON_SIGNING_KEY="$(openssl rand -hex 32)"   # HMAC: 64 hex chars (32 bytes)
    ```
 
 3. Store local provider credentials in the vault (even for Ollama, use a placeholder if your endpoint has no auth):
 
    ```bash
-   talon secrets set ollama-api-key 'local-only' --tenant default --agent '*'
+   talon secrets set ollama-api-key 'local-only'
    ```
 
 4. Validate before serving:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -151,7 +151,7 @@ Optional. When present, the `llm:` block configures the provider registry and da
 | Section | Purpose |
 |---------|---------|
 | `llm.providers` | Map of provider IDs to `type`, `config`, and `enabled`. Used when building providers from config instead of env vars only. |
-| `llm.routing.data_sovereignty_mode` | `eu_strict`, `eu_preferred`, or `global`. When set, the router evaluates each candidate with OPA `routing.rego` and records the selected provider and rejected candidates in evidence. |
+| `llm.routing.data_sovereignty_mode` | `eu_strict`, `eu_preferred`, or `global`. When set, the router evaluates each candidate with OPA `routing.rego` and records the selected provider and rejected candidates in evidence. **Superseded by the top-level [`sovereignty.mode`](#sovereignty-block-data-residency--air-gap)** — when `sovereignty.mode` is set it is the source of truth and overrides this value (with a warning). |
 | `llm.pricing_file` | Path to the LLM pricing table (default: `pricing/models.yaml`). Used for cost estimation in evidence and OTel; see [Provider registry — Cost estimation](provider-registry.md#cost-estimation). |
 
 Example:
@@ -168,6 +168,41 @@ llm:
 ```
 
 See [Provider registry](provider-registry.md) for the full reference.
+
+---
+
+### Sovereignty block (data residency & air-gap)
+
+Optional. The top-level `sovereignty:` block is the **single source of truth** for
+your data-sovereignty posture. When `sovereignty.mode` is set it supersedes
+`llm.routing.data_sovereignty_mode` (a conflicting routing value is overridden
+with a warning) and applies to **both** the `talon run` agent path and the
+gateway. This is the recommended way to declare sovereignty — set it once here
+rather than mirroring it under `llm.routing`.
+
+| Field | Values | Purpose |
+|-------|--------|---------|
+| `sovereignty.mode` | `eu_strict`, `eu_preferred`, `global` | Data-sovereignty posture (source of truth). Under `eu_strict` the **provider gate fails closed**: any explicitly declared provider that is not EU/LOCAL (or EU-region-capable, e.g. Bedrock `eu-central-1`) is rejected at startup — this covers operator-keyed providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), `llm.providers` entries, and enabled gateway upstreams. Non-sovereign providers that were not explicitly configured are filtered out of the router set. `eu_preferred` and `global` impose no hard gate. |
+| `sovereignty.deployment_mode` | `standard`, `air_gap` | `air_gap` is a stricter sub-mode that **implies `eu_strict`** (a looser `mode` is rejected). It adds deny-by-default EU/LOCAL gateway egress, a transport-level egress allowlist guard, and rejects generated default crypto keys. See the [air-gapped deployment guide](../guides/air-gapped-deployment.md). |
+| `sovereignty.allowed_egress_hosts` | list of host or URL strings | Optional extension to the air-gap transport allowlist (in addition to `ollama_base_url`, enabled gateway `base_url`s, and loopback). |
+
+Precedence: `sovereignty.mode` (and `deployment_mode: air_gap`, which forces
+`eu_strict`) wins over `llm.routing.data_sovereignty_mode`. When a `sovereignty`
+block is present in a `--gateway-config` file, it is merged with the operator
+config fail-safe (the stronger posture wins) before validation.
+
+Example:
+
+```yaml
+sovereignty:
+  mode: eu_strict                 # source of truth; gates providers (fail closed)
+  deployment_mode: air_gap        # optional: implies eu_strict + egress hardening
+  allowed_egress_hosts:           # optional extra private EU endpoints
+    - "llm.internal.example"
+```
+
+Validated by `talon doctor` (`sovereignty_providers`, `air_gap_config`, and the
+`air_gap_egress_guard` transport probe).
 
 ---
 
@@ -306,7 +341,9 @@ Behavior:
 
 **Relationship to `llm.routing.data_sovereignty_mode`:** the two controls are
 complementary and share the same sources of truth, but govern different
-planes:
+planes. (Note: `data_sovereignty_mode` is itself set by the top-level
+[`sovereignty.mode`](#sovereignty-block-data-residency--air-gap) when present —
+declare the posture there once.)
 
 - `data_sovereignty_mode` (`eu_strict` / `eu_preferred` / `global`) applies
   when **Talon selects the provider** — agent runs (`talon run`, triggers,

--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -4,11 +4,16 @@ Minimal `talon.config.yaml` for a fully in-region deployment using local Ollama 
 Copy to your Talon data directory and set explicit crypto keys before `talon serve --gateway`.
 
 ```bash
-export TALON_SECRETS_KEY="$(openssl rand -hex 16)"   # 32-byte hex
-export TALON_SIGNING_KEY="$(openssl rand -hex 32)"   # 64-byte hex
+export TALON_SECRETS_KEY="$(openssl rand -hex 32)"   # AES-256: 64 hex chars (32 bytes)
+export TALON_SIGNING_KEY="$(openssl rand -hex 32)"   # HMAC: 64 hex chars (32 bytes)
 cp talon.config.airgap.yaml ~/.talon/talon.config.yaml
+talon secrets set ollama-api-key 'local-only'   # placeholder; Ollama needs no auth
 talon doctor --gateway-config ~/.talon/talon.config.yaml --skip-upstream
 talon serve --gateway --gateway-config ~/.talon/talon.config.yaml
 ```
+
+`talon doctor` should report `0 failures` (a couple of advisory warnings are
+expected: no agent policy is needed for a gateway-only deployment, and an empty
+`forbidden_tools` list).
 
 See [Air-gapped deployment guide](../../docs/guides/air-gapped-deployment.md) for the full runbook.

--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -1,0 +1,14 @@
+# Air-gapped deployment example (#132)
+
+Minimal `talon.config.yaml` for a fully in-region deployment using local Ollama only.
+Copy to your Talon data directory and set explicit crypto keys before `talon serve --gateway`.
+
+```bash
+export TALON_SECRETS_KEY="$(openssl rand -hex 16)"   # 32-byte hex
+export TALON_SIGNING_KEY="$(openssl rand -hex 32)"   # 64-byte hex
+cp talon.config.airgap.yaml ~/.talon/talon.config.yaml
+talon doctor --gateway-config ~/.talon/talon.config.yaml --skip-upstream
+talon serve --gateway --gateway-config ~/.talon/talon.config.yaml
+```
+
+See [Air-gapped deployment guide](../../docs/guides/air-gapped-deployment.md) for the full runbook.

--- a/examples/airgap/talon.config.airgap.yaml
+++ b/examples/airgap/talon.config.airgap.yaml
@@ -1,0 +1,56 @@
+# Air-gapped / in-region operator config (feature bet 5.3).
+# Requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY — no generated defaults.
+
+sovereignty:
+  deployment_mode: air_gap
+  # Optional extra private EU endpoints (host or URL):
+  # allowed_egress_hosts:
+  #   - "llm.internal.example"
+
+ollama_base_url: "http://127.0.0.1:11434"
+
+llm:
+  routing:
+    data_sovereignty_mode: eu_strict
+  providers:
+    ollama:
+      type: ollama
+      enabled: true
+      config:
+        base_url: "http://127.0.0.1:11434"
+
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: enforce
+
+  providers:
+    ollama:
+      enabled: true
+      secret_name: "ollama-api-key"
+      base_url: "http://127.0.0.1:11434"
+      region: "LOCAL"
+      allowed_models: ["llama3", "mistral"]
+
+  callers:
+    - name: "airgap-app"
+      tenant_key: "talon-airgap"
+      tenant_id: "default"
+      team: "platform"
+
+  default_policy:
+    default_pii_action: block
+    max_daily_cost: 50.00
+    require_caller_id: true
+    log_prompts: false
+    log_responses: false
+    # When omitted, air_gap mode applies deny-by-default egress to EU/LOCAL only.
+
+  rate_limits:
+    global_requests_per_min: 120
+    per_caller_requests_per_min: 30
+
+  timeouts:
+    connect_timeout: 10s
+    request_timeout: 60s
+    stream_idle_timeout: 60s

--- a/examples/airgap/talon.config.airgap.yaml
+++ b/examples/airgap/talon.config.airgap.yaml
@@ -2,6 +2,12 @@
 # Requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY — no generated defaults.
 
 sovereignty:
+  # mode is the single source of truth for data sovereignty. It supersedes
+  # llm.routing.data_sovereignty_mode and gates providers: under eu_strict only
+  # EU/LOCAL (or EU-region-capable) providers are allowed; any other declared
+  # provider fails closed at startup. deployment_mode air_gap implies eu_strict,
+  # so the line below is optional here and shown for clarity.
+  mode: eu_strict
   deployment_mode: air_gap
   # Optional extra private EU endpoints (host or URL):
   # allowed_egress_hosts:
@@ -10,8 +16,9 @@ sovereignty:
 ollama_base_url: "http://127.0.0.1:11434"
 
 llm:
-  routing:
-    data_sovereignty_mode: eu_strict
+  # No need to set routing.data_sovereignty_mode — it is derived from
+  # sovereignty.mode (eu_strict here). Setting a conflicting value triggers a
+  # warning and is overridden.
   providers:
     ollama:
       type: ollama

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -28,6 +28,7 @@ import (
 	talonprompt "github.com/dativo-io/talon/internal/prompt"
 	"github.com/dativo-io/talon/internal/secrets"
 	talonsession "github.com/dativo-io/talon/internal/session"
+	"github.com/dativo-io/talon/internal/sovereignty"
 )
 
 var (
@@ -138,6 +139,10 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	}
 	attScanner := attachment.MustNewScanner()
 	extractor := attachment.NewExtractor(cfg.MaxAttachmentMB)
+
+	if err := sovereignty.ValidateSovereignty(cfg, nil); err != nil {
+		return fmt.Errorf("sovereignty validation: %w", err)
+	}
 
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, baseDir)
@@ -314,8 +319,27 @@ func runAgent(cmd *cobra.Command, args []string) error {
 // buildProviders creates LLM providers from OPERATOR-LEVEL environment variables
 // via the provider registry. Ensures openai/anthropic/ollama are always registered
 // so vault-only keys work. Use "talon secrets set openai-api-key <key>" etc.
+//
+// When the effective sovereignty mode is eu_strict, providers that are not
+// EU/LOCAL (and have no EU regions) are filtered out so the available set
+// reflects the declared sovereignty; explicitly keyed non-sovereign providers are
+// rejected earlier by sovereignty.ValidateSovereignty (fail closed).
 func buildProviders(cfg *config.Config) map[string]llm.Provider {
+	mode := cfg.EffectiveSovereigntyMode()
 	providers := make(map[string]llm.Provider)
+
+	register := func(providerType string, configYAML []byte) {
+		if !sovereignty.AllowsProvider(mode, providerType) {
+			log.Debug().
+				Str("provider", providerType).
+				Str("sovereignty_mode", mode).
+				Msg("provider excluded by sovereignty mode")
+			return
+		}
+		if p, err := llm.NewProvider(providerType, configYAML); err == nil {
+			providers[providerType] = p
+		}
+	}
 
 	openaiCfg := map[string]string{"api_key": os.Getenv("OPENAI_API_KEY")}
 	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
@@ -325,34 +349,26 @@ func buildProviders(cfg *config.Config) map[string]llm.Provider {
 		log.Debug().Msg("OPENAI_API_KEY set — using as operator fallback (use vault for production)")
 	}
 	openaiYAML, _ := yaml.Marshal(openaiCfg)
-	if p, err := llm.NewProvider("openai", openaiYAML); err == nil {
-		providers["openai"] = p
-	}
+	register("openai", openaiYAML)
 
 	anthropicCfg := map[string]string{"api_key": os.Getenv("ANTHROPIC_API_KEY")}
 	anthropicYAML, _ := yaml.Marshal(anthropicCfg)
 	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
 		log.Debug().Msg("ANTHROPIC_API_KEY set — using as operator fallback (use vault for production)")
 	}
-	if p, err := llm.NewProvider("anthropic", anthropicYAML); err == nil {
-		providers["anthropic"] = p
-	}
+	register("anthropic", anthropicYAML)
 
 	ollamaCfg := map[string]string{"base_url": cfg.OllamaBaseURL}
 	if ollamaCfg["base_url"] == "" {
 		ollamaCfg["base_url"] = "http://localhost:11434"
 	}
 	ollamaYAML, _ := yaml.Marshal(ollamaCfg)
-	if p, err := llm.NewProvider("ollama", ollamaYAML); err == nil {
-		providers["ollama"] = p
-	}
+	register("ollama", ollamaYAML)
 
 	if region := os.Getenv("AWS_REGION"); region != "" {
 		bedrockCfg := map[string]string{"region": region}
 		bedrockYAML, _ := yaml.Marshal(bedrockCfg)
-		if p, err := llm.NewProvider("bedrock", bedrockYAML); err == nil {
-			providers["bedrock"] = p
-		}
+		register("bedrock", bedrockYAML)
 	}
 
 	return providers

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -82,6 +82,24 @@ func TestBuildProviders_OllamaCustomURL(t *testing.T) {
 	assert.Contains(t, providers, "ollama")
 }
 
+func TestBuildProviders_EUStrictFiltersNonSovereignProviders(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_REGION", "eu-west-1")
+
+	cfg := &config.Config{
+		OllamaBaseURL: "http://localhost:11434",
+		Sovereignty:   &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	providers := buildProviders(cfg)
+	// US providers are filtered out under eu_strict.
+	assert.NotContains(t, providers, "openai")
+	assert.NotContains(t, providers, "anthropic")
+	// LOCAL and EU-region-capable providers remain available.
+	assert.Contains(t, providers, "ollama")
+	assert.Contains(t, providers, "bedrock")
+}
+
 func TestValidatePolicyFile_Valid(t *testing.T) {
 	dir := t.TempDir()
 	policyPath := testutil.WriteTestPolicyFile(t, dir, "valid-agent")

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dativo-io/talon/internal/secrets"
 	"github.com/dativo-io/talon/internal/server"
 	talonsession "github.com/dativo-io/talon/internal/session"
+	"github.com/dativo-io/talon/internal/sovereignty"
 	"github.com/dativo-io/talon/internal/trigger"
 	"github.com/dativo-io/talon/web"
 )
@@ -349,6 +350,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 		gatewayCfg, err := gateway.LoadGatewayConfig(serveGatewayConfig)
 		if err != nil {
 			return fmt.Errorf("loading gateway config: %w", err)
+		}
+		if err := sovereignty.ValidateAirGap(cfg, gatewayCfg); err != nil {
+			return fmt.Errorf("air-gap validation: %w", err)
+		}
+		guard, err := sovereignty.ApplyAirGapPreset(cfg, gatewayCfg)
+		if err != nil {
+			return fmt.Errorf("air-gap preset: %w", err)
+		}
+		if guard != nil {
+			gatewayCfg.UpstreamTransport = guard
+		}
+		if err := gatewayCfg.ApplyDefaults(); err != nil {
+			return fmt.Errorf("gateway defaults: %w", err)
 		}
 		tenantKeys = gatewayCfg.TenantKeyMap()
 		log.Info().Int("tenant_keys", len(tenantKeys)).Int("callers", len(gatewayCfg.Callers)).Msg("gateway_tenant_keys_loaded")

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -351,6 +351,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("loading gateway config: %w", err)
 		}
+		if cfg.Sovereignty == nil {
+			if sc := config.LoadSovereigntyFromFile(serveGatewayConfig); sc != nil {
+				cfg.Sovereignty = sc
+			}
+		}
 		if err := sovereignty.ValidateAirGap(cfg, gatewayCfg); err != nil {
 			return fmt.Errorf("air-gap validation: %w", err)
 		}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -96,7 +97,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	pol, err := policy.LoadPolicy(ctx, policyPath, false, policyBaseDir)
 	if err != nil {
-		return fmt.Errorf("loading policy: %w", err)
+		gatewayOnly := serveGateway || serveProxyQuickstart
+		if gatewayOnly && errors.Is(err, os.ErrNotExist) {
+			pol = &policy.Policy{
+				Agent: policy.AgentConfig{Name: "gateway", Version: "0.0.0"},
+			}
+			log.Warn().Str("path", policyPath).Msg("agent policy not found; using minimal default for gateway-only mode")
+		} else {
+			return fmt.Errorf("loading policy: %w", err)
+		}
 	}
 	policyPath = safePath
 	policyBaseDir = filepath.Dir(safePath) // so pricing and other project paths resolve relative to policy directory
@@ -407,6 +416,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 		})
 		if err != nil {
 			return fmt.Errorf("building quickstart gateway config: %w", err)
+		}
+		if err := sovereignty.ValidateAirGap(cfg, quickstartCfg); err != nil {
+			return fmt.Errorf("air-gap validation: %w", err)
+		}
+		guard, err := sovereignty.ApplyAirGapPreset(cfg, quickstartCfg)
+		if err != nil {
+			return fmt.Errorf("air-gap preset: %w", err)
+		}
+		if guard != nil {
+			quickstartCfg.UpstreamTransport = guard
 		}
 		gatewayPolicy, err := policy.NewGatewayEngine(ctx)
 		if err != nil {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -113,6 +113,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	attScanner := attachment.MustNewScanner()
 	extractor := attachment.NewExtractor(cfg.MaxAttachmentMB)
 
+	if err := sovereignty.ValidateSovereignty(cfg, nil); err != nil {
+		return fmt.Errorf("sovereignty validation: %w", err)
+	}
+
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, policyBaseDir)
 	injectPricingInProviders(providers, pricingTable)
@@ -355,6 +359,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if sc := config.LoadSovereigntyFromFile(serveGatewayConfig); sc != nil {
 				cfg.Sovereignty = sc
 			}
+		}
+		if err := sovereignty.ValidateSovereignty(cfg, gatewayCfg); err != nil {
+			return fmt.Errorf("sovereignty validation: %w", err)
 		}
 		if err := sovereignty.ValidateAirGap(cfg, gatewayCfg); err != nil {
 			return fmt.Errorf("air-gap validation: %w", err)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -113,6 +113,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	attScanner := attachment.MustNewScanner()
 	extractor := attachment.NewExtractor(cfg.MaxAttachmentMB)
 
+	if serveGateway {
+		if err := config.ResolveSovereigntyForGateway(cfg, serveGatewayConfig); err != nil {
+			return fmt.Errorf("resolving sovereignty config: %w", err)
+		}
+	}
+
 	if err := sovereignty.ValidateSovereignty(cfg, nil); err != nil {
 		return fmt.Errorf("sovereignty validation: %w", err)
 	}
@@ -354,9 +360,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		gatewayCfg, err := gateway.LoadGatewayConfig(serveGatewayConfig)
 		if err != nil {
 			return fmt.Errorf("loading gateway config: %w", err)
-		}
-		if err := config.ResolveSovereigntyForGateway(cfg, serveGatewayConfig); err != nil {
-			return fmt.Errorf("resolving sovereignty config: %w", err)
 		}
 		if err := sovereignty.ValidateSovereignty(cfg, gatewayCfg); err != nil {
 			return fmt.Errorf("sovereignty validation: %w", err)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -355,10 +355,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("loading gateway config: %w", err)
 		}
-		if cfg.Sovereignty == nil {
-			if sc := config.LoadSovereigntyFromFile(serveGatewayConfig); sc != nil {
-				cfg.Sovereignty = sc
-			}
+		if err := config.ResolveSovereigntyForGateway(cfg, serveGatewayConfig); err != nil {
+			return fmt.Errorf("resolving sovereignty config: %w", err)
 		}
 		if err := sovereignty.ValidateSovereignty(cfg, gatewayCfg); err != nil {
 			return fmt.Errorf("sovereignty validation: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,31 @@ type LLMConfig struct {
 	PricingFile string                       `mapstructure:"pricing_file"` // path to pricing/models.yaml; default "pricing/models.yaml"
 }
 
+// Sovereignty deployment modes (feature bet 5.3).
+const (
+	SovereigntyModeStandard = "standard"
+	SovereigntyModeAirGap   = "air_gap"
+)
+
+// SovereigntyConfig is the optional sovereignty block from talon.config.yaml.
+type SovereigntyConfig struct {
+	DeploymentMode     string   `mapstructure:"deployment_mode" yaml:"deployment_mode"`
+	AllowedEgressHosts []string `mapstructure:"allowed_egress_hosts" yaml:"allowed_egress_hosts"`
+}
+
+// Mode returns the normalized deployment mode (standard when unset).
+func (c *SovereigntyConfig) Mode() string {
+	if c == nil || c.DeploymentMode == "" {
+		return SovereigntyModeStandard
+	}
+	return c.DeploymentMode
+}
+
+// AirGapEnabled reports whether transport-level egress guarding is active.
+func (c *SovereigntyConfig) AirGapEnabled() bool {
+	return c.Mode() == SovereigntyModeAirGap
+}
+
 // ComplianceConfig is the optional compliance block from talon.config.yaml.
 // It declares org-level facts (controller identity) used to populate auditor
 // exports such as the GDPR Art. 30 RoPA. Declared facts only — runtime facts
@@ -95,15 +120,16 @@ type CacheConfig struct {
 // For tenant-level secrets (LLM API keys, webhook tokens), use the
 // secrets vault (internal/secrets.SecretStore).
 type Config struct {
-	DataDir         string            // Base directory for all state (~/.talon)
-	SecretsKey      string            // AES-256 encryption key for the vault (exactly 32 bytes)
-	SigningKey      string            // HMAC-SHA256 key for evidence signing (≥32 bytes)
-	DefaultPolicy   string            // Filename of the agent policy file (agent.talon.yaml by default)
-	MaxAttachmentMB int               // Maximum attachment size in MB
-	OllamaBaseURL   string            // Ollama API endpoint (operator infrastructure)
-	LLM             *LLMConfig        // Optional: llm block from config file (providers, routing)
-	Cache           *CacheConfig      // Optional: governed semantic cache (off by default)
-	Compliance      *ComplianceConfig // Optional: declared controller identity for auditor exports
+	DataDir         string             // Base directory for all state (~/.talon)
+	SecretsKey      string             // AES-256 encryption key for the vault (exactly 32 bytes)
+	SigningKey      string             // HMAC-SHA256 key for evidence signing (≥32 bytes)
+	DefaultPolicy   string             // Filename of the agent policy file (agent.talon.yaml by default)
+	MaxAttachmentMB int                // Maximum attachment size in MB
+	OllamaBaseURL   string             // Ollama API endpoint (operator infrastructure)
+	LLM             *LLMConfig         // Optional: llm block from config file (providers, routing)
+	Cache           *CacheConfig       // Optional: governed semantic cache (off by default)
+	Compliance      *ComplianceConfig  // Optional: declared controller identity for auditor exports
+	Sovereignty     *SovereigntyConfig // Optional: air-gap / deployment sovereignty mode
 
 	usingDefaultSecretsKey bool
 	usingDefaultSigningKey bool
@@ -191,6 +217,7 @@ func Load() (*Config, error) {
 		LLM:             loadLLMConfig(),
 		Cache:           loadCacheConfig(),
 		Compliance:      loadComplianceConfig(),
+		Sovereignty:     loadSovereigntyConfig(),
 	}
 
 	if cfg.SecretsKey == "" {
@@ -233,6 +260,18 @@ const (
 	DefaultCacheSimilarity          = 0.92
 	DefaultCacheMaxEntriesPerTenant = 10000
 )
+
+// loadSovereigntyConfig reads the optional sovereignty block from Viper.
+func loadSovereigntyConfig() *SovereigntyConfig {
+	if !viper.IsSet("sovereignty") {
+		return nil
+	}
+	var sc SovereigntyConfig
+	if err := viper.UnmarshalKey("sovereignty", &sc); err != nil {
+		return nil
+	}
+	return &sc
+}
 
 // loadComplianceConfig reads the optional compliance block from Viper.
 // Returns nil when absent.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,8 +80,21 @@ const (
 	SovereigntyModeAirGap   = "air_gap"
 )
 
+// Data-sovereignty routing modes. These are the single vocabulary used both for
+// agent routing (routing.rego) and for the top-level sovereignty.mode provider gate.
+const (
+	DataSovereigntyEUStrict    = "eu_strict"
+	DataSovereigntyEUPreferred = "eu_preferred"
+	DataSovereigntyGlobal      = "global"
+)
+
 // SovereigntyConfig is the optional sovereignty block from talon.config.yaml.
+// When SovereigntyMode is set it is the single source of truth for data
+// sovereignty: it supersedes llm.routing.data_sovereignty_mode and gates which
+// providers are allowed. DeploymentMode air_gap additionally implies eu_strict.
 type SovereigntyConfig struct {
+	// SovereigntyMode is the required jurisdiction posture: eu_strict | eu_preferred | global.
+	SovereigntyMode    string   `mapstructure:"mode" yaml:"mode"`
 	DeploymentMode     string   `mapstructure:"deployment_mode" yaml:"deployment_mode"`
 	AllowedEgressHosts []string `mapstructure:"allowed_egress_hosts" yaml:"allowed_egress_hosts"`
 }
@@ -230,11 +243,90 @@ func Load() (*Config, error) {
 		cfg.usingDefaultSigningKey = true
 	}
 
+	if err := cfg.resolveSovereignty(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	return cfg, nil
+}
+
+// EffectiveSovereigntyMode returns the resolved data-sovereignty mode. The
+// top-level sovereignty block is the source of truth: sovereignty.mode wins, and
+// deployment_mode air_gap implies eu_strict. Falls back to
+// llm.routing.data_sovereignty_mode when no sovereignty block mode is declared.
+func (c *Config) EffectiveSovereigntyMode() string {
+	if c.Sovereignty != nil {
+		if c.Sovereignty.AirGapEnabled() {
+			return DataSovereigntyEUStrict
+		}
+		if c.Sovereignty.SovereigntyMode != "" {
+			return c.Sovereignty.SovereigntyMode
+		}
+	}
+	if c.LLM != nil && c.LLM.Routing != nil {
+		return c.LLM.Routing.DataSovereigntyMode
+	}
+	return ""
+}
+
+// resolveSovereignty makes the top-level sovereignty block the single source of
+// truth for data sovereignty (fail closed). It validates the declared mode,
+// reconciles air_gap (which implies eu_strict), and propagates the effective
+// mode into llm.routing.data_sovereignty_mode so the routing engine and provider
+// gate observe one consistent value. A conflicting llm.routing value is
+// overridden with a warning.
+func (c *Config) resolveSovereignty() error {
+	if c.Sovereignty == nil {
+		return nil
+	}
+
+	declared := c.Sovereignty.SovereigntyMode
+	if !validSovereigntyMode(declared) {
+		return fmt.Errorf("sovereignty.mode %q is invalid (use %s, %s, or %s)",
+			declared, DataSovereigntyEUStrict, DataSovereigntyEUPreferred, DataSovereigntyGlobal)
+	}
+
+	effective := declared
+	if c.Sovereignty.AirGapEnabled() {
+		if declared != "" && declared != DataSovereigntyEUStrict {
+			return fmt.Errorf("sovereignty.deployment_mode air_gap requires sovereignty.mode %s (got %q)",
+				DataSovereigntyEUStrict, declared)
+		}
+		effective = DataSovereigntyEUStrict
+	}
+	if effective == "" {
+		return nil
+	}
+
+	if c.LLM == nil {
+		c.LLM = &LLMConfig{}
+	}
+	if c.LLM.Routing == nil {
+		c.LLM.Routing = &LLMRoutingConfig{}
+	}
+	if existing := c.LLM.Routing.DataSovereigntyMode; existing != "" && existing != effective {
+		log.Warn().
+			Str("sovereignty_mode", effective).
+			Str("llm_routing_data_sovereignty_mode", existing).
+			Msg("sovereignty.mode supersedes conflicting llm.routing.data_sovereignty_mode")
+	}
+	c.LLM.Routing.DataSovereigntyMode = effective
+	return nil
+}
+
+// validSovereigntyMode reports whether m is an accepted data-sovereignty mode
+// (empty is accepted: it means "unset").
+func validSovereigntyMode(m string) bool {
+	switch m {
+	case "", DataSovereigntyEUStrict, DataSovereigntyEUPreferred, DataSovereigntyGlobal:
+		return true
+	default:
+		return false
+	}
 }
 
 // DefaultPricingFile is the default path to the LLM pricing table.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 
 	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/cryptoutil"
@@ -271,6 +272,22 @@ func loadSovereigntyConfig() *SovereigntyConfig {
 		return nil
 	}
 	return &sc
+}
+
+// LoadSovereigntyFromFile reads the sovereignty block from a YAML file path.
+// Returns nil when the file does not contain a sovereignty section.
+func LoadSovereigntyFromFile(path string) *SovereigntyConfig {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		Sovereignty *SovereigntyConfig `yaml:"sovereignty"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	return raw.Sovereignty
 }
 
 // loadComplianceConfig reads the optional compliance block from Viper.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,6 +284,11 @@ func (c *Config) resolveSovereignty() error {
 		return nil
 	}
 
+	if dm := c.Sovereignty.DeploymentMode; dm != "" && dm != SovereigntyModeStandard && dm != SovereigntyModeAirGap {
+		return fmt.Errorf("sovereignty.deployment_mode %q is invalid (use %s or %s)",
+			dm, SovereigntyModeStandard, SovereigntyModeAirGap)
+	}
+
 	declared := c.Sovereignty.SovereigntyMode
 	if !validSovereigntyMode(declared) {
 		return fmt.Errorf("sovereignty.mode %q is invalid (use %s, %s, or %s)",
@@ -327,6 +332,90 @@ func validSovereigntyMode(m string) bool {
 	default:
 		return false
 	}
+}
+
+// ResolveSovereigntyForGateway merges the sovereignty block declared in the
+// gateway config file into the operator config, then re-runs the same
+// sovereignty resolution used by Load(). It exists because air-gap deployments
+// commonly declare sovereignty in the gateway config file passed to
+// `talon serve --gateway-config`, while the operator config may already carry a
+// weaker (or empty/standard) sovereignty block that would otherwise mask it.
+//
+// Precedence is fail-safe: the stronger posture from either source is adopted —
+// air_gap is never downgraded, the stricter data-sovereignty mode wins
+// (eu_strict > eu_preferred > global), and allowed_egress_hosts are unioned.
+// Re-running resolution then propagates the effective mode into
+// llm.routing.data_sovereignty_mode and rejects genuine conflicts (e.g.
+// deployment_mode air_gap combined with an explicit non-eu_strict mode).
+func ResolveSovereigntyForGateway(op *Config, gatewayConfigPath string) error {
+	if op == nil || gatewayConfigPath == "" {
+		return nil
+	}
+	gwSov := LoadSovereigntyFromFile(gatewayConfigPath)
+	if gwSov == nil {
+		return nil
+	}
+	if op.Sovereignty == nil {
+		op.Sovereignty = &SovereigntyConfig{}
+	}
+	op.Sovereignty.mergeStronger(gwSov)
+	return op.resolveSovereignty()
+}
+
+// mergeStronger overlays other onto c, adopting the stronger posture per field
+// so that a stronger sovereignty declaration in either source is never silently
+// downgraded.
+func (c *SovereigntyConfig) mergeStronger(other *SovereigntyConfig) {
+	if c == nil || other == nil {
+		return
+	}
+	// Deployment mode: air_gap (the stronger posture) wins; otherwise fill gaps.
+	if other.AirGapEnabled() {
+		c.DeploymentMode = SovereigntyModeAirGap
+	} else if c.DeploymentMode == "" {
+		c.DeploymentMode = other.DeploymentMode
+	}
+	// Data-sovereignty mode: the stricter mode wins.
+	if sovereigntyModeStrength(other.SovereigntyMode) > sovereigntyModeStrength(c.SovereigntyMode) {
+		c.SovereigntyMode = other.SovereigntyMode
+	}
+	// Allowed egress hosts are additive declarations: union both sources.
+	c.AllowedEgressHosts = unionStrings(c.AllowedEgressHosts, other.AllowedEgressHosts)
+}
+
+// sovereigntyModeStrength ranks data-sovereignty modes by strictness so the
+// stronger posture can be selected during a merge.
+func sovereigntyModeStrength(m string) int {
+	switch m {
+	case DataSovereigntyEUStrict:
+		return 3
+	case DataSovereigntyEUPreferred:
+		return 2
+	case DataSovereigntyGlobal:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// unionStrings returns the de-duplicated union of a and b, preserving order
+// (a first, then any new entries from b).
+func unionStrings(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, list := range [][]string{a, b} {
+		for _, s := range list {
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // DefaultPricingFile is the default path to the LLM pricing table.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -359,3 +359,62 @@ func TestEffectiveSovereigntyMode_FallbackToRouting(t *testing.T) {
 	assert.Nil(t, cfg.Sovereignty)
 	assert.Equal(t, DataSovereigntyEUPreferred, cfg.EffectiveSovereigntyMode())
 }
+
+func TestResolveSovereignty_InvalidDeploymentMode(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("sovereignty", map[string]interface{}{"deployment_mode": "offline"})
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deployment_mode")
+}
+
+// TestResolveSovereigntyForGateway_WeakOperatorBlockUpgradedByGatewayAirGap is
+// the regression for the doctor/serve "merge is fragile" bug: a weak (standard)
+// operator sovereignty block must NOT mask a stronger air_gap block declared in
+// the gateway config file.
+func TestResolveSovereigntyForGateway_WeakOperatorBlockUpgradedByGatewayAirGap(t *testing.T) {
+	dir := t.TempDir()
+	gwPath := filepath.Join(dir, "talon.config.airgap.yaml")
+	require.NoError(t, os.WriteFile(gwPath, []byte("sovereignty:\n  deployment_mode: air_gap\n  allowed_egress_hosts: [\"llm.internal.example\"]\n"), 0o600))
+
+	op := &Config{Sovereignty: &SovereigntyConfig{
+		DeploymentMode:     SovereigntyModeStandard,
+		AllowedEgressHosts: []string{"ops.internal.example"},
+	}}
+	require.NoError(t, ResolveSovereigntyForGateway(op, gwPath))
+
+	assert.True(t, op.Sovereignty.AirGapEnabled(), "gateway air_gap must override operator standard")
+	assert.Equal(t, DataSovereigntyEUStrict, op.EffectiveSovereigntyMode())
+	require.NotNil(t, op.LLM)
+	require.NotNil(t, op.LLM.Routing)
+	assert.Equal(t, DataSovereigntyEUStrict, op.LLM.Routing.DataSovereigntyMode)
+	// allowed_egress_hosts from both sources are unioned, not replaced.
+	assert.Contains(t, op.Sovereignty.AllowedEgressHosts, "ops.internal.example")
+	assert.Contains(t, op.Sovereignty.AllowedEgressHosts, "llm.internal.example")
+}
+
+func TestResolveSovereigntyForGateway_AirGapPlusOperatorGlobalErrors(t *testing.T) {
+	dir := t.TempDir()
+	gwPath := filepath.Join(dir, "talon.config.airgap.yaml")
+	require.NoError(t, os.WriteFile(gwPath, []byte("sovereignty:\n  deployment_mode: air_gap\n"), 0o600))
+
+	// Operator explicitly demands global; the gateway demands air_gap. This is a
+	// genuine conflict (air_gap implies eu_strict) and must fail closed.
+	op := &Config{Sovereignty: &SovereigntyConfig{SovereigntyMode: DataSovereigntyGlobal}}
+	err := ResolveSovereigntyForGateway(op, gwPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "air_gap")
+}
+
+func TestResolveSovereigntyForGateway_NoGatewaySovereigntyIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	gwPath := filepath.Join(dir, "talon.config.yaml")
+	require.NoError(t, os.WriteFile(gwPath, []byte("gateway:\n  enabled: true\n"), 0o600))
+
+	op := &Config{Sovereignty: &SovereigntyConfig{SovereigntyMode: DataSovereigntyEUPreferred}}
+	require.NoError(t, ResolveSovereigntyForGateway(op, gwPath))
+	assert.Equal(t, DataSovereigntyEUPreferred, op.EffectiveSovereigntyMode())
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -290,3 +290,72 @@ func TestExampleDockerComposeEnvKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveSovereignty_AirGapImpliesEUStrict(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("sovereignty", map[string]interface{}{"deployment_mode": "air_gap"})
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, DataSovereigntyEUStrict, cfg.EffectiveSovereigntyMode())
+	require.NotNil(t, cfg.LLM)
+	require.NotNil(t, cfg.LLM.Routing)
+	assert.Equal(t, DataSovereigntyEUStrict, cfg.LLM.Routing.DataSovereigntyMode)
+}
+
+func TestResolveSovereignty_ModeSupersedesRouting(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("sovereignty", map[string]interface{}{"mode": "eu_strict"})
+	viper.Set("llm", map[string]interface{}{
+		"routing": map[string]interface{}{"data_sovereignty_mode": "global"},
+	})
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	// sovereignty.mode is the source of truth and overrides the conflicting routing value.
+	assert.Equal(t, DataSovereigntyEUStrict, cfg.EffectiveSovereigntyMode())
+	assert.Equal(t, DataSovereigntyEUStrict, cfg.LLM.Routing.DataSovereigntyMode)
+}
+
+func TestResolveSovereignty_InvalidMode(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("sovereignty", map[string]interface{}{"mode": "eu_only"})
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sovereignty.mode")
+}
+
+func TestResolveSovereignty_AirGapConflictsWithLooserMode(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("sovereignty", map[string]interface{}{
+		"deployment_mode": "air_gap",
+		"mode":            "global",
+	})
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "air_gap")
+}
+
+func TestEffectiveSovereigntyMode_FallbackToRouting(t *testing.T) {
+	resetViper(t)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	viper.Set("llm", map[string]interface{}{
+		"routing": map[string]interface{}{"data_sovereignty_mode": "eu_preferred"},
+	})
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Sovereignty)
+	assert.Equal(t, DataSovereigntyEUPreferred, cfg.EffectiveSovereigntyMode())
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dativo-io/talon/internal/gateway"
 	"github.com/dativo-io/talon/internal/policy"
 	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/sovereignty"
 )
 
 // CheckResult is a single doctor check outcome.
@@ -95,6 +96,7 @@ func checkConfig() []CheckResult {
 	results = append(results, checkCryptoKeys(cfg)...)
 	results = append(results, checkEvidenceDB(cfg))
 	results = append(results, checkCache(cfg))
+	results = append(results, checkAirGap(cfg, nil))
 	return results
 }
 
@@ -297,6 +299,7 @@ func checkGateway(ctx context.Context, opts Options) []CheckResult {
 	results = append(results, checkGatewayMode(gwCfg))
 	results = append(results, checkGatewayCallers(gwCfg))
 	results = append(results, checkGatewayToolPolicy(gwCfg))
+	results = append(results, checkAirGapFromGateway(gwCfg))
 
 	if !opts.SkipUpstream {
 		results = append(results, checkGatewayUpstreams(ctx, gwCfg)...)
@@ -519,4 +522,42 @@ func checkSystem() []CheckResult {
 	}
 
 	return results
+}
+
+func checkAirGap(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
+	if cfg.Sovereignty == nil || !cfg.Sovereignty.AirGapEnabled() {
+		return CheckResult{
+			Name: "air_gap_mode", Category: "sovereignty", Status: "pass",
+			Message: "standard deployment (sovereignty.deployment_mode not air_gap)",
+		}
+	}
+	if cfg.UsingDefaultKeys() {
+		return CheckResult{
+			Name: "air_gap_crypto_keys", Category: "sovereignty", Status: "fail",
+			Message: "air_gap requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY",
+			Fix:     "Set both keys via env vars before enabling air_gap mode",
+		}
+	}
+	if err := sovereignty.ValidateAirGap(cfg, gwCfg); err != nil {
+		return CheckResult{
+			Name: "air_gap_config", Category: "sovereignty", Status: "fail",
+			Message: err.Error(),
+			Fix:     "Use EU/LOCAL gateway providers only; set llm.routing.data_sovereignty_mode: eu_strict",
+		}
+	}
+	return CheckResult{
+		Name: "air_gap_config", Category: "sovereignty", Status: "pass",
+		Message: "air_gap deployment configuration validated",
+	}
+}
+
+func checkAirGapFromGateway(gwCfg *gateway.GatewayConfig) CheckResult {
+	cfg, err := config.Load()
+	if err != nil {
+		return CheckResult{
+			Name: "air_gap_gateway", Category: "sovereignty", Status: "warn",
+			Message: "cannot load operator config for air-gap gateway check",
+		}
+	}
+	return checkAirGap(cfg, gwCfg)
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dativo-io/talon/internal/config"
@@ -92,7 +93,7 @@ func checkConfig() []CheckResult {
 
 	results = append(results, checkDataDir(cfg))
 	results = append(results, checkPolicy(cfg))
-	results = append(results, checkLLMKeys())
+	results = append(results, checkLLMKeys(cfg))
 	results = append(results, checkCryptoKeys(cfg)...)
 	results = append(results, checkEvidenceDB(cfg))
 	results = append(results, checkCache(cfg))
@@ -126,10 +127,13 @@ func checkDataDir(cfg *config.Config) CheckResult {
 func checkPolicy(cfg *config.Config) CheckResult {
 	policyPath := cfg.DefaultPolicy
 	if _, err := os.Stat(policyPath); err != nil {
+		// A missing agent policy is advisory, not fatal: gateway-only deployments
+		// (e.g. air-gap proxy) govern requests via the gateway default_policy and
+		// need no agent.talon.yaml. It is only required for the `talon run` path.
 		return CheckResult{
-			Name: "policy_valid", Category: "config", Status: "fail",
-			Message: fmt.Sprintf("%s — file not found", policyPath),
-			Fix:     "Run 'talon init' to create a policy file",
+			Name: "policy_valid", Category: "config", Status: "warn",
+			Message: fmt.Sprintf("%s — file not found (not required for gateway-only deployments)", policyPath),
+			Fix:     "Run 'talon init' to create an agent policy file (needed for 'talon run')",
 		}
 	}
 	pol, loadErr := policy.LoadPolicy(context.Background(), policyPath, false, ".")
@@ -145,30 +149,41 @@ func checkPolicy(cfg *config.Config) CheckResult {
 	}
 }
 
-func checkLLMKeys() CheckResult {
-	hasOpenAI := os.Getenv("OPENAI_API_KEY") != ""
-	hasAnthropic := os.Getenv("ANTHROPIC_API_KEY") != ""
-	hasAWS := os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_PROFILE") != ""
-	if !hasOpenAI && !hasAnthropic && !hasAWS {
-		return CheckResult{
-			Name: "llm_keys", Category: "config", Status: "fail",
-			Message: "No OPENAI_API_KEY, ANTHROPIC_API_KEY, or AWS credentials found",
-			Fix:     "Set at least one LLM provider key (env or vault)",
+func checkLLMKeys(cfg *config.Config) CheckResult {
+	var sources []string
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		sources = append(sources, "openai (env)")
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		sources = append(sources, "anthropic (env)")
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_PROFILE") != "" {
+		sources = append(sources, "aws (env)")
+	}
+	// Local-first / air-gap deployments declare providers in llm.providers with
+	// vault-backed (or, for Ollama, no) credentials. These are valid provider
+	// paths and must not be reported as "no LLM keys" just because no cloud env
+	// key is set.
+	if cfg.LLM != nil {
+		for id := range cfg.LLM.Providers {
+			p := cfg.LLM.Providers[id]
+			providerType := p.Type
+			if providerType == "" {
+				providerType = id
+			}
+			sources = append(sources, providerType+" (llm.providers)")
 		}
 	}
-	var keys []string
-	if hasOpenAI {
-		keys = append(keys, "openai")
-	}
-	if hasAnthropic {
-		keys = append(keys, "anthropic")
-	}
-	if hasAWS {
-		keys = append(keys, "aws")
+	if len(sources) == 0 {
+		return CheckResult{
+			Name: "llm_keys", Category: "config", Status: "fail",
+			Message: "No LLM provider configured (no OPENAI_API_KEY/ANTHROPIC_API_KEY/AWS credentials and no llm.providers)",
+			Fix:     "Set a provider key (env or vault) or declare a local provider (e.g. Ollama) in llm.providers",
+		}
 	}
 	return CheckResult{
 		Name: "llm_keys", Category: "config", Status: "pass",
-		Message: fmt.Sprintf("%v (env)", keys),
+		Message: "LLM providers available: " + strings.Join(sources, ", "),
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -96,6 +96,7 @@ func checkConfig() []CheckResult {
 	results = append(results, checkCryptoKeys(cfg)...)
 	results = append(results, checkEvidenceDB(cfg))
 	results = append(results, checkCache(cfg))
+	results = append(results, checkSovereignty(cfg, nil))
 	results = append(results, checkAirGap(cfg, nil))
 	return results
 }
@@ -299,6 +300,7 @@ func checkGateway(ctx context.Context, opts Options) []CheckResult {
 	results = append(results, checkGatewayMode(gwCfg))
 	results = append(results, checkGatewayCallers(gwCfg))
 	results = append(results, checkGatewayToolPolicy(gwCfg))
+	results = append(results, checkSovereigntyFromGateway(gwCfg))
 	results = append(results, checkAirGapFromGateway(gwCfg, opts.GatewayConfigPath))
 
 	if !opts.SkipUpstream {
@@ -522,6 +524,38 @@ func checkSystem() []CheckResult {
 	}
 
 	return results
+}
+
+func checkSovereignty(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
+	mode := cfg.EffectiveSovereigntyMode()
+	if mode == "" || mode == config.DataSovereigntyGlobal {
+		return CheckResult{
+			Name: "sovereignty_mode", Category: "sovereignty", Status: "pass",
+			Message: "no sovereignty restriction (mode unset or global)",
+		}
+	}
+	if err := sovereignty.ValidateSovereignty(cfg, gwCfg); err != nil {
+		return CheckResult{
+			Name: "sovereignty_providers", Category: "sovereignty", Status: "fail",
+			Message: err.Error(),
+			Fix:     "Use EU/LOCAL providers only, or relax sovereignty.mode",
+		}
+	}
+	return CheckResult{
+		Name: "sovereignty_providers", Category: "sovereignty", Status: "pass",
+		Message: fmt.Sprintf("all declared providers satisfy sovereignty mode %q", mode),
+	}
+}
+
+func checkSovereigntyFromGateway(gwCfg *gateway.GatewayConfig) CheckResult {
+	cfg, err := config.Load()
+	if err != nil {
+		return CheckResult{
+			Name: "sovereignty_gateway", Category: "sovereignty", Status: "warn",
+			Message: "cannot load operator config for sovereignty gateway check",
+		}
+	}
+	return checkSovereignty(cfg, gwCfg)
 }
 
 func checkAirGap(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -300,7 +300,7 @@ func checkGateway(ctx context.Context, opts Options) []CheckResult {
 	results = append(results, checkGatewayMode(gwCfg))
 	results = append(results, checkGatewayCallers(gwCfg))
 	results = append(results, checkGatewayToolPolicy(gwCfg))
-	results = append(results, checkSovereigntyFromGateway(gwCfg))
+	results = append(results, checkSovereigntyFromGateway(gwCfg, opts.GatewayConfigPath))
 	results = append(results, checkAirGapFromGateway(gwCfg, opts.GatewayConfigPath))
 
 	if !opts.SkipUpstream {
@@ -547,12 +547,17 @@ func checkSovereignty(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckRes
 	}
 }
 
-func checkSovereigntyFromGateway(gwCfg *gateway.GatewayConfig) CheckResult {
+func checkSovereigntyFromGateway(gwCfg *gateway.GatewayConfig, gatewayConfigPath string) CheckResult {
 	cfg, err := config.Load()
 	if err != nil {
 		return CheckResult{
 			Name: "sovereignty_gateway", Category: "sovereignty", Status: "warn",
 			Message: "cannot load operator config for sovereignty gateway check",
+		}
+	}
+	if cfg.Sovereignty == nil && gatewayConfigPath != "" {
+		if sc := config.LoadSovereigntyFromFile(gatewayConfigPath); sc != nil {
+			cfg.Sovereignty = sc
 		}
 	}
 	return checkSovereignty(cfg, gwCfg)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -302,6 +302,7 @@ func checkGateway(ctx context.Context, opts Options) []CheckResult {
 	results = append(results, checkGatewayToolPolicy(gwCfg))
 	results = append(results, checkSovereigntyFromGateway(gwCfg, opts.GatewayConfigPath))
 	results = append(results, checkAirGapFromGateway(gwCfg, opts.GatewayConfigPath))
+	results = append(results, checkAirGapEgressGuardFromGateway(gwCfg, opts.GatewayConfigPath))
 
 	if !opts.SkipUpstream {
 		results = append(results, checkGatewayUpstreams(ctx, gwCfg)...)
@@ -555,9 +556,11 @@ func checkSovereigntyFromGateway(gwCfg *gateway.GatewayConfig, gatewayConfigPath
 			Message: "cannot load operator config for sovereignty gateway check",
 		}
 	}
-	if cfg.Sovereignty == nil && gatewayConfigPath != "" {
-		if sc := config.LoadSovereigntyFromFile(gatewayConfigPath); sc != nil {
-			cfg.Sovereignty = sc
+	if err := config.ResolveSovereigntyForGateway(cfg, gatewayConfigPath); err != nil {
+		return CheckResult{
+			Name: "sovereignty_gateway", Category: "sovereignty", Status: "fail",
+			Message: err.Error(),
+			Fix:     "Reconcile sovereignty blocks in operator and gateway config (e.g. air_gap requires eu_strict)",
 		}
 	}
 	return checkSovereignty(cfg, gwCfg)
@@ -605,10 +608,54 @@ func checkAirGapFromGateway(gwCfg *gateway.GatewayConfig, gatewayConfigPath stri
 			Message: "cannot load operator config for air-gap gateway check",
 		}
 	}
-	if cfg.Sovereignty == nil && gatewayConfigPath != "" {
-		if sc := config.LoadSovereigntyFromFile(gatewayConfigPath); sc != nil {
-			cfg.Sovereignty = sc
+	if err := config.ResolveSovereigntyForGateway(cfg, gatewayConfigPath); err != nil {
+		return CheckResult{
+			Name: "air_gap_gateway", Category: "sovereignty", Status: "fail",
+			Message: err.Error(),
+			Fix:     "Reconcile sovereignty blocks in operator and gateway config (e.g. air_gap requires eu_strict)",
 		}
 	}
 	return checkAirGap(cfg, gwCfg)
+}
+
+// checkAirGapEgressGuard confirms a transport-level egress guard exists and
+// actively blocks non-allowlisted hosts (not merely that config parsed). This
+// is the buyer-facing promise of air_gap: "no surprise egress path exists."
+func checkAirGapEgressGuard(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
+	if cfg.Sovereignty == nil || !cfg.Sovereignty.AirGapEnabled() {
+		return CheckResult{
+			Name: "air_gap_egress_guard", Category: "sovereignty", Status: "pass",
+			Message: "not applicable (sovereignty.deployment_mode not air_gap)",
+		}
+	}
+	n, err := sovereignty.VerifyEgressGuard(cfg, gwCfg)
+	if err != nil {
+		return CheckResult{
+			Name: "air_gap_egress_guard", Category: "sovereignty", Status: "fail",
+			Message: fmt.Sprintf("transport egress guard not enforcing: %v", err),
+			Fix:     "Ensure allowed_egress_hosts and gateway upstreams are valid URLs/hosts",
+		}
+	}
+	return CheckResult{
+		Name: "air_gap_egress_guard", Category: "sovereignty", Status: "pass",
+		Message: fmt.Sprintf("transport egress guard blocks non-allowlisted hosts (%d hosts allowlisted)", n),
+	}
+}
+
+func checkAirGapEgressGuardFromGateway(gwCfg *gateway.GatewayConfig, gatewayConfigPath string) CheckResult {
+	cfg, err := config.Load()
+	if err != nil {
+		return CheckResult{
+			Name: "air_gap_egress_guard", Category: "sovereignty", Status: "warn",
+			Message: "cannot load operator config for egress guard check",
+		}
+	}
+	if err := config.ResolveSovereigntyForGateway(cfg, gatewayConfigPath); err != nil {
+		return CheckResult{
+			Name: "air_gap_egress_guard", Category: "sovereignty", Status: "fail",
+			Message: err.Error(),
+			Fix:     "Reconcile sovereignty blocks in operator and gateway config (e.g. air_gap requires eu_strict)",
+		}
+	}
+	return checkAirGapEgressGuard(cfg, gwCfg)
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -299,7 +299,7 @@ func checkGateway(ctx context.Context, opts Options) []CheckResult {
 	results = append(results, checkGatewayMode(gwCfg))
 	results = append(results, checkGatewayCallers(gwCfg))
 	results = append(results, checkGatewayToolPolicy(gwCfg))
-	results = append(results, checkAirGapFromGateway(gwCfg))
+	results = append(results, checkAirGapFromGateway(gwCfg, opts.GatewayConfigPath))
 
 	if !opts.SkipUpstream {
 		results = append(results, checkGatewayUpstreams(ctx, gwCfg)...)
@@ -538,6 +538,13 @@ func checkAirGap(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
 			Fix:     "Set both keys via env vars before enabling air_gap mode",
 		}
 	}
+	if gwCfg == nil {
+		return CheckResult{
+			Name: "air_gap_config", Category: "sovereignty", Status: "warn",
+			Message: "air_gap enabled but no gateway config provided; provider region checks skipped",
+			Fix:     "Run with --gateway-config to validate full air-gap deployment",
+		}
+	}
 	if err := sovereignty.ValidateAirGap(cfg, gwCfg); err != nil {
 		return CheckResult{
 			Name: "air_gap_config", Category: "sovereignty", Status: "fail",
@@ -551,12 +558,17 @@ func checkAirGap(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
 	}
 }
 
-func checkAirGapFromGateway(gwCfg *gateway.GatewayConfig) CheckResult {
+func checkAirGapFromGateway(gwCfg *gateway.GatewayConfig, gatewayConfigPath string) CheckResult {
 	cfg, err := config.Load()
 	if err != nil {
 		return CheckResult{
 			Name: "air_gap_gateway", Category: "sovereignty", Status: "warn",
 			Message: "cannot load operator config for air-gap gateway check",
+		}
+	}
+	if cfg.Sovereignty == nil && gatewayConfigPath != "" {
+		if sc := config.LoadSovereigntyFromFile(gatewayConfigPath); sc != nil {
+			cfg.Sovereignty = sc
 		}
 	}
 	return checkAirGap(cfg, gwCfg)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -6,8 +6,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
 )
 
 func TestRun_ConfigCategory(t *testing.T) {
@@ -124,6 +128,66 @@ func TestRun_InvalidGatewayConfig(t *testing.T) {
 		}
 	}
 	assert.True(t, found)
+}
+
+// TestDoctorGatewaySovereigntyFromGatewayConfig_WhenOperatorSovereigntyEmpty is
+// the regression for the "doctor sovereignty merge is fragile" bug: even when
+// the operator config already carries a weak/empty sovereignty block, the
+// stronger air_gap block declared in --gateway-config must be honored, so a
+// non-EU gateway upstream is flagged.
+func TestDoctorGatewaySovereigntyFromGatewayConfig_WhenOperatorSovereigntyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	// Operator config carries an empty/standard sovereignty block (the case that
+	// previously masked the gateway file's air_gap declaration).
+	viper.Set("sovereignty", map[string]interface{}{"deployment_mode": "standard"})
+	t.Cleanup(func() {
+		viper.Reset()
+		viper.SetEnvPrefix("TALON")
+		viper.AutomaticEnv()
+		viper.SetDefault(config.KeyDefaultPolicy, config.DefaultPolicy)
+		viper.SetDefault(config.KeyMaxAttachmentMB, config.DefaultMaxAttachMB)
+		viper.SetDefault(config.KeyOllamaBaseURL, config.DefaultOllamaURL)
+	})
+
+	gwCfgPath := filepath.Join(dir, "talon.config.airgap.yaml")
+	gwYAML := `sovereignty:
+  deployment_mode: air_gap
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "shadow"
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      region: "US"
+      secret_name: "openai-api-key"
+  callers:
+    - name: "test"
+      tenant_key: "test-key"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+    forbidden_tools: ["rm_rf"]
+`
+	require.NoError(t, os.WriteFile(gwCfgPath, []byte(gwYAML), 0o600))
+
+	gwCfg, err := gateway.LoadGatewayConfig(gwCfgPath)
+	require.NoError(t, err)
+
+	res := checkAirGapFromGateway(gwCfg, gwCfgPath)
+	assert.Equal(t, "fail", res.Status,
+		"gateway air_gap + US upstream must fail even when operator carries a standard sovereignty block")
+
+	sov := checkSovereigntyFromGateway(gwCfg, gwCfgPath)
+	assert.Equal(t, "fail", sov.Status,
+		"sovereignty provider gate must fail for US gateway upstream under merged eu_strict")
 }
 
 func TestCheckResult_StatusValues(t *testing.T) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -190,6 +190,37 @@ gateway:
 		"sovereignty provider gate must fail for US gateway upstream under merged eu_strict")
 }
 
+// TestCheckLLMKeys_RecognizesLocalProviders guards the air-gap operator path:
+// an Ollama-only deployment declares a local provider in llm.providers and must
+// satisfy the LLM-provider check without any cloud key set.
+func TestCheckLLMKeys_RecognizesLocalProviders(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_PROFILE", "")
+
+	cfg := &config.Config{LLM: &config.LLMConfig{
+		Providers: map[string]config.LLMProviderConfig{
+			"ollama": {Type: "ollama", Enabled: true},
+		},
+	}}
+	res := checkLLMKeys(cfg)
+	assert.Equal(t, "pass", res.Status)
+	assert.Contains(t, res.Message, "ollama")
+
+	// No providers and no cloud key → still fails closed.
+	assert.Equal(t, "fail", checkLLMKeys(&config.Config{}).Status)
+}
+
+// TestCheckPolicy_MissingFileWarnsNotFails ensures a missing agent policy is
+// advisory (gateway-only deployments need no agent.talon.yaml), not a failure.
+func TestCheckPolicy_MissingFileWarnsNotFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{DefaultPolicy: filepath.Join(dir, "does-not-exist.talon.yaml")}
+	res := checkPolicy(cfg)
+	assert.Equal(t, "warn", res.Status)
+}
+
 func TestCheckResult_StatusValues(t *testing.T) {
 	statuses := []string{"pass", "warn", "fail"}
 	for _, s := range statuses {

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -5,6 +5,7 @@ package gateway
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -49,6 +50,8 @@ type GatewayConfig struct {
 	// The gateway uses this at evidence time to annotate requests with
 	// quickstart_unsafe_listen without relying on process-wide environment state.
 	QuickstartUnsafeListen bool `yaml:"-" json:"-"`
+	// UpstreamTransport when set wraps the gateway upstream HTTP client (air-gap egress guard).
+	UpstreamTransport http.RoundTripper `yaml:"-" json:"-"`
 }
 
 // ProviderConfig holds per-provider gateway settings.

--- a/internal/gateway/forward.go
+++ b/internal/gateway/forward.go
@@ -279,12 +279,17 @@ func parseUsageFromJSON(body []byte, _ string, usage *TokenUsage) {
 }
 
 // HTTPClientForGateway returns an http.Client with gateway timeouts.
-// When transport is non-nil it is used as the client's RoundTripper (e.g. air-gap egress guard).
+// When transport is non-nil it wraps the timeout-aware base transport
+// (e.g. air-gap egress guard layered on top of the ResponseHeaderTimeout transport).
 func HTTPClientForGateway(timeouts ParsedTimeouts, transport http.RoundTripper) *http.Client {
-	rt := http.RoundTripper(&http.Transport{
+	base := &http.Transport{
 		ResponseHeaderTimeout: timeouts.ConnectTimeout,
-	})
+	}
+	var rt http.RoundTripper = base
 	if transport != nil {
+		if guard, ok := transport.(interface{ SetBase(http.RoundTripper) }); ok {
+			guard.SetBase(base)
+		}
 		rt = transport
 	}
 	return &http.Client{

--- a/internal/gateway/forward.go
+++ b/internal/gateway/forward.go
@@ -279,11 +279,16 @@ func parseUsageFromJSON(body []byte, _ string, usage *TokenUsage) {
 }
 
 // HTTPClientForGateway returns an http.Client with gateway timeouts.
-func HTTPClientForGateway(timeouts ParsedTimeouts) *http.Client {
+// When transport is non-nil it is used as the client's RoundTripper (e.g. air-gap egress guard).
+func HTTPClientForGateway(timeouts ParsedTimeouts, transport http.RoundTripper) *http.Client {
+	rt := http.RoundTripper(&http.Transport{
+		ResponseHeaderTimeout: timeouts.ConnectTimeout,
+	})
+	if transport != nil {
+		rt = transport
+	}
 	return &http.Client{
-		Timeout: timeouts.RequestTimeout,
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: timeouts.ConnectTimeout,
-		},
+		Timeout:   timeouts.RequestTimeout,
+		Transport: rt,
 	}
 }

--- a/internal/gateway/forward_test.go
+++ b/internal/gateway/forward_test.go
@@ -329,7 +329,7 @@ func TestHTTPClientForGateway(t *testing.T) {
 		RequestTimeout:    10 * time.Second,
 		StreamIdleTimeout: 30 * time.Second,
 	}
-	client := HTTPClientForGateway(timeouts)
+	client := HTTPClientForGateway(timeouts, nil)
 	require.NotNil(t, client)
 	require.Equal(t, 10*time.Second, client.Timeout)
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -163,7 +163,7 @@ func NewGateway(
 	if err != nil {
 		return nil, err
 	}
-	client := HTTPClientForGateway(timeouts)
+	client := HTTPClientForGateway(timeouts, config.UpstreamTransport)
 	rl := NewRateLimiter(
 		config.RateLimits.GlobalRequestsPerMin,
 		config.RateLimits.PerCallerRequestsPerMin,

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -88,15 +88,26 @@ func AllRegisteredProviders() []Provider {
 // ("EU", "US", "LOCAL", ...) from its static metadata, or "" when the
 // provider type is not registered. No network calls.
 func JurisdictionForProvider(providerType string) string {
-	factory, ok := registry[providerType]
+	meta, ok := ProviderMetadataByType(providerType)
 	if !ok {
 		return ""
 	}
+	return meta.Jurisdiction
+}
+
+// ProviderMetadataByType returns the static metadata for a registered provider
+// type (jurisdiction, EU regions, etc.) without making network calls. The second
+// return value is false when the provider type is not registered.
+func ProviderMetadataByType(providerType string) (ProviderMetadata, bool) {
+	factory, ok := registry[providerType]
+	if !ok {
+		return ProviderMetadata{}, false
+	}
 	p, err := factory(nil) // nil config — metadata only
 	if err != nil || p == nil {
-		return ""
+		return ProviderMetadata{}, false
 	}
-	return p.Metadata().Jurisdiction
+	return p.Metadata(), true
 }
 
 // RegisteredTypes returns the list of registered provider type names (sorted).

--- a/internal/sovereignty/egress_guard.go
+++ b/internal/sovereignty/egress_guard.go
@@ -1,0 +1,92 @@
+package sovereignty
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+)
+
+// ErrEgressBlocked is returned when an outbound request targets a host outside
+// the air-gap allowlist.
+var ErrEgressBlocked = errors.New("egress blocked by air-gap guard")
+
+// EgressGuard is an http.RoundTripper that denies outbound requests to hosts
+// outside the configured allowlist. Used in air_gap deployment mode to catch
+// surprise egress at the transport layer (defense in depth with policy egress).
+type EgressGuard struct {
+	base       http.RoundTripper
+	allowed    map[string]struct{}
+	violations atomic.Int64
+}
+
+// NewEgressGuard creates a guard wrapping the default transport.
+func NewEgressGuard(allowedHosts []string) *EgressGuard {
+	allowed := make(map[string]struct{})
+	for _, h := range allowedHosts {
+		if host, err := hostFromAllowEntry(h); err == nil && host != "" {
+			allowed[host] = struct{}{}
+		}
+	}
+	// Always permit loopback.
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		allowed[h] = struct{}{}
+	}
+	base := http.DefaultTransport
+	if base == nil {
+		base = &http.Transport{}
+	}
+	return &EgressGuard{base: base, allowed: allowed}
+}
+
+func hostFromAllowEntry(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", err
+		}
+		return normalizeHost(u.Hostname()), nil
+	}
+	return normalizeHost(raw), nil
+}
+
+// RoundTrip implements http.RoundTripper.
+func (g *EgressGuard) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("egress guard: nil request")
+	}
+	host := normalizeHost(req.URL.Hostname())
+	if host == "" {
+		g.violations.Add(1)
+		return nil, fmt.Errorf("%w: empty host", ErrEgressBlocked)
+	}
+	if _, ok := g.allowed[host]; !ok {
+		g.violations.Add(1)
+		return nil, fmt.Errorf("%w: host %q not in allowlist", ErrEgressBlocked, host)
+	}
+	return g.base.RoundTrip(req)
+}
+
+// Violations returns the number of blocked egress attempts since creation.
+func (g *EgressGuard) Violations() int64 {
+	return g.violations.Load()
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return ""
+	}
+	// Strip brackets from IPv6 literals for map lookup.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return strings.Trim(h, "[]")
+	}
+	return strings.Trim(host, "[]")
+}

--- a/internal/sovereignty/egress_guard.go
+++ b/internal/sovereignty/egress_guard.go
@@ -23,8 +23,9 @@ type EgressGuard struct {
 	violations atomic.Int64
 }
 
-// NewEgressGuard creates a guard wrapping the default transport.
-func NewEgressGuard(allowedHosts []string) *EgressGuard {
+// NewEgressGuard creates a guard wrapping the given base transport (or
+// http.DefaultTransport when base is nil).
+func NewEgressGuard(allowedHosts []string, base ...http.RoundTripper) *EgressGuard {
 	allowed := make(map[string]struct{})
 	for _, h := range allowedHosts {
 		if host, err := hostFromAllowEntry(h); err == nil && host != "" {
@@ -35,11 +36,16 @@ func NewEgressGuard(allowedHosts []string) *EgressGuard {
 	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
 		allowed[h] = struct{}{}
 	}
-	base := http.DefaultTransport
-	if base == nil {
-		base = &http.Transport{}
+	var rt http.RoundTripper
+	if len(base) > 0 && base[0] != nil {
+		rt = base[0]
+	} else {
+		rt = http.DefaultTransport
+		if rt == nil {
+			rt = &http.Transport{}
+		}
 	}
-	return &EgressGuard{base: base, allowed: allowed}
+	return &EgressGuard{base: rt, allowed: allowed}
 }
 
 func hostFromAllowEntry(raw string) (string, error) {
@@ -72,6 +78,14 @@ func (g *EgressGuard) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("%w: host %q not in allowlist", ErrEgressBlocked, host)
 	}
 	return g.base.RoundTrip(req)
+}
+
+// SetBase replaces the underlying transport. Used by HTTPClientForGateway to
+// inject the timeout-aware transport after guard construction.
+func (g *EgressGuard) SetBase(rt http.RoundTripper) {
+	if rt != nil {
+		g.base = rt
+	}
 }
 
 // Violations returns the number of blocked egress attempts since creation.

--- a/internal/sovereignty/egress_guard.go
+++ b/internal/sovereignty/egress_guard.go
@@ -93,6 +93,12 @@ func (g *EgressGuard) Violations() int64 {
 	return g.violations.Load()
 }
 
+// AllowlistSize returns the number of hosts permitted by the guard, including
+// the always-allowed loopback addresses.
+func (g *EgressGuard) AllowlistSize() int {
+	return len(g.allowed)
+}
+
 func normalizeHost(host string) string {
 	host = strings.TrimSpace(strings.ToLower(host))
 	if host == "" {

--- a/internal/sovereignty/mode.go
+++ b/internal/sovereignty/mode.go
@@ -1,0 +1,13 @@
+// Package sovereignty implements air-gapped deployment presets, egress guards,
+// and validation for EU in-region self-host operation (feature bet 5.3).
+package sovereignty
+
+import (
+	"github.com/dativo-io/talon/internal/config"
+)
+
+// Deployment mode aliases re-exported from config for callers outside config.
+const (
+	ModeStandard = config.SovereigntyModeStandard
+	ModeAirGap   = config.SovereigntyModeAirGap
+)

--- a/internal/sovereignty/preset.go
+++ b/internal/sovereignty/preset.go
@@ -1,0 +1,106 @@
+package sovereignty
+
+import (
+	"fmt"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
+)
+
+// DefaultAirGapEgress returns the gateway egress policy applied when
+// sovereignty.deployment_mode is air_gap and no explicit egress block is set.
+func DefaultAirGapEgress() *gateway.EgressPolicyConfig {
+	tier0 := gateway.TierLevel(0)
+	tier1 := gateway.TierLevel(1)
+	tier2 := gateway.TierLevel(2)
+	return &gateway.EgressPolicyConfig{
+		DefaultAction: gateway.EgressActionDeny,
+		Rules: []gateway.EgressRule{
+			{Tier: &tier0, AllowedRegions: []string{"EU", "LOCAL"}},
+			{Tier: &tier1, AllowedRegions: []string{"EU", "LOCAL"}},
+			{Tier: &tier2, AllowedRegions: []string{"EU", "LOCAL"}},
+		},
+	}
+}
+
+// ApplyAirGapPreset mutates operator and gateway config for air-gap mode:
+// forces eu_strict routing, applies default egress when absent, and returns
+// an egress guard built from declared upstream endpoints.
+func ApplyAirGapPreset(op *config.Config, gw *gateway.GatewayConfig) (*EgressGuard, error) {
+	if op == nil || op.Sovereignty == nil || !op.Sovereignty.AirGapEnabled() {
+		return nil, nil
+	}
+	if op.LLM == nil {
+		op.LLM = &config.LLMConfig{}
+	}
+	if op.LLM.Routing == nil {
+		op.LLM.Routing = &config.LLMRoutingConfig{}
+	}
+	if op.LLM.Routing.DataSovereigntyMode == "" {
+		op.LLM.Routing.DataSovereigntyMode = "eu_strict"
+	} else if op.LLM.Routing.DataSovereigntyMode != "eu_strict" {
+		return nil, fmt.Errorf("sovereignty.deployment_mode air_gap requires llm.routing.data_sovereignty_mode eu_strict (got %q)", op.LLM.Routing.DataSovereigntyMode)
+	}
+
+	if gw != nil && gw.ServerDefaults.Egress == nil {
+		gw.ServerDefaults.Egress = DefaultAirGapEgress()
+	}
+
+	allow, err := BuildAllowlist(op, gw)
+	if err != nil {
+		return nil, err
+	}
+	return NewEgressGuard(allow), nil
+}
+
+// BuildAllowlist derives permitted upstream hosts from operator config and
+// enabled gateway providers. Local loopback is always permitted.
+func BuildAllowlist(op *config.Config, gw *gateway.GatewayConfig) ([]string, error) {
+	hosts := map[string]struct{}{
+		"localhost": {},
+		"127.0.0.1": {},
+		"[::1]":     {},
+		"::1":       {},
+	}
+	addHost := func(raw string) error {
+		host, err := hostFromAllowEntry(raw)
+		if err != nil {
+			return fmt.Errorf("parsing allowed egress host %q: %w", raw, err)
+		}
+		if host == "" {
+			return nil
+		}
+		hosts[host] = struct{}{}
+		return nil
+	}
+
+	if op != nil {
+		if err := addHost(op.OllamaBaseURL); err != nil {
+			return nil, err
+		}
+		if op.Sovereignty != nil {
+			for _, h := range op.Sovereignty.AllowedEgressHosts {
+				if err := addHost(h); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if gw != nil {
+		for name := range gw.Providers {
+			p := gw.Providers[name]
+			if !p.Enabled {
+				continue
+			}
+			if err := addHost(p.BaseURL); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	out := make([]string, 0, len(hosts))
+	for h := range hosts {
+		out = append(out, h)
+	}
+	return out, nil
+}

--- a/internal/sovereignty/preset.go
+++ b/internal/sovereignty/preset.go
@@ -42,7 +42,7 @@ func ApplyAirGapPreset(op *config.Config, gw *gateway.GatewayConfig) (*EgressGua
 		return nil, fmt.Errorf("sovereignty.deployment_mode air_gap requires llm.routing.data_sovereignty_mode eu_strict (got %q)", op.LLM.Routing.DataSovereigntyMode)
 	}
 
-	if gw != nil && gw.ServerDefaults.Egress == nil {
+	if gw != nil && isEgressUnconfigured(gw.ServerDefaults.Egress) {
 		gw.ServerDefaults.Egress = DefaultAirGapEgress()
 	}
 
@@ -103,4 +103,14 @@ func BuildAllowlist(op *config.Config, gw *gateway.GatewayConfig) ([]string, err
 		out = append(out, h)
 	}
 	return out, nil
+}
+
+// isEgressUnconfigured returns true when the egress policy is nil or
+// effectively empty (default allow with no rules), meaning the operator
+// did not provide a meaningful custom egress configuration.
+func isEgressUnconfigured(e *gateway.EgressPolicyConfig) bool {
+	if e == nil {
+		return true
+	}
+	return len(e.Rules) == 0 && (e.DefaultAction == "" || e.DefaultAction == gateway.EgressActionAllow)
 }

--- a/internal/sovereignty/preset.go
+++ b/internal/sovereignty/preset.go
@@ -1,7 +1,12 @@
 package sovereignty
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/gateway"
@@ -26,6 +31,12 @@ func DefaultAirGapEgress() *gateway.EgressPolicyConfig {
 // ApplyAirGapPreset mutates operator and gateway config for air-gap mode:
 // forces eu_strict routing, applies default egress when absent, and returns
 // an egress guard built from declared upstream endpoints.
+//
+// Consistent with the single-source-of-truth model, air_gap forces eu_strict
+// and overrides any conflicting llm.routing.data_sovereignty_mode with a warning
+// rather than erroring. The genuine conflict (deployment_mode air_gap combined
+// with an explicit sovereignty.mode other than eu_strict, e.g. global) is
+// rejected earlier by config.resolveSovereignty during load.
 func ApplyAirGapPreset(op *config.Config, gw *gateway.GatewayConfig) (*EgressGuard, error) {
 	if op == nil || op.Sovereignty == nil || !op.Sovereignty.AirGapEnabled() {
 		return nil, nil
@@ -36,10 +47,13 @@ func ApplyAirGapPreset(op *config.Config, gw *gateway.GatewayConfig) (*EgressGua
 	if op.LLM.Routing == nil {
 		op.LLM.Routing = &config.LLMRoutingConfig{}
 	}
-	if op.LLM.Routing.DataSovereigntyMode == "" {
-		op.LLM.Routing.DataSovereigntyMode = "eu_strict"
-	} else if op.LLM.Routing.DataSovereigntyMode != "eu_strict" {
-		return nil, fmt.Errorf("sovereignty.deployment_mode air_gap requires llm.routing.data_sovereignty_mode eu_strict (got %q)", op.LLM.Routing.DataSovereigntyMode)
+	if op.LLM.Routing.DataSovereigntyMode != config.DataSovereigntyEUStrict {
+		if op.LLM.Routing.DataSovereigntyMode != "" {
+			log.Warn().
+				Str("data_sovereignty_mode", op.LLM.Routing.DataSovereigntyMode).
+				Msg("air_gap forces eu_strict; overriding llm.routing.data_sovereignty_mode")
+		}
+		op.LLM.Routing.DataSovereigntyMode = config.DataSovereigntyEUStrict
 	}
 
 	if gw != nil && isEgressUnconfigured(gw.ServerDefaults.Egress) {
@@ -103,6 +117,33 @@ func BuildAllowlist(op *config.Config, gw *gateway.GatewayConfig) ([]string, err
 		out = append(out, h)
 	}
 	return out, nil
+}
+
+// VerifyEgressGuard builds the air-gap egress guard from the same inputs serve
+// uses and self-tests that it blocks a synthetic, non-allowlisted host. The
+// guard consults its allowlist before calling the base transport, so the probe
+// makes no network call. Returns the number of allowlisted hosts (loopback plus
+// declared upstreams). It returns an error only when the guard fails to block
+// surprise egress — proving to `talon doctor` that a transport-level
+// enforcement path exists, not merely that the config parsed.
+func VerifyEgressGuard(op *config.Config, gw *gateway.GatewayConfig) (int, error) {
+	allow, err := BuildAllowlist(op, gw)
+	if err != nil {
+		return 0, err
+	}
+	guard := NewEgressGuard(allow)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://surprise-egress.invalid/probe", nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, rtErr := guard.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if !errors.Is(rtErr, ErrEgressBlocked) {
+		return 0, fmt.Errorf("egress guard did not block surprise egress (got %v)", rtErr)
+	}
+	return guard.AllowlistSize(), nil
 }
 
 // isEgressUnconfigured returns true when the egress policy is nil or

--- a/internal/sovereignty/preset_test.go
+++ b/internal/sovereignty/preset_test.go
@@ -1,0 +1,94 @@
+package sovereignty
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+func TestEgressGuard_AllowsAndBlocks(t *testing.T) {
+	allowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(allowed.Close)
+
+	guard := NewEgressGuard([]string{allowed.URL})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, allowed.URL, nil)
+	require.NoError(t, err)
+	resp, err := guard.RoundTrip(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	req2, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://surprise-egress.example/v1", nil)
+	require.NoError(t, err)
+	resp2, err := guard.RoundTrip(req2)
+	if resp2 != nil && resp2.Body != nil {
+		_ = resp2.Body.Close()
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEgressBlocked)
+	assert.Equal(t, int64(1), guard.Violations())
+}
+
+func TestApplyAirGapPreset_ForcesEUStrictAndEgress(t *testing.T) {
+	op := &config.Config{
+		Sovereignty:   &config.SovereigntyConfig{DeploymentMode: ModeAirGap},
+		OllamaBaseURL: "http://localhost:11434",
+		SecretsKey:    testutil.TestEncryptionKey,
+		SigningKey:    testutil.TestSigningKey,
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"ollama": {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
+		},
+	}
+	guard, err := ApplyAirGapPreset(op, gw)
+	require.NoError(t, err)
+	require.NotNil(t, guard)
+	require.NotNil(t, op.LLM)
+	require.Equal(t, "eu_strict", op.LLM.Routing.DataSovereigntyMode)
+	require.NotNil(t, gw.ServerDefaults.Egress)
+	assert.Equal(t, gateway.EgressActionDeny, gw.ServerDefaults.Egress.DefaultAction)
+}
+
+func TestValidateAirGap_RejectsUSProvider(t *testing.T) {
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{DeploymentMode: ModeAirGap},
+		SecretsKey:  testutil.TestEncryptionKey,
+		SigningKey:  testutil.TestSigningKey,
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+		},
+	}
+	err := ValidateAirGap(op, gw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openai")
+}
+
+func TestBuildAllowlist_IncludesOllamaAndProviders(t *testing.T) {
+	op := &config.Config{
+		OllamaBaseURL: "http://localhost:11434",
+		Sovereignty:   &config.SovereigntyConfig{AllowedEgressHosts: []string{"llm.internal.example"}},
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"eu": {Enabled: true, BaseURL: "https://api.mistral.ai", Region: "EU"},
+		},
+	}
+	hosts, err := BuildAllowlist(op, gw)
+	require.NoError(t, err)
+	assert.Contains(t, hosts, "localhost")
+	assert.Contains(t, hosts, "api.mistral.ai")
+	assert.Contains(t, hosts, "llm.internal.example")
+}

--- a/internal/sovereignty/preset_test.go
+++ b/internal/sovereignty/preset_test.go
@@ -60,6 +60,32 @@ func TestApplyAirGapPreset_ForcesEUStrictAndEgress(t *testing.T) {
 	assert.Equal(t, gateway.EgressActionDeny, gw.ServerDefaults.Egress.DefaultAction)
 }
 
+// TestAirGapPreset_OverridesConflictingLLMRouting is the regression for the
+// "single source of truth" bug: under air_gap the preset must force eu_strict
+// and override a conflicting llm.routing.data_sovereignty_mode (with a warning),
+// not error. The genuine conflict (sovereignty.mode global + air_gap) is caught
+// earlier by config.resolveSovereignty during load.
+func TestAirGapPreset_OverridesConflictingLLMRouting(t *testing.T) {
+	op := &config.Config{
+		Sovereignty:   &config.SovereigntyConfig{DeploymentMode: ModeAirGap},
+		OllamaBaseURL: "http://localhost:11434",
+		LLM: &config.LLMConfig{
+			Routing: &config.LLMRoutingConfig{DataSovereigntyMode: config.DataSovereigntyGlobal},
+		},
+		SecretsKey: testutil.TestEncryptionKey,
+		SigningKey: testutil.TestSigningKey,
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"ollama": {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
+		},
+	}
+	guard, err := ApplyAirGapPreset(op, gw)
+	require.NoError(t, err, "air_gap must override conflicting routing, not error")
+	require.NotNil(t, guard)
+	assert.Equal(t, config.DataSovereigntyEUStrict, op.LLM.Routing.DataSovereigntyMode)
+}
+
 func TestApplyAirGapPreset_EmptyEgressStillAppliesPreset(t *testing.T) {
 	op := &config.Config{
 		Sovereignty:   &config.SovereigntyConfig{DeploymentMode: ModeAirGap},

--- a/internal/sovereignty/preset_test.go
+++ b/internal/sovereignty/preset_test.go
@@ -60,6 +60,29 @@ func TestApplyAirGapPreset_ForcesEUStrictAndEgress(t *testing.T) {
 	assert.Equal(t, gateway.EgressActionDeny, gw.ServerDefaults.Egress.DefaultAction)
 }
 
+func TestApplyAirGapPreset_EmptyEgressStillAppliesPreset(t *testing.T) {
+	op := &config.Config{
+		Sovereignty:   &config.SovereigntyConfig{DeploymentMode: ModeAirGap},
+		OllamaBaseURL: "http://localhost:11434",
+		SecretsKey:    testutil.TestEncryptionKey,
+		SigningKey:    testutil.TestSigningKey,
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"ollama": {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
+		},
+		ServerDefaults: gateway.ServerDefaults{
+			Egress: &gateway.EgressPolicyConfig{DefaultAction: "allow"},
+		},
+	}
+	guard, err := ApplyAirGapPreset(op, gw)
+	require.NoError(t, err)
+	require.NotNil(t, guard)
+	require.NotNil(t, gw.ServerDefaults.Egress)
+	assert.Equal(t, gateway.EgressActionDeny, gw.ServerDefaults.Egress.DefaultAction)
+	assert.NotEmpty(t, gw.ServerDefaults.Egress.Rules)
+}
+
 func TestValidateAirGap_RejectsUSProvider(t *testing.T) {
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{DeploymentMode: ModeAirGap},

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -1,0 +1,109 @@
+package sovereignty
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/llm"
+)
+
+// operatorKeyedProviders maps an operator-level env var to the provider type it
+// configures. When the env var is set the operator has explicitly declared that
+// provider, so it must satisfy the sovereignty gate (fail closed).
+var operatorKeyedProviders = []struct {
+	env      string
+	provider string
+}{
+	{env: "OPENAI_API_KEY", provider: "openai"},
+	{env: "ANTHROPIC_API_KEY", provider: "anthropic"},
+}
+
+// AllowsProvider reports whether a provider type is permitted under the given
+// data-sovereignty mode. Only eu_strict imposes a hard gate: a provider is
+// allowed when its jurisdiction is EU or LOCAL, or it exposes at least one EU
+// region (e.g. Bedrock eu-central-1, Azure westeurope). eu_preferred and global
+// allow all providers (routing applies preference). Unknown provider types are
+// allowed here and rejected by the registry's own validation.
+func AllowsProvider(mode, providerType string) bool {
+	switch mode {
+	case config.DataSovereigntyEUStrict:
+		meta, ok := llm.ProviderMetadataByType(providerType)
+		if !ok {
+			return true
+		}
+		j := strings.ToUpper(strings.TrimSpace(meta.Jurisdiction))
+		return j == "EU" || j == "LOCAL" || len(meta.EURegions) > 0
+	default:
+		return true
+	}
+}
+
+// ValidateSovereignty enforces the effective data-sovereignty mode against every
+// declared provider (fail closed). For eu_strict, operator-keyed providers,
+// llm.providers entries, and enabled gateway providers must all be EU/LOCAL (or
+// EU-region capable). eu_preferred and global impose no hard provider gate.
+// air_gap implies eu_strict via config resolution, so this also covers air-gap.
+func ValidateSovereignty(op *config.Config, gw *gateway.GatewayConfig) error {
+	if op == nil {
+		return nil
+	}
+	mode := op.EffectiveSovereigntyMode()
+	if mode != config.DataSovereigntyEUStrict {
+		return nil
+	}
+	if err := validateOperatorProviders(op, mode); err != nil {
+		return err
+	}
+	return validateGatewayProviders(gw, mode)
+}
+
+// validateOperatorProviders fails closed when an operator has explicitly
+// configured a provider (via env key or the llm.providers block) that is not
+// permitted under the sovereignty mode.
+func validateOperatorProviders(op *config.Config, mode string) error {
+	for _, kp := range operatorKeyedProviders {
+		if os.Getenv(kp.env) == "" {
+			continue
+		}
+		if !AllowsProvider(mode, kp.provider) {
+			return fmt.Errorf(
+				"sovereignty mode %s: %s is set but provider %q (%s jurisdiction) is not EU/LOCAL — remove the key or relax sovereignty.mode",
+				mode, kp.env, kp.provider, llm.JurisdictionForProvider(kp.provider))
+		}
+	}
+	if op.LLM != nil {
+		for id := range op.LLM.Providers {
+			if !AllowsProvider(mode, id) {
+				return fmt.Errorf(
+					"sovereignty mode %s: llm.providers includes %q (%s jurisdiction) which is not EU/LOCAL",
+					mode, id, llm.JurisdictionForProvider(id))
+			}
+		}
+	}
+	return nil
+}
+
+// validateGatewayProviders fails closed when an enabled gateway upstream is
+// declared in a region that is not permitted under the sovereignty mode.
+func validateGatewayProviders(gw *gateway.GatewayConfig, mode string) error {
+	if gw == nil {
+		return nil
+	}
+	for name := range gw.Providers {
+		p := gw.Providers[name]
+		if !p.Enabled {
+			continue
+		}
+		region := strings.ToUpper(strings.TrimSpace(p.Region))
+		if region == "" {
+			return fmt.Errorf("sovereignty mode %s: gateway provider %q region must be set (EU or LOCAL)", mode, name)
+		}
+		if region != "EU" && region != "LOCAL" {
+			return fmt.Errorf("sovereignty mode %s: gateway provider %q region %q is not permitted (use EU or LOCAL)", mode, name, region)
+		}
+	}
+	return nil
+}

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -76,6 +76,9 @@ func validateOperatorProviders(op *config.Config, mode string) error {
 	}
 	if op.LLM != nil {
 		for id, p := range op.LLM.Providers {
+			if !p.Enabled {
+				continue
+			}
 			providerType := p.Type
 			if providerType == "" {
 				providerType = id

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -26,13 +26,13 @@ var operatorKeyedProviders = []struct {
 // allowed when its jurisdiction is EU or LOCAL, or it exposes at least one EU
 // region (e.g. Bedrock eu-central-1, Azure westeurope). eu_preferred and global
 // allow all providers (routing applies preference). Unknown provider types are
-// allowed here and rejected by the registry's own validation.
+// rejected under eu_strict (fail closed).
 func AllowsProvider(mode, providerType string) bool {
 	switch mode {
 	case config.DataSovereigntyEUStrict:
 		meta, ok := llm.ProviderMetadataByType(providerType)
 		if !ok {
-			return true
+			return false
 		}
 		j := strings.ToUpper(strings.TrimSpace(meta.Jurisdiction))
 		return j == "EU" || j == "LOCAL" || len(meta.EURegions) > 0
@@ -75,11 +75,15 @@ func validateOperatorProviders(op *config.Config, mode string) error {
 		}
 	}
 	if op.LLM != nil {
-		for id := range op.LLM.Providers {
-			if !AllowsProvider(mode, id) {
+		for id, p := range op.LLM.Providers {
+			providerType := p.Type
+			if providerType == "" {
+				providerType = id
+			}
+			if !AllowsProvider(mode, providerType) {
 				return fmt.Errorf(
-					"sovereignty mode %s: llm.providers includes %q (%s jurisdiction) which is not EU/LOCAL",
-					mode, id, llm.JurisdictionForProvider(id))
+					"sovereignty mode %s: llm.providers includes %q (type %q, %s jurisdiction) which is not EU/LOCAL",
+					mode, id, providerType, llm.JurisdictionForProvider(providerType))
 			}
 		}
 	}

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -1,0 +1,118 @@
+package sovereignty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
+	_ "github.com/dativo-io/talon/internal/llm/providers"
+)
+
+func TestAllowsProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		provider string
+		want     bool
+	}{
+		{"eu_strict allows ollama (LOCAL)", config.DataSovereigntyEUStrict, "ollama", true},
+		{"eu_strict allows mistral (EU)", config.DataSovereigntyEUStrict, "mistral", true},
+		{"eu_strict allows bedrock (US + EU regions)", config.DataSovereigntyEUStrict, "bedrock", true},
+		{"eu_strict rejects openai (US)", config.DataSovereigntyEUStrict, "openai", false},
+		{"eu_strict rejects anthropic (US)", config.DataSovereigntyEUStrict, "anthropic", false},
+		{"eu_strict allows unknown provider (registry validates)", config.DataSovereigntyEUStrict, "made-up", true},
+		{"eu_preferred allows openai", config.DataSovereigntyEUPreferred, "openai", true},
+		{"global allows openai", config.DataSovereigntyGlobal, "openai", true},
+		{"empty mode allows openai", "", "openai", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, AllowsProvider(tt.mode, tt.provider))
+		})
+	}
+}
+
+func TestValidateSovereignty_EUStrictRejectsGatewayUSProvider(t *testing.T) {
+	clearProviderKeys(t)
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+		},
+	}
+	err := ValidateSovereignty(op, gw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openai")
+	assert.Contains(t, err.Error(), "eu_strict")
+}
+
+func TestValidateSovereignty_EUStrictAllowsEUAndLocal(t *testing.T) {
+	clearProviderKeys(t)
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"mistral":  {Enabled: true, BaseURL: "https://api.mistral.ai", Region: "EU"},
+			"ollama":   {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
+			"disabled": {Enabled: false, BaseURL: "https://api.openai.com", Region: "US"}, // ignored: not enabled
+		},
+	}
+	require.NoError(t, ValidateSovereignty(op, gw))
+}
+
+func TestValidateSovereignty_EUStrictRejectsKeyedOpenAI(t *testing.T) {
+	clearProviderKeys(t)
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	err := ValidateSovereignty(op, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
+}
+
+func TestValidateSovereignty_EUStrictRejectsLLMProvidersBlock(t *testing.T) {
+	clearProviderKeys(t)
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+		LLM: &config.LLMConfig{
+			Providers: map[string]config.LLMProviderConfig{"openai": {Enabled: true}},
+		},
+	}
+	err := ValidateSovereignty(op, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm.providers")
+}
+
+func TestValidateSovereignty_GlobalAllowsAll(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyGlobal},
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+		},
+	}
+	require.NoError(t, ValidateSovereignty(op, gw))
+}
+
+func TestValidateSovereignty_NoSovereigntyBlockIsNoop(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	op := &config.Config{}
+	require.NoError(t, ValidateSovereignty(op, nil))
+}
+
+// clearProviderKeys ensures operator-keyed provider env vars are unset so the
+// fail-closed gate is exercised deterministically regardless of the dev shell.
+func clearProviderKeys(t *testing.T) {
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+}

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -109,6 +109,41 @@ func TestValidateSovereignty_NoSovereigntyBlockIsNoop(t *testing.T) {
 	require.NoError(t, ValidateSovereignty(op, nil))
 }
 
+// TestValidateOperatorProviders_UsesProviderTypeNotAlias is the regression for
+// the "provider gate uses map key" bug: the gate must classify llm.providers
+// entries by their Type field, not by the (operator-chosen) map alias.
+func TestValidateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
+	clearProviderKeys(t)
+
+	// Alias looks EU-friendly but the real type is openai (US) → must be rejected.
+	t.Run("rejects by type not alias", func(t *testing.T) {
+		op := &config.Config{
+			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+			LLM: &config.LLMConfig{
+				Providers: map[string]config.LLMProviderConfig{
+					"my-eu-llm": {Type: "openai", Enabled: true},
+				},
+			},
+		}
+		err := validateOperatorProviders(op, config.DataSovereigntyEUStrict)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "openai")
+	})
+
+	// Alias looks like a US provider but the real type is mistral (EU) → allowed.
+	t.Run("allows by type not alias", func(t *testing.T) {
+		op := &config.Config{
+			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+			LLM: &config.LLMConfig{
+				Providers: map[string]config.LLMProviderConfig{
+					"openai": {Type: "mistral", Enabled: true},
+				},
+			},
+		}
+		require.NoError(t, validateOperatorProviders(op, config.DataSovereigntyEUStrict))
+	})
+}
+
 // clearProviderKeys ensures operator-keyed provider env vars are unset so the
 // fail-closed gate is exercised deterministically regardless of the dev shell.
 func clearProviderKeys(t *testing.T) {

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -23,7 +23,7 @@ func TestAllowsProvider(t *testing.T) {
 		{"eu_strict allows bedrock (US + EU regions)", config.DataSovereigntyEUStrict, "bedrock", true},
 		{"eu_strict rejects openai (US)", config.DataSovereigntyEUStrict, "openai", false},
 		{"eu_strict rejects anthropic (US)", config.DataSovereigntyEUStrict, "anthropic", false},
-		{"eu_strict allows unknown provider (registry validates)", config.DataSovereigntyEUStrict, "made-up", true},
+		{"eu_strict rejects unknown provider (fail closed)", config.DataSovereigntyEUStrict, "made-up", false},
 		{"eu_preferred allows openai", config.DataSovereigntyEUPreferred, "openai", true},
 		{"global allows openai", config.DataSovereigntyGlobal, "openai", true},
 		{"empty mode allows openai", "", "openai", true},

--- a/internal/sovereignty/validate.go
+++ b/internal/sovereignty/validate.go
@@ -1,0 +1,43 @@
+package sovereignty
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/gateway"
+)
+
+// ValidateAirGap checks operator and gateway configuration for air-gap mode.
+// Returns an error when the deployment cannot be considered provably in-region.
+func ValidateAirGap(op *config.Config, gw *gateway.GatewayConfig) error {
+	if op == nil || op.Sovereignty == nil || !op.Sovereignty.AirGapEnabled() {
+		return nil
+	}
+	if op.UsingDefaultKeys() {
+		return fmt.Errorf("air_gap mode requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY (no generated defaults)")
+	}
+	if op.LLM != nil && op.LLM.Routing != nil {
+		mode := op.LLM.Routing.DataSovereigntyMode
+		if mode != "" && mode != "eu_strict" {
+			return fmt.Errorf("air_gap mode requires llm.routing.data_sovereignty_mode eu_strict (got %q)", mode)
+		}
+	}
+	if gw == nil {
+		return nil
+	}
+	for name := range gw.Providers {
+		p := gw.Providers[name]
+		if !p.Enabled {
+			continue
+		}
+		region := strings.ToUpper(strings.TrimSpace(p.Region))
+		if region == "" {
+			return fmt.Errorf("air_gap gateway provider %q: region must be set (EU or LOCAL)", name)
+		}
+		if region != "EU" && region != "LOCAL" {
+			return fmt.Errorf("air_gap gateway provider %q: region %q is not permitted (use EU or LOCAL)", name, region)
+		}
+	}
+	return nil
+}

--- a/internal/sovereignty/validate.go
+++ b/internal/sovereignty/validate.go
@@ -2,7 +2,6 @@ package sovereignty
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/gateway"
@@ -10,6 +9,9 @@ import (
 
 // ValidateAirGap checks operator and gateway configuration for air-gap mode.
 // Returns an error when the deployment cannot be considered provably in-region.
+// The provider/region gate (eu_strict) is enforced by ValidateSovereignty;
+// ValidateAirGap adds the air-gap-specific requirement that crypto keys are
+// explicit so signed evidence cannot be forged with a derived default key.
 func ValidateAirGap(op *config.Config, gw *gateway.GatewayConfig) error {
 	if op == nil || op.Sovereignty == nil || !op.Sovereignty.AirGapEnabled() {
 		return nil
@@ -17,27 +19,6 @@ func ValidateAirGap(op *config.Config, gw *gateway.GatewayConfig) error {
 	if op.UsingDefaultKeys() {
 		return fmt.Errorf("air_gap mode requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY (no generated defaults)")
 	}
-	if op.LLM != nil && op.LLM.Routing != nil {
-		mode := op.LLM.Routing.DataSovereigntyMode
-		if mode != "" && mode != "eu_strict" {
-			return fmt.Errorf("air_gap mode requires llm.routing.data_sovereignty_mode eu_strict (got %q)", mode)
-		}
-	}
-	if gw == nil {
-		return nil
-	}
-	for name := range gw.Providers {
-		p := gw.Providers[name]
-		if !p.Enabled {
-			continue
-		}
-		region := strings.ToUpper(strings.TrimSpace(p.Region))
-		if region == "" {
-			return fmt.Errorf("air_gap gateway provider %q: region must be set (EU or LOCAL)", name)
-		}
-		if region != "EU" && region != "LOCAL" {
-			return fmt.Errorf("air_gap gateway provider %q: region %q is not permitted (use EU or LOCAL)", name, region)
-		}
-	}
-	return nil
+	// air_gap implies eu_strict (config resolution); enforce the provider gate.
+	return ValidateSovereignty(op, gw)
 }

--- a/schemas/talon.config.schema.json
+++ b/schemas/talon.config.schema.json
@@ -125,6 +125,23 @@
         }
       }
     },
+    "sovereignty": {
+      "type": "object",
+      "description": "Deployment sovereignty mode (air-gap presets and egress guard). Feature bet 5.3.",
+      "properties": {
+        "deployment_mode": {
+          "type": "string",
+          "enum": ["standard", "air_gap"],
+          "default": "standard",
+          "description": "air_gap enables eu_strict routing preset, EU/LOCAL egress defaults, and transport-level egress allowlist."
+        },
+        "allowed_egress_hosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional hosts/URLs added to the air-gap egress allowlist beyond ollama_base_url and gateway providers."
+        }
+      }
+    },
     "cache": {
       "type": "object",
       "description": "Governed semantic cache (optional, off by default). Validated by `talon doctor`.",

--- a/schemas/talon.config.schema.json
+++ b/schemas/talon.config.schema.json
@@ -127,8 +127,13 @@
     },
     "sovereignty": {
       "type": "object",
-      "description": "Deployment sovereignty mode (air-gap presets and egress guard). Feature bet 5.3.",
+      "description": "Deployment sovereignty (provider gate, air-gap presets and egress guard). Feature bet 5.3.",
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["eu_strict", "eu_preferred", "global"],
+          "description": "Single source of truth for data sovereignty. When set it supersedes llm.routing.data_sovereignty_mode and gates providers: eu_strict allows only EU/LOCAL (or EU-region-capable) providers and fails closed on any other declared provider. deployment_mode air_gap implies eu_strict."
+        },
         "deployment_mode": {
           "type": "string",
           "enum": ["standard", "air_gap"],

--- a/tests/integration/airgap_test.go
+++ b/tests/integration/airgap_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/sovereignty"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// TestAirGap_ZeroUnexpectedEgress proves air_gap mode blocks surprise outbound
+// hosts at the transport layer and applies EU/LOCAL-only egress policy before
+// bytes leave Talon (#132).
+func TestAirGap_ZeroUnexpectedEgress(t *testing.T) {
+	var allowedCalls atomic.Int64
+	allowedUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		allowedCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`))
+	}))
+	t.Cleanup(allowedUpstream.Close)
+
+	dir := t.TempDir()
+	configYAML := fmt.Sprintf(`
+sovereignty:
+  deployment_mode: air_gap
+
+llm:
+  routing:
+    data_sovereignty_mode: eu_strict
+
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: enforce
+  providers:
+    ollama:
+      enabled: true
+      secret_name: "ollama-key"
+      base_url: %q
+      region: "LOCAL"
+  callers:
+    - name: airgap-e2e
+      tenant_key: "talon-gw-airgap"
+      tenant_id: "airgap-tenant"
+      policy_overrides:
+        pii_action: warn
+        max_daily_cost: 100
+        max_monthly_cost: 2000
+  default_policy:
+    default_pii_action: warn
+    max_daily_cost: 100
+    max_monthly_cost: 2000
+  timeouts:
+    connect_timeout: "5s"
+    request_timeout: "30s"
+    stream_idle_timeout: "60s"
+`, allowedUpstream.URL)
+	configPath := filepath.Join(dir, "talon.config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigFile(configPath)
+	require.NoError(t, viper.ReadInConfig())
+	viper.Set("secrets_key", testutil.TestEncryptionKey)
+	viper.Set("signing_key", testutil.TestSigningKey)
+	viper.Set("data_dir", dir)
+	viper.Set("max_attachment_mb", 10)
+
+	opCfg, err := config.Load()
+	require.NoError(t, err)
+
+	gwCfg, err := gateway.LoadGatewayConfig(configPath)
+	require.NoError(t, err)
+	require.NoError(t, sovereignty.ValidateAirGap(opCfg, gwCfg))
+	guard, err := sovereignty.ApplyAirGapPreset(opCfg, gwCfg)
+	require.NoError(t, err)
+	require.NotNil(t, guard)
+	gwCfg.UpstreamTransport = guard
+	require.NoError(t, gwCfg.ApplyDefaults())
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "ollama-key",
+		[]byte("local"),
+		secrets.ACL{Tenants: []string{"airgap-tenant"}, Agents: []string{"*"}}))
+
+	policyEngine, err := policy.NewGatewayEngine(context.Background())
+	require.NoError(t, err)
+
+	gw, err := gateway.NewGateway(gwCfg, classifier.MustNewScanner(), evStore, secStore, policyEngine, nil)
+	require.NoError(t, err)
+
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) {
+		r.Handle("/*", gw)
+	})
+	send := func(body string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://test/v1/proxy/ollama/v1/chat/completions", bytes.NewReader([]byte(body)))
+		req.Header.Set("Authorization", "Bearer talon-gw-airgap")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	w := send(`{"model":"llama3","messages":[{"role":"user","content":"Summarize public docs"}]}`)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, int64(1), allowedCalls.Load())
+
+	// Direct guard check: non-allowlisted host must increment violations.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://surprise-egress.example/v1", nil)
+	require.NoError(t, err)
+	_, err = guard.RoundTrip(req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sovereignty.ErrEgressBlocked)
+	assert.Equal(t, int64(1), guard.Violations())
+
+	records, err := evStore.List(context.Background(), "airgap-tenant", "airgap-e2e", time.Time{}, time.Time{}, 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	assert.True(t, evStore.VerifyRecord(&records[0]))
+}
+
+func TestAirGap_RejectsUSProviderAtValidation(t *testing.T) {
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{DeploymentMode: sovereignty.ModeAirGap},
+		SecretsKey:  testutil.TestEncryptionKey,
+		SigningKey:  testutil.TestSigningKey,
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+		},
+	}
+	err := sovereignty.ValidateAirGap(op, gw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "US")
+}


### PR DESCRIPTION
## Summary
- Adds `sovereignty.deployment_mode: air_gap` with `eu_strict` routing preset, deny-by-default EU/LOCAL gateway egress, and a transport-level egress allowlist guard
- Wires validation into `talon serve --gateway` and `talon doctor`; requires explicit crypto keys in air-gap mode
- Adds integration tests (`TestAirGap_*`), example config, and [air-gapped deployment guide](docs/guides/air-gapped-deployment.md)

Closes #132. Part of epic #111.

## Test plan
- [x] `go test ./internal/sovereignty/...`
- [x] `go test -tags=integration ./tests/integration/ -run AirGap`
- [x] `make lint`
- [x] `talon doctor --gateway-config examples/airgap/talon.config.airgap.yaml --skip-upstream` (with explicit 64-hex-char keys + the config installed as operator config and the `ollama-api-key` vault secret set, per the example runbook) → **16 passed, 3 advisory warnings, 0 failures**. The air-gap checks pass: `sovereignty_providers` (eu_strict), `air_gap_config`, and `air_gap_egress_guard` (transport guard blocks non-allowlisted hosts). `llm_keys` now recognizes the local Ollama provider and `policy_valid` is advisory for gateway-only deployments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes startup and gateway egress enforcement for sovereignty-sensitive deployments; misconfiguration or merge bugs could block legitimate traffic or weaken residency guarantees.
> 
> **Overview**
> Introduces a top-level **`sovereignty`** block as the single source of truth for data residency: **`sovereignty.mode`** supersedes `llm.routing.data_sovereignty_mode`, and under **`eu_strict`** declared providers (env keys, `llm.providers`, gateway upstreams) are **fail-closed** at startup while undeclared non-EU types are dropped from the router set.
> 
> **`sovereignty.deployment_mode: air_gap`** forces `eu_strict`, requires explicit crypto keys, applies deny-by-default EU/LOCAL gateway egress when unset, and wraps upstream HTTP with a transport **egress allowlist** (Ollama URL, gateway `base_url`s, optional `allowed_egress_hosts`, loopback). Operator and `--gateway-config` sovereignty blocks are merged fail-safe via **`ResolveSovereigntyForGateway`**.
> 
> Validation and presets live in **`internal/sovereignty`**; **`talon run`** / **`talon serve --gateway`** apply them before serving. **`talon doctor`** adds sovereignty, air-gap, and egress-guard probes; gateway-only deploys get softer policy/LLM-key checks. Adds example config, deployment guide, schema, unit tests, and integration **`TestAirGap_*`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1bd52ed58103aa9c65a97da468ad3f6f20e872. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

