### PR TITLE
feat(compliance): sovereignty posture report CLI (#133)

### DIFF
--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -316,9 +316,7 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 	return os.WriteFile(complianceOutput, out, 0o600)
 }
 
-func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) (compliance.SovereigntyPostureConfig, []string) {
-	cfg := compliance.SovereigntyPostureConfig{}
-	var warnings []string
+func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) (cfg compliance.SovereigntyPostureConfig, warnings []string) {
 	if opCfg.LLM != nil && opCfg.LLM.Routing != nil {
 		cfg.DataSovereigntyMode = opCfg.LLM.Routing.DataSovereigntyMode
 	}

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -14,6 +14,9 @@ import (
 	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/llm"
+	_ "github.com/dativo-io/talon/internal/llm/providers"
 	"github.com/dativo-io/talon/internal/policy"
 )
 
@@ -111,6 +114,23 @@ model provider to complete. Missing declarations are reported as warnings and
 rendered as flagged placeholder sections.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runAuditorDocument(cmd, generateAnnexIVDocument)
+	},
+}
+
+var complianceSovereigntyCmd = &cobra.Command{
+	Use:   "sovereignty",
+	Short: "Generate a sovereignty posture report (configured mode + observed egress)",
+	Long: `Generate a sovereignty posture report for security review.
+
+Declared facts (data_sovereignty_mode, deployment_mode, gateway providers,
+LLM registry allowlist) come from talon.config.yaml. Runtime facts (observed
+destinations, egress denials, routing rejections) come from the signed evidence
+store.
+
+This is supporting evidence for data-residency posture — not a compliance
+determination.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runSovereigntyPosture(cmd)
 	},
 }
 
@@ -229,7 +249,126 @@ func loadComplianceDeclarations(ctx context.Context, policyFile string, warn io.
 	return decl
 }
 
-var compliancePolicyFile string
+func runSovereigntyPosture(cmd *cobra.Command) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+	defer cancel()
+
+	opCfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	postureCfg := buildSovereigntyPostureConfig(ctx, opCfg, complianceGatewayConfig)
+
+	store, err := openEvidenceStore()
+	if err != nil {
+		return fmt.Errorf("initializing evidence store: %w", err)
+	}
+	defer store.Close()
+
+	from, to, err := parseAuditDateRange(complianceFrom, complianceTo)
+	if err != nil {
+		return err
+	}
+	list, err := store.List(ctx, complianceTenant, complianceAgent, from, to, 200000)
+	if err != nil {
+		return fmt.Errorf("querying evidence: %w", err)
+	}
+
+	doc, err := compliance.GenerateSovereigntyPosture(ctx, postureCfg, list, compliance.SovereigntyPostureOptions{
+		TenantID: complianceTenant,
+		AgentID:  complianceAgent,
+		From:     complianceFrom,
+		To:       complianceTo,
+	})
+	if err != nil {
+		return fmt.Errorf("generating sovereignty posture report: %w", err)
+	}
+	for _, w := range doc.Warnings {
+		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING:", w)
+	}
+
+	var out []byte
+	switch strings.ToLower(complianceFormat) {
+	case "json":
+		out, err = compliance.RenderDocumentJSON(doc)
+	case "html":
+		out, err = compliance.RenderDocumentHTML(doc)
+	default:
+		return fmt.Errorf("unsupported --format %q; use html or json", complianceFormat)
+	}
+	if err != nil {
+		return fmt.Errorf("rendering document: %w", err)
+	}
+	if complianceOutput == "" {
+		_, _ = cmd.OutOrStdout().Write(out)
+		if len(out) == 0 || out[len(out)-1] != '\n' {
+			_, _ = cmd.OutOrStdout().Write([]byte("\n"))
+		}
+		return nil
+	}
+	return os.WriteFile(complianceOutput, out, 0o600)
+}
+
+func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) compliance.SovereigntyPostureConfig {
+	cfg := compliance.SovereigntyPostureConfig{}
+	if opCfg.LLM != nil && opCfg.LLM.Routing != nil {
+		cfg.DataSovereigntyMode = opCfg.LLM.Routing.DataSovereigntyMode
+	}
+	if opCfg.Sovereignty != nil {
+		cfg.DeploymentMode = opCfg.Sovereignty.Mode()
+		cfg.AirGapEgressGuard = opCfg.Sovereignty.AirGapEnabled()
+		cfg.AllowedEgressHosts = append([]string(nil), opCfg.Sovereignty.AllowedEgressHosts...)
+	}
+	if gatewayConfigPath != "" {
+		if gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath); err == nil {
+			for name := range gwCfg.Providers {
+				p := gwCfg.Providers[name]
+				cfg.GatewayProviders = append(cfg.GatewayProviders, compliance.SovereigntyGatewayProvider{
+					Name: name, Region: p.Region, Enabled: p.Enabled,
+				})
+			}
+		}
+	}
+	mode := cfg.DataSovereigntyMode
+	if mode == "" {
+		mode = "global"
+	}
+	pol := &policy.Policy{VersionTag: "v1", Policies: policy.PoliciesConfig{}}
+	eng, err := policy.NewEngine(ctx, pol)
+	if err == nil {
+		list := llm.ListForWizard(false)
+		for i := range list {
+			meta := list[i]
+			region := ""
+			if len(meta.EURegions) > 0 {
+				region = meta.EURegions[0]
+			}
+			row := compliance.SovereigntyLLMProvider{ID: meta.ID}
+			dec, evalErr := eng.EvaluateRouting(ctx, &policy.RoutingInput{
+				SovereigntyMode:      mode,
+				ProviderID:           meta.ID,
+				ProviderJurisdiction: meta.Jurisdiction,
+				ProviderRegion:       region,
+				DataTier:             0,
+			})
+			switch {
+			case evalErr != nil:
+				row.Reason = evalErr.Error()
+			case dec.Allowed:
+				row.Allowed = true
+			default:
+				row.Reason = strings.Join(dec.Reasons, "; ")
+			}
+			cfg.LLMProviders = append(cfg.LLMProviders, row)
+		}
+	}
+	return cfg
+}
+
+var (
+	compliancePolicyFile    string
+	complianceGatewayConfig string
+)
 
 func init() {
 	complianceReportCmd.Flags().StringVar(&complianceFramework, "framework", "", "Framework filter: gdpr, eu-ai-act, nis2, dora, iso-27001")
@@ -256,8 +395,17 @@ func init() {
 	complianceAnnexIVCmd.Flags().StringVar(&complianceOutput, "output", "", "Write document to file")
 	complianceAnnexIVCmd.Flags().StringVar(&compliancePolicyFile, "policy", "", "Agent policy file for declarations (default: from talon.config.yaml)")
 
+	complianceSovereigntyCmd.Flags().StringVar(&complianceFormat, "format", "html", "Output format: html or json")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceTenant, "tenant", "", "Filter by tenant ID")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceAgent, "agent", "", "Filter by agent ID")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceFrom, "from", "", "Start date (YYYY-MM-DD)")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceTo, "to", "", "End date (YYYY-MM-DD)")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceOutput, "output", "", "Write document to file")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceGatewayConfig, "gateway-config", "talon.config.yaml", "Gateway config path for declared upstream providers")
+
 	complianceCmd.AddCommand(complianceReportCmd)
 	complianceCmd.AddCommand(complianceRopaCmd)
 	complianceCmd.AddCommand(complianceAnnexIVCmd)
+	complianceCmd.AddCommand(complianceSovereigntyCmd)
 	rootCmd.AddCommand(complianceCmd)
 }

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/dativo-io/talon/internal/compliance"
 	"github.com/dativo-io/talon/internal/config"
@@ -257,7 +258,12 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
-	postureCfg := buildSovereigntyPostureConfig(ctx, opCfg, complianceGatewayConfig)
+
+	gwPath := complianceGatewayConfig
+	if gwPath == "" {
+		gwPath = viper.ConfigFileUsed()
+	}
+	postureCfg, cfgWarnings := buildSovereigntyPostureConfig(ctx, opCfg, gwPath)
 
 	store, err := openEvidenceStore()
 	if err != nil {
@@ -283,6 +289,7 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("generating sovereignty posture report: %w", err)
 	}
+	doc.Warnings = append(cfgWarnings, doc.Warnings...)
 	for _, w := range doc.Warnings {
 		fmt.Fprintln(cmd.ErrOrStderr(), "WARNING:", w)
 	}
@@ -309,8 +316,9 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 	return os.WriteFile(complianceOutput, out, 0o600)
 }
 
-func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) compliance.SovereigntyPostureConfig {
+func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) (compliance.SovereigntyPostureConfig, []string) {
 	cfg := compliance.SovereigntyPostureConfig{}
+	var warnings []string
 	if opCfg.LLM != nil && opCfg.LLM.Routing != nil {
 		cfg.DataSovereigntyMode = opCfg.LLM.Routing.DataSovereigntyMode
 	}
@@ -320,7 +328,10 @@ func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, ga
 		cfg.AllowedEgressHosts = append([]string(nil), opCfg.Sovereignty.AllowedEgressHosts...)
 	}
 	if gatewayConfigPath != "" {
-		if gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath); err == nil {
+		gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("could not load gateway config %s: %v — gateway providers section may be incomplete", gatewayConfigPath, err))
+		} else {
 			for name := range gwCfg.Providers {
 				p := gwCfg.Providers[name]
 				cfg.GatewayProviders = append(cfg.GatewayProviders, compliance.SovereigntyGatewayProvider{
@@ -362,7 +373,7 @@ func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, ga
 			cfg.LLMProviders = append(cfg.LLMProviders, row)
 		}
 	}
-	return cfg
+	return cfg, warnings
 }
 
 var (
@@ -401,7 +412,7 @@ func init() {
 	complianceSovereigntyCmd.Flags().StringVar(&complianceFrom, "from", "", "Start date (YYYY-MM-DD)")
 	complianceSovereigntyCmd.Flags().StringVar(&complianceTo, "to", "", "End date (YYYY-MM-DD)")
 	complianceSovereigntyCmd.Flags().StringVar(&complianceOutput, "output", "", "Write document to file")
-	complianceSovereigntyCmd.Flags().StringVar(&complianceGatewayConfig, "gateway-config", "talon.config.yaml", "Gateway config path for declared upstream providers")
+	complianceSovereigntyCmd.Flags().StringVar(&complianceGatewayConfig, "gateway-config", "", "Gateway config path for declared upstream providers (default: active config file)")
 
 	complianceCmd.AddCommand(complianceReportCmd)
 	complianceCmd.AddCommand(complianceRopaCmd)

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -259,11 +259,10 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	gwPath := complianceGatewayConfig
-	if gwPath == "" {
-		gwPath = viper.ConfigFileUsed()
+	postureCfg, cfgWarnings, err := resolveSovereigntyPostureConfig(ctx, opCfg)
+	if err != nil {
+		return err
 	}
-	postureCfg, cfgWarnings := buildSovereigntyPostureConfig(ctx, opCfg, gwPath)
 
 	store, err := openEvidenceStore()
 	if err != nil {
@@ -316,10 +315,36 @@ func runSovereigntyPosture(cmd *cobra.Command) error {
 	return os.WriteFile(complianceOutput, out, 0o600)
 }
 
-func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string) (cfg compliance.SovereigntyPostureConfig, warnings []string) {
-	if opCfg.LLM != nil && opCfg.LLM.Routing != nil {
-		cfg.DataSovereigntyMode = opCfg.LLM.Routing.DataSovereigntyMode
+// resolveSovereigntyPostureConfig resolves the effective sovereignty posture for
+// the report. Sovereignty (air_gap / eu_strict) commonly lives in the
+// --gateway-config file, so it merges any gateway-declared block into the
+// operator config fail-safe (stronger posture wins) — the same resolution the
+// gateway and `talon doctor` use — before building the posture config. An
+// explicitly provided --gateway-config that cannot be loaded is a hard error so
+// an auditor-facing report never silently renders "no providers".
+func resolveSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config) (compliance.SovereigntyPostureConfig, []string, error) {
+	gwPath := complianceGatewayConfig
+	if gwPath == "" {
+		gwPath = viper.ConfigFileUsed()
 	}
+	if gwPath != "" {
+		if err := config.ResolveSovereigntyForGateway(opCfg, gwPath); err != nil {
+			return compliance.SovereigntyPostureConfig{}, nil, fmt.Errorf("resolving sovereignty config: %w", err)
+		}
+	}
+	postureCfg, warnings := buildSovereigntyPostureConfig(ctx, opCfg, gwPath, complianceGatewayConfig != "")
+	if complianceGatewayConfig != "" && postureCfg.GatewayConfigError != "" {
+		return compliance.SovereigntyPostureConfig{}, nil, fmt.Errorf("loading gateway config %s: %s", complianceGatewayConfig, postureCfg.GatewayConfigError)
+	}
+	return postureCfg, warnings, nil
+}
+
+func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string, gatewayExplicit bool) (cfg compliance.SovereigntyPostureConfig, warnings []string) {
+	// Use the resolved effective mode (sovereignty.mode, or air_gap implying
+	// eu_strict, falling back to llm.routing.data_sovereignty_mode) rather than
+	// reading the routing value directly, so a gateway-declared posture is
+	// reflected after ResolveSovereigntyForGateway.
+	cfg.DataSovereigntyMode = opCfg.EffectiveSovereigntyMode()
 	if opCfg.Sovereignty != nil {
 		cfg.DeploymentMode = opCfg.Sovereignty.Mode()
 		cfg.AirGapEgressGuard = opCfg.Sovereignty.AirGapEnabled()
@@ -327,9 +352,18 @@ func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, ga
 	}
 	if gatewayConfigPath != "" {
 		gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("could not load gateway config %s: %v — gateway providers section may be incomplete", gatewayConfigPath, err))
-		} else {
+		switch {
+		case err != nil && gatewayExplicit:
+			// Explicit --gateway-config that fails to load is surfaced distinctly
+			// (and turned into a hard error by the caller) so the gateway section
+			// is never misread as "no providers configured".
+			cfg.GatewayConfigError = err.Error()
+			warnings = append(warnings, fmt.Sprintf("could not load gateway config %s: %v", gatewayConfigPath, err))
+		case err != nil:
+			// Auto-detected config without a (valid) gateway block: treat as "no
+			// gateway providers", but note it so the operator can tell why.
+			warnings = append(warnings, fmt.Sprintf("active config %s has no usable gateway block (%v); gateway providers section will be empty", gatewayConfigPath, err))
+		default:
 			for name := range gwCfg.Providers {
 				p := gwCfg.Providers[name]
 				cfg.GatewayProviders = append(cfg.GatewayProviders, compliance.SovereigntyGatewayProvider{

--- a/internal/cmd/compliance_test.go
+++ b/internal/cmd/compliance_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestComplianceCmd_HasSubcommands(t *testing.T) {
-	expected := []string{"report", "ropa", "annex-iv"}
+	expected := []string{"report", "ropa", "annex-iv", "sovereignty"}
 	registered := make(map[string]bool)
 	for _, c := range complianceCmd.Commands() {
 		registered[c.Name()] = true
@@ -237,6 +237,98 @@ compliance:
 	operator := findSection(t, doc, "Items to complete outside Talon")
 	require.NotNil(t, operator.Table)
 	assert.Len(t, operator.Table.Rows, 4)
+}
+
+// TestComplianceSovereignty_MergesGatewaySovereignty verifies that a
+// sovereignty block declared in --gateway-config (air_gap) is merged into the
+// operator config and reflected as the effective eu_strict mode in the report.
+// This is the same class of bug fixed in #185 for serve/doctor.
+func TestComplianceSovereignty_MergesGatewaySovereignty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	seedComplianceEvidence(t)
+
+	gwPath := filepath.Join(dir, "gw.airgap.yaml")
+	gwYAML := `sovereignty:
+  deployment_mode: air_gap
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "shadow"
+  providers:
+    ollama:
+      enabled: true
+      base_url: "http://127.0.0.1:11434"
+      region: "LOCAL"
+      secret_name: "ollama-api-key"
+  callers:
+    - name: "local"
+      tenant_key: "k-local"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+`
+	require.NoError(t, os.WriteFile(gwPath, []byte(gwYAML), 0o600))
+
+	outPath := filepath.Join(dir, "sov.json")
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"compliance", "sovereignty",
+		"--format", "json",
+		"--gateway-config", gwPath,
+		"--from", "2020-01-01",
+		"--output", outPath,
+	})
+	t.Cleanup(func() {
+		rootCmd.SetErr(nil)
+		complianceFormat, complianceFrom, complianceGatewayConfig, complianceOutput = "html", "", "", ""
+	})
+
+	require.NoError(t, rootCmd.Execute())
+
+	raw, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	var doc compliance.Document
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	assert.Equal(t, "Sovereignty Posture Report", doc.Title)
+	cfgSection := findSection(t, doc, "1. Configured sovereignty posture")
+	assert.Contains(t, cfgSection.Body, "eu_strict", "gateway air_gap should resolve to effective eu_strict routing mode")
+	assert.Contains(t, cfgSection.Body, "air_gap", "deployment mode should reflect gateway-declared air_gap")
+
+	// Gateway providers were loaded (no GatewayConfigError path).
+	gw := findSection(t, doc, "3. Gateway upstream providers")
+	require.NotNil(t, gw.Table)
+}
+
+// TestComplianceSovereignty_ExplicitInvalidGatewayConfigFails verifies that an
+// explicitly provided --gateway-config that cannot be loaded is a hard error,
+// not a report rendering "No gateway providers configured."
+func TestComplianceSovereignty_ExplicitInvalidGatewayConfigFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	seedComplianceEvidence(t)
+
+	badGw := filepath.Join(dir, "bad.gateway.yaml")
+	require.NoError(t, os.WriteFile(badGw, []byte("gateway: [this is not valid\n"), 0o600))
+
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"compliance", "sovereignty",
+		"--format", "json",
+		"--gateway-config", badGw,
+		"--from", "2020-01-01",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetErr(nil)
+		rootCmd.SetOut(nil)
+		complianceFormat, complianceFrom, complianceGatewayConfig = "html", "", ""
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway config")
 }
 
 func TestComplianceRopa_RejectsUnknownFormat(t *testing.T) {

--- a/internal/compliance/sovereignty.go
+++ b/internal/compliance/sovereignty.go
@@ -1,0 +1,293 @@
+package compliance
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+// SovereigntyPostureConfig carries declared operator/gateway facts for the
+// posture report. Runtime observations come from signed evidence.
+type SovereigntyPostureConfig struct {
+	DataSovereigntyMode string
+	DeploymentMode      string
+	AirGapEgressGuard   bool
+	AllowedEgressHosts  []string
+	GatewayProviders    []SovereigntyGatewayProvider
+	LLMProviders        []SovereigntyLLMProvider
+}
+
+// SovereigntyGatewayProvider is one configured gateway upstream.
+type SovereigntyGatewayProvider struct {
+	Name    string
+	Region  string
+	Enabled bool
+}
+
+// SovereigntyLLMProvider is one registry provider evaluated under the
+// configured data sovereignty mode.
+type SovereigntyLLMProvider struct {
+	ID      string
+	Allowed bool
+	Reason  string
+}
+
+// SovereigntyPostureOptions scopes the export and carries presentation inputs.
+type SovereigntyPostureOptions struct {
+	TenantID        string
+	AgentID         string
+	From            string
+	To              string
+	SignedExportRef string
+	Now             time.Time
+}
+
+type sovereigntyStats struct {
+	policyDenials      int
+	egressDenials      int
+	egressAllows       int
+	routingRejections  int
+	egressDenyByReason map[string]int
+	routingRejectByID  map[string]int
+}
+
+// GenerateSovereigntyPosture builds a sovereignty posture report from declared
+// configuration and signed runtime evidence (#133). The report is intended for
+// security teams and auditors reviewing in-region / air-gap posture — not a
+// compliance determination.
+func GenerateSovereigntyPosture(
+	ctx context.Context,
+	cfg SovereigntyPostureConfig,
+	list []evidence.Evidence,
+	opts SovereigntyPostureOptions,
+) (Document, error) {
+	_, span := tracer.Start(ctx, "compliance.generate_sovereignty_posture")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("tenant_id", opts.TenantID),
+		attribute.String("agent_id", opts.AgentID),
+		attribute.Int("evidence_count", len(list)),
+	)
+
+	stats := aggregateSovereigntyStats(list)
+	agg := newDestinationAggregator()
+	var sampleIDs []string
+	for i := range list {
+		ev := &list[i]
+		agg.addRecord(ev.DataFlow)
+		if len(sampleIDs) < maxSampleEvidenceIDs {
+			sampleIDs = append(sampleIDs, ev.ID)
+		}
+	}
+	sort.Strings(sampleIDs)
+	destinations := agg.summaries()
+
+	generatedAt := opts.Now
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+
+	mode := cfg.DataSovereigntyMode
+	if mode == "" {
+		mode = "global"
+	}
+	deploy := cfg.DeploymentMode
+	if deploy == "" {
+		deploy = "standard"
+	}
+
+	warnings := sovereigntyWarnings(cfg, destinations, stats)
+
+	doc := Document{
+		Title:       "Sovereignty Posture Report",
+		Subtitle:    "Configured EU/in-region controls and observed egress — generated from signed runtime evidence",
+		GeneratedAt: generatedAt,
+		Framework:   "sovereignty",
+		Article:     "Posture",
+		TenantID:    opts.TenantID,
+		AgentID:     opts.AgentID,
+		Warnings:    warnings,
+		ClaimNote:   ClaimNoteFor("data-residency and egress governance"),
+		Linkage: EvidenceLinkage{
+			EvidenceCount:     len(list),
+			From:              opts.From,
+			To:                opts.To,
+			SampleEvidenceIDs: sampleIDs,
+			VerifyCommand:     sovereigntyVerifyCommand(opts),
+			SignedExportRef:   opts.SignedExportRef,
+		},
+		Sections: []DocSection{
+			sovereigntyConfigSection(cfg, mode, deploy),
+			sovereigntyLLMProvidersSection(cfg),
+			sovereigntyGatewaySection(cfg),
+			sovereigntyObservedDestinationsSection(destinations),
+			sovereigntyDenialsSection(stats),
+		},
+	}
+	return doc, nil
+}
+
+func sovereigntyVerifyCommand(opts SovereigntyPostureOptions) string {
+	if opts.SignedExportRef != "" {
+		return "talon audit verify --file " + opts.SignedExportRef
+	}
+	return "talon audit verify"
+}
+
+func sovereigntyWarnings(cfg SovereigntyPostureConfig, destinations []DestinationSummary, stats sovereigntyStats) []string {
+	var warnings []string
+	if cfg.DataSovereigntyMode == "" {
+		warnings = append(warnings, "llm.routing.data_sovereignty_mode is not set — routing defaults to global in this report")
+	}
+	for _, d := range destinations {
+		if strings.EqualFold(d.Region, "US") || strings.EqualFold(d.Region, "CN") {
+			warnings = append(warnings, fmt.Sprintf("observed egress to non-EU region %q via %s (%s)", d.Region, d.Name, d.Kind))
+		}
+	}
+	if stats.egressDenials > 0 && cfg.DataSovereigntyMode != "eu_strict" {
+		warnings = append(warnings, "egress denials observed while data_sovereignty_mode is not eu_strict — align routing and egress policy")
+	}
+	return warnings
+}
+
+func sovereigntyConfigSection(cfg SovereigntyPostureConfig, mode, deploy string) DocSection {
+	body := fmt.Sprintf(
+		"Data sovereignty routing mode: %s\nDeployment mode: %s\nTransport egress guard: %s",
+		mode, deploy, boolLabel(cfg.AirGapEgressGuard),
+	)
+	if len(cfg.AllowedEgressHosts) > 0 {
+		body += "\nAdditional allowed egress hosts: " + strings.Join(cfg.AllowedEgressHosts, ", ")
+	}
+	return DocSection{Heading: "1. Configured sovereignty posture", Body: body}
+}
+
+func sovereigntyLLMProvidersSection(cfg SovereigntyPostureConfig) DocSection {
+	if len(cfg.LLMProviders) == 0 {
+		return DocSection{
+			Heading: "2. LLM providers (registry evaluation)",
+			Body:    "No provider registry entries evaluated.",
+		}
+	}
+	rows := make([][]string, 0, len(cfg.LLMProviders))
+	for _, p := range cfg.LLMProviders {
+		allowed := "no"
+		if p.Allowed {
+			allowed = "yes"
+		}
+		rows = append(rows, []string{p.ID, allowed, p.Reason})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+	return DocSection{
+		Heading: "2. LLM providers (registry evaluation)",
+		Body:    "Providers evaluated under the configured data_sovereignty_mode using routing.rego.",
+		Table:   &DocTable{Headers: []string{"Provider", "Allowed", "Reason"}, Rows: rows},
+	}
+}
+
+func sovereigntyGatewaySection(cfg SovereigntyPostureConfig) DocSection {
+	if len(cfg.GatewayProviders) == 0 {
+		return DocSection{
+			Heading: "3. Gateway upstream providers",
+			Body:    "No gateway providers configured.",
+		}
+	}
+	rows := make([][]string, 0, len(cfg.GatewayProviders))
+	for _, p := range cfg.GatewayProviders {
+		rows = append(rows, []string{p.Name, p.Region, boolLabel(p.Enabled)})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+	return DocSection{
+		Heading: "3. Gateway upstream providers",
+		Table:   &DocTable{Headers: []string{"Provider", "Region", "Enabled"}, Rows: rows},
+	}
+}
+
+func sovereigntyObservedDestinationsSection(destinations []DestinationSummary) DocSection {
+	if len(destinations) == 0 {
+		return DocSection{
+			Heading: "4. Observed egress destinations (runtime)",
+			Body:    "No forwarded data-flow destinations in the selected evidence window.",
+		}
+	}
+	rows := make([][]string, 0, len(destinations))
+	for _, d := range destinations {
+		rows = append(rows, []string{d.Kind, d.Name, d.Region, strconv.Itoa(d.RecordCount)})
+	}
+	return DocSection{
+		Heading: "4. Observed egress destinations (runtime)",
+		Body:    "Aggregated from signed data_flow evidence (blocked flows excluded).",
+		Table:   &DocTable{Headers: []string{"Kind", "Name", "Region", "Records"}, Rows: rows},
+	}
+}
+
+func sovereigntyDenialsSection(stats sovereigntyStats) DocSection {
+	rows := [][]string{
+		{"Policy denials (any reason)", strconv.Itoa(stats.policyDenials)},
+		{"Egress denials", strconv.Itoa(stats.egressDenials)},
+		{"Egress allows (control executed)", strconv.Itoa(stats.egressAllows)},
+		{"Routing rejections (candidates)", strconv.Itoa(stats.routingRejections)},
+	}
+	for reason, n := range stats.egressDenyByReason {
+		rows = append(rows, []string{"Egress deny: " + reason, strconv.Itoa(n)})
+	}
+	for id, n := range stats.routingRejectByID {
+		rows = append(rows, []string{"Routing reject: " + id, strconv.Itoa(n)})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+	return DocSection{
+		Heading: "5. Policy and egress denials (runtime)",
+		Body:    "Counts from signed evidence in the selected window.",
+		Table:   &DocTable{Headers: []string{"Control", "Count"}, Rows: rows},
+	}
+}
+
+func aggregateSovereigntyStats(list []evidence.Evidence) sovereigntyStats {
+	s := sovereigntyStats{
+		egressDenyByReason: make(map[string]int),
+		routingRejectByID:  make(map[string]int),
+	}
+	for i := range list {
+		ev := &list[i]
+		if !ev.PolicyDecision.Allowed {
+			s.policyDenials++
+		}
+		if ev.EgressDecision != nil {
+			switch ev.EgressDecision.Decision {
+			case "deny":
+				s.egressDenials++
+				reason := ev.EgressDecision.Reason
+				if reason == "" {
+					reason = "unspecified"
+				}
+				s.egressDenyByReason[reason]++
+			case "allow":
+				s.egressAllows++
+			}
+		}
+		if ev.RoutingDecision != nil {
+			s.routingRejections += len(ev.RoutingDecision.RejectedCandidates)
+			for _, rc := range ev.RoutingDecision.RejectedCandidates {
+				id := rc.ProviderID
+				if id == "" {
+					id = "unknown"
+				}
+				s.routingRejectByID[id]++
+			}
+		}
+	}
+	return s
+}
+
+func boolLabel(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/compliance/sovereignty.go
+++ b/internal/compliance/sovereignty.go
@@ -22,6 +22,10 @@ type SovereigntyPostureConfig struct {
 	AllowedEgressHosts  []string
 	GatewayProviders    []SovereigntyGatewayProvider
 	LLMProviders        []SovereigntyLLMProvider
+	// GatewayConfigError, when non-empty, records that a declared gateway config
+	// could not be loaded. The gateway section renders this distinctly so an
+	// empty provider list is never misread as "no providers configured".
+	GatewayConfigError string
 }
 
 // SovereigntyGatewayProvider is one configured gateway upstream.
@@ -192,6 +196,13 @@ func sovereigntyLLMProvidersSection(cfg SovereigntyPostureConfig) DocSection {
 }
 
 func sovereigntyGatewaySection(cfg SovereigntyPostureConfig) DocSection {
+	if cfg.GatewayConfigError != "" {
+		return DocSection{
+			Heading: "3. Gateway upstream providers",
+			Body: "Gateway config could not be loaded: " + cfg.GatewayConfigError +
+				"\nProvider rows are unavailable for this report. This is NOT a statement that no gateway providers are configured — resolve the gateway config and regenerate.",
+		}
+	}
 	if len(cfg.GatewayProviders) == 0 {
 		return DocSection{
 			Heading: "3. Gateway upstream providers",

--- a/internal/compliance/sovereignty_test.go
+++ b/internal/compliance/sovereignty_test.go
@@ -91,6 +91,28 @@ func TestGenerateSovereigntyPosture_GoldenShape(t *testing.T) {
 	assert.Contains(t, string(out), "eu_strict")
 }
 
+// TestGenerateSovereigntyPosture_GatewayConfigError ensures a gateway-config
+// load failure renders a distinct section rather than the misleading
+// "No gateway providers configured." auditors must not misread.
+func TestGenerateSovereigntyPosture_GatewayConfigError(t *testing.T) {
+	cfg := SovereigntyPostureConfig{
+		DataSovereigntyMode: "eu_strict",
+		GatewayConfigError:  "parsing gateway config: yaml: line 3: did not find expected key",
+	}
+	doc, err := GenerateSovereigntyPosture(context.Background(), cfg, nil, SovereigntyPostureOptions{Now: fixedTime})
+	require.NoError(t, err)
+
+	var gw *DocSection
+	for i := range doc.Sections {
+		if doc.Sections[i].Heading == "3. Gateway upstream providers" {
+			gw = &doc.Sections[i]
+		}
+	}
+	require.NotNil(t, gw)
+	assert.Contains(t, gw.Body, "could not be loaded")
+	assert.NotContains(t, gw.Body, "No gateway providers configured")
+}
+
 func TestGenerateSovereigntyPosture_HTML(t *testing.T) {
 	doc, err := GenerateSovereigntyPosture(context.Background(), SovereigntyPostureConfig{
 		DataSovereigntyMode: "eu_strict",

--- a/internal/compliance/sovereignty_test.go
+++ b/internal/compliance/sovereignty_test.go
@@ -1,0 +1,102 @@
+package compliance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+func sovereigntyEvidence() []evidence.Evidence {
+	return []evidence.Evidence{
+		{
+			ID: "sov_aaa", TenantID: "acme", AgentID: "gw", Timestamp: fixedTime,
+			PolicyDecision: evidence.PolicyDecision{Allowed: true},
+			RoutingDecision: &evidence.RoutingDecision{
+				SelectedProvider: "mistral",
+				SelectedModel:    "mistral-large",
+				RejectedCandidates: []evidence.RejectedCandidate{
+					{ProviderID: "openai", Reason: "jurisdiction not allowed"},
+				},
+			},
+			DataFlow: &evidence.DataFlow{Items: []evidence.DataFlowItem{{
+				Source: "prompt", Tier: 1,
+				Disposition: evidence.FlowDispositionForwarded,
+				Destination: evidence.FlowDestination{Kind: "llm_provider", Name: "mistral", Region: "EU"},
+			}}},
+		},
+		{
+			ID: "sov_bbb", TenantID: "acme", AgentID: "gw", Timestamp: fixedTime,
+			PolicyDecision: evidence.PolicyDecision{Allowed: false},
+			EgressDecision: &evidence.EgressDecision{
+				Tier: 2, Provider: "openai", Region: "US",
+				Decision: "deny", Reason: "egress_tier_destination_disallowed",
+			},
+		},
+	}
+}
+
+func TestGenerateSovereigntyPosture_GoldenShape(t *testing.T) {
+	cfg := SovereigntyPostureConfig{
+		DataSovereigntyMode: "eu_strict",
+		DeploymentMode:      "air_gap",
+		AirGapEgressGuard:   true,
+		AllowedEgressHosts:  []string{"llm.internal.example"},
+		GatewayProviders: []SovereigntyGatewayProvider{
+			{Name: "ollama", Region: "LOCAL", Enabled: true},
+		},
+		LLMProviders: []SovereigntyLLMProvider{
+			{ID: "mistral", Allowed: true},
+			{ID: "openai", Allowed: false, Reason: "jurisdiction not allowed"},
+		},
+	}
+	doc, err := GenerateSovereigntyPosture(context.Background(), cfg, sovereigntyEvidence(), SovereigntyPostureOptions{
+		TenantID:        "acme",
+		From:            "2026-01-01",
+		To:              "2026-06-11",
+		SignedExportRef: "evidence.signed.json",
+		Now:             fixedTime,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Sovereignty Posture Report", doc.Title)
+	assert.Equal(t, "sovereignty", doc.Framework)
+	assert.Equal(t, 2, doc.Linkage.EvidenceCount)
+	assert.Equal(t, "talon audit verify --file evidence.signed.json", doc.Linkage.VerifyCommand)
+	require.Len(t, doc.Sections, 5)
+	assert.Contains(t, doc.Sections[0].Body, "eu_strict")
+	assert.Contains(t, doc.Sections[0].Body, "air_gap")
+	assert.NotNil(t, doc.Sections[4].Table)
+
+	// policy denials: 1, egress denials: 1
+	denialRows := doc.Sections[4].Table.Rows
+	foundPolicy := false
+	foundEgress := false
+	for _, row := range denialRows {
+		if row[0] == "Policy denials (any reason)" && row[1] == "1" {
+			foundPolicy = true
+		}
+		if row[0] == "Egress denials" && row[1] == "1" {
+			foundEgress = true
+		}
+	}
+	assert.True(t, foundPolicy)
+	assert.True(t, foundEgress)
+
+	out, err := RenderDocumentJSON(doc)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "eu_strict")
+}
+
+func TestGenerateSovereigntyPosture_HTML(t *testing.T) {
+	doc, err := GenerateSovereigntyPosture(context.Background(), SovereigntyPostureConfig{
+		DataSovereigntyMode: "eu_strict",
+	}, nil, SovereigntyPostureOptions{Now: fixedTime})
+	require.NoError(t, err)
+	html, err := RenderDocumentHTML(doc)
+	require.NoError(t, err)
+	assert.Contains(t, string(html), "Sovereignty Posture Report")
+}


### PR DESCRIPTION
## Summary
- Adds `talon compliance sovereignty` to generate an HTML/JSON sovereignty posture report
- Aggregates declared config (effective sovereignty mode, deployment mode, gateway/LLM providers) with runtime evidence (data_flow destinations, egress denials, routing rejections)
- Reuses the auditor document renderer and evidence linkage pattern from RoPA/Annex IV

Closes #133. Part of epic #111.

### Post-#185 cleanup (this revision)
- Rebased onto `main` and retargeted the PR base to `main` (#185 is merged; the stacked #132 commits dropped out cleanly via `git rebase --onto`).
- Merge gateway-declared sovereignty into the operator config via `config.ResolveSovereigntyForGateway` **before** building the report, and report the **effective** mode via `EffectiveSovereigntyMode()` instead of reading `llm.routing.data_sovereignty_mode` directly. `air_gap` / `eu_strict` declared in `--gateway-config` is now reflected — the same class of bug fixed in #185 for serve/doctor.
- An explicit `--gateway-config` that fails to load is now a **hard error**; the report renders a distinct "Gateway config could not be loaded" section instead of the misleading "No gateway providers configured."

## Test plan
- [x] `go test ./internal/compliance/... -run Sovereignty`
- [x] `make lint` / `make vet` / `make test` (full suite green)
- [x] `talon compliance sovereignty --format json` with sample evidence
- [x] `talon compliance sovereignty --format json --gateway-config examples/airgap/talon.config.airgap.yaml` → report shows effective `eu_strict` + `air_gap` + gateway providers
- [x] explicit invalid `--gateway-config` → hard error (`loading gateway config ...`), no misleading report

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New auditor-facing export that interprets sovereignty config and evidence for egress/routing posture; misconfiguration handling was tightened but incorrect effective-mode resolution could still mislead reviewers.
> 
> **Overview**
> Adds **`talon compliance sovereignty`** to produce HTML/JSON **sovereignty posture** documents for security review, using the same auditor-document pipeline as RoPA and Annex IV.
> 
> The report combines **declared** posture (effective `data_sovereignty_mode`, deployment/air-gap settings, gateway upstreams, LLM registry allow/deny via routing policy) with **runtime** signed evidence (aggregated data-flow destinations, policy/egress denials, routing rejections). New **`--gateway-config`** flag feeds gateway providers; sovereignty is merged with **`ResolveSovereigntyForGateway`** and **`EffectiveSovereigntyMode()`** so gateway-declared `air_gap` / `eu_strict` matches serve/doctor behavior.
> 
> An **explicit invalid `--gateway-config` fails the command** instead of emitting a report that looks like “no gateway providers”; load errors can also render a distinct gateway section when surfaced in-document. Warnings cover missing routing mode, non-EU observed egress, and egress denials when mode is not `eu_strict`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad361ed094362f9379504b37ced23184e385597b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->