### PR TITLE
feat(sovereignty): non-fatal eu_strict provider gate with runtime gateway denial

### DIFF
--- a/docs/guides/air-gapped-deployment.md
+++ b/docs/guides/air-gapped-deployment.md
@@ -12,15 +12,17 @@ defines your data-sovereignty posture. When set, it:
 1. **Supersedes** `llm.routing.data_sovereignty_mode` — you set the mode once at the
    top level; the routing engine inherits it. A conflicting routing value is
    overridden with a warning.
-2. **Gates providers (fail closed)** — under `eu_strict`, only providers whose
-   jurisdiction is `EU`/`LOCAL` (or that expose an EU region, e.g. Bedrock
-   `eu-central-1`) are allowed. Any other **declared** provider is rejected at
-   startup:
+2. **Excludes non-compliant providers** — under `eu_strict`, declared providers
+   whose jurisdiction is not `EU`/`LOCAL` (and that do not expose an EU region,
+   e.g. Bedrock `eu-central-1`) are **excluded from routing** with an ERROR log
+   at startup. The process keeps running so compliant providers remain available.
+   Direct gateway requests to an excluded provider receive HTTP 403 with signed
+   audit evidence. This covers:
    - an enabled gateway provider in a non-EU/LOCAL region,
    - an operator-keyed provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`),
    - a non-sovereign entry in the `llm.providers` block.
-   Non-sovereign providers that were *not* explicitly configured are simply
-   filtered out of the available set so routing cannot select them.
+   Non-sovereign providers that were *not* explicitly configured are filtered
+   silently from the available set (Debug log) so routing cannot select them.
 
 `eu_preferred` and `global` impose no hard provider gate (routing still applies EU
 preference under `eu_preferred`).
@@ -38,7 +40,7 @@ preference under `eu_preferred`).
    - loopback (`localhost`, `127.0.0.1`, `::1`)
 3. **Crypto hardening** — rejects startup when `TALON_SECRETS_KEY` / `TALON_SIGNING_KEY` are generated defaults (air-gap deployments must use explicit keys).
 
-Defense in depth: the sovereignty gate rejects non-EU providers at config load; policy egress blocks disallowed destinations **before** forward; the transport guard catches misconfiguration or code paths that would otherwise surprise-egress.
+Defense in depth: excluded providers are dropped from routing and denied at the gateway (403); policy egress blocks disallowed destinations **before** forward; the transport guard catches misconfiguration or code paths that would otherwise surprise-egress.
 
 ## Quick start
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -182,7 +182,7 @@ rather than mirroring it under `llm.routing`.
 
 | Field | Values | Purpose |
 |-------|--------|---------|
-| `sovereignty.mode` | `eu_strict`, `eu_preferred`, `global` | Data-sovereignty posture (source of truth). Under `eu_strict`, declared non-EU/LOCAL providers are **excluded from routing** (ERROR log at startup) and **denied at the gateway** (HTTP 403 + audit evidence). The process continues unless `deployment_mode: air_gap` is set without explicit crypto keys. Covers operator-keyed providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), `llm.providers` entries, and enabled gateway upstreams. Non-declared registry defaults are filtered silently. `eu_preferred` and `global` impose no hard gate. |
+| `sovereignty.mode` | `eu_strict`, `eu_preferred`, `global` | Data-sovereignty posture (source of truth). Under `eu_strict`, declared non-EU/LOCAL providers are **excluded from routing** (ERROR log at startup) and **denied at the gateway** (HTTP 403 + audit evidence). The process continues unless `deployment_mode: air_gap` is set without explicit crypto keys. Covers operator-keyed providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), `llm.providers` entries, and enabled gateway upstreams. Region-aware providers (Bedrock, Azure OpenAI, Vertex) are gated on their **configured region**, not just metadata: e.g. `AWS_REGION=us-east-1` excludes Bedrock, while `AWS_REGION=eu-central-1` keeps it routable. Non-declared registry defaults are filtered silently. `eu_preferred` and `global` impose no hard gate. |
 | `sovereignty.deployment_mode` | `standard`, `air_gap` | `air_gap` is a stricter sub-mode that **implies `eu_strict`** (a looser `mode` is rejected). It adds deny-by-default EU/LOCAL gateway egress, a transport-level egress allowlist guard, and rejects generated default crypto keys. See the [air-gapped deployment guide](../guides/air-gapped-deployment.md). |
 | `sovereignty.allowed_egress_hosts` | list of host or URL strings | Optional extension to the air-gap transport allowlist (in addition to `ollama_base_url`, enabled gateway `base_url`s, and loopback). |
 
@@ -201,7 +201,7 @@ sovereignty:
     - "llm.internal.example"
 ```
 
-Validated by `talon doctor` (`sovereignty_providers` warns when exclusions exist but compliant providers remain; fails only when nothing EU/LOCAL is routable; `air_gap_crypto_keys` fails on default keys; `air_gap_egress_guard` transport probe). See the [air-gapped deployment guide](../guides/air-gapped-deployment.md).
+Validated by `talon doctor` (`sovereignty_providers` warns when exclusions exist but compliant providers remain; fails only when nothing EU/LOCAL is routable. Gateway and native routability are checked **independently** — with `--gateway-config`, the gateway must have at least one compliant enabled provider, and a compliant native/LLM provider does not mask an all-excluded gateway. `air_gap_crypto_keys` fails on default keys; `air_gap_egress_guard` transport probe). See the [air-gapped deployment guide](../guides/air-gapped-deployment.md).
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -182,7 +182,7 @@ rather than mirroring it under `llm.routing`.
 
 | Field | Values | Purpose |
 |-------|--------|---------|
-| `sovereignty.mode` | `eu_strict`, `eu_preferred`, `global` | Data-sovereignty posture (source of truth). Under `eu_strict` the **provider gate fails closed**: any explicitly declared provider that is not EU/LOCAL (or EU-region-capable, e.g. Bedrock `eu-central-1`) is rejected at startup — this covers operator-keyed providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), `llm.providers` entries, and enabled gateway upstreams. Non-sovereign providers that were not explicitly configured are filtered out of the router set. `eu_preferred` and `global` impose no hard gate. |
+| `sovereignty.mode` | `eu_strict`, `eu_preferred`, `global` | Data-sovereignty posture (source of truth). Under `eu_strict`, declared non-EU/LOCAL providers are **excluded from routing** (ERROR log at startup) and **denied at the gateway** (HTTP 403 + audit evidence). The process continues unless `deployment_mode: air_gap` is set without explicit crypto keys. Covers operator-keyed providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), `llm.providers` entries, and enabled gateway upstreams. Non-declared registry defaults are filtered silently. `eu_preferred` and `global` impose no hard gate. |
 | `sovereignty.deployment_mode` | `standard`, `air_gap` | `air_gap` is a stricter sub-mode that **implies `eu_strict`** (a looser `mode` is rejected). It adds deny-by-default EU/LOCAL gateway egress, a transport-level egress allowlist guard, and rejects generated default crypto keys. See the [air-gapped deployment guide](../guides/air-gapped-deployment.md). |
 | `sovereignty.allowed_egress_hosts` | list of host or URL strings | Optional extension to the air-gap transport allowlist (in addition to `ollama_base_url`, enabled gateway `base_url`s, and loopback). |
 
@@ -195,14 +195,13 @@ Example:
 
 ```yaml
 sovereignty:
-  mode: eu_strict                 # source of truth; gates providers (fail closed)
+  mode: eu_strict                 # source of truth; excludes non-EU providers
   deployment_mode: air_gap        # optional: implies eu_strict + egress hardening
   allowed_egress_hosts:           # optional extra private EU endpoints
     - "llm.internal.example"
 ```
 
-Validated by `talon doctor` (`sovereignty_providers`, `air_gap_config`, and the
-`air_gap_egress_guard` transport probe).
+Validated by `talon doctor` (`sovereignty_providers` warns when exclusions exist but compliant providers remain; fails only when nothing EU/LOCAL is routable; `air_gap_crypto_keys` fails on default keys; `air_gap_egress_guard` transport probe). See the [air-gapped deployment guide](../guides/air-gapped-deployment.md).
 
 ---
 

--- a/examples/airgap/README.md
+++ b/examples/airgap/README.md
@@ -12,8 +12,8 @@ talon doctor --gateway-config ~/.talon/talon.config.yaml --skip-upstream
 talon serve --gateway --gateway-config ~/.talon/talon.config.yaml
 ```
 
-`talon doctor` should report `0 failures` (a couple of advisory warnings are
-expected: no agent policy is needed for a gateway-only deployment, and an empty
-`forbidden_tools` list).
+`talon doctor` should report `0 failures` for a healthy air-gap deployment (a couple of advisory warnings are
+expected: no agent policy is needed for a gateway-only deployment, an empty
+`forbidden_tools` list, or excluded non-EU providers when a compliant LOCAL/EU provider also exists).
 
 See [Air-gapped deployment guide](../../docs/guides/air-gapped-deployment.md) for the full runbook.

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dativo-io/talon/internal/llm"
 	_ "github.com/dativo-io/talon/internal/llm/providers"
 	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/sovereignty"
 )
 
 var (
@@ -340,72 +341,121 @@ func resolveSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config) 
 }
 
 func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, gatewayConfigPath string, gatewayExplicit bool) (cfg compliance.SovereigntyPostureConfig, warnings []string) {
-	// Use the resolved effective mode (sovereignty.mode, or air_gap implying
-	// eu_strict, falling back to llm.routing.data_sovereignty_mode) rather than
-	// reading the routing value directly, so a gateway-declared posture is
-	// reflected after ResolveSovereigntyForGateway.
 	cfg.DataSovereigntyMode = opCfg.EffectiveSovereigntyMode()
 	if opCfg.Sovereignty != nil {
 		cfg.DeploymentMode = opCfg.Sovereignty.Mode()
 		cfg.AirGapEgressGuard = opCfg.Sovereignty.AirGapEnabled()
 		cfg.AllowedEgressHosts = append([]string(nil), opCfg.Sovereignty.AllowedEgressHosts...)
 	}
-	if gatewayConfigPath != "" {
-		gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath)
-		switch {
-		case err != nil && gatewayExplicit:
-			// Explicit --gateway-config that fails to load is surfaced distinctly
-			// (and turned into a hard error by the caller) so the gateway section
-			// is never misread as "no providers configured".
-			cfg.GatewayConfigError = err.Error()
-			warnings = append(warnings, fmt.Sprintf("could not load gateway config %s: %v", gatewayConfigPath, err))
-		case err != nil:
-			// Auto-detected config without a (valid) gateway block: treat as "no
-			// gateway providers", but note it so the operator can tell why.
-			warnings = append(warnings, fmt.Sprintf("active config %s has no usable gateway block (%v); gateway providers section will be empty", gatewayConfigPath, err))
-		default:
-			for name := range gwCfg.Providers {
-				p := gwCfg.Providers[name]
-				cfg.GatewayProviders = append(cfg.GatewayProviders, compliance.SovereigntyGatewayProvider{
-					Name: name, Region: p.Region, Enabled: p.Enabled,
-				})
-			}
+	gwCfg, gwWarnings := loadGatewayProvidersForPosture(gatewayConfigPath, gatewayExplicit)
+	warnings = append(warnings, gwWarnings...)
+	cfg.GatewayProviders = gwCfg.providers
+	cfg.GatewayConfigError = gwCfg.loadError
+
+	excludedGateway, excludedLLM := sovereigntyExclusionMaps(sovereignty.EvaluateSovereignty(opCfg, gwCfg.cfg))
+	applyGatewayPostureLabels(cfg.GatewayProviders, excludedGateway)
+	cfg.LLMProviders = buildLLMProviderRowsForPosture(ctx, cfg.DataSovereigntyMode, excludedLLM)
+	return cfg, warnings
+}
+
+type postureGatewayLoad struct {
+	cfg       *gateway.GatewayConfig
+	providers []compliance.SovereigntyGatewayProvider
+	loadError string
+}
+
+func loadGatewayProvidersForPosture(gatewayConfigPath string, gatewayExplicit bool) (loaded postureGatewayLoad, warnings []string) {
+	if gatewayConfigPath == "" {
+		return postureGatewayLoad{}, nil
+	}
+	gwCfg, err := gateway.LoadGatewayConfig(gatewayConfigPath)
+	switch {
+	case err != nil && gatewayExplicit:
+		return postureGatewayLoad{loadError: err.Error()},
+			[]string{fmt.Sprintf("could not load gateway config %s: %v", gatewayConfigPath, err)}
+	case err != nil:
+		return postureGatewayLoad{},
+			[]string{fmt.Sprintf("active config %s has no usable gateway block (%v); gateway providers section will be empty", gatewayConfigPath, err)}
+	default:
+		out := postureGatewayLoad{cfg: gwCfg}
+		for name := range gwCfg.Providers {
+			p := gwCfg.Providers[name]
+			out.providers = append(out.providers, compliance.SovereigntyGatewayProvider{
+				Name: name, Region: p.Region, Enabled: p.Enabled,
+			})
+		}
+		return out, nil
+	}
+}
+
+func sovereigntyExclusionMaps(eval sovereignty.Evaluation) (gateway, llm map[string]bool) {
+	gateway = make(map[string]bool)
+	llm = make(map[string]bool)
+	for _, ex := range eval.Excluded {
+		switch ex.Scope {
+		case sovereignty.ExclusionScopeGateway:
+			gateway[ex.Provider] = true
+		case sovereignty.ExclusionScopeEnv, sovereignty.ExclusionScopeLLMProviders:
+			llm[ex.Provider] = true
 		}
 	}
-	mode := cfg.DataSovereigntyMode
+	return gateway, llm
+}
+
+func applyGatewayPostureLabels(providers []compliance.SovereigntyGatewayProvider, excluded map[string]bool) {
+	for i := range providers {
+		switch {
+		case !providers[i].Enabled:
+			providers[i].Posture = "disabled"
+		case excluded[providers[i].Name]:
+			providers[i].Posture = "excluded"
+		default:
+			providers[i].Posture = "allowed"
+		}
+	}
+}
+
+func buildLLMProviderRowsForPosture(ctx context.Context, mode string, excludedLLM map[string]bool) []compliance.SovereigntyLLMProvider {
 	if mode == "" {
 		mode = "global"
 	}
 	pol := &policy.Policy{VersionTag: "v1", Policies: policy.PoliciesConfig{}}
 	eng, err := policy.NewEngine(ctx, pol)
-	if err == nil {
-		list := llm.ListForWizard(false)
-		for i := range list {
-			meta := list[i]
-			region := ""
-			if len(meta.EURegions) > 0 {
-				region = meta.EURegions[0]
-			}
-			row := compliance.SovereigntyLLMProvider{ID: meta.ID}
-			dec, evalErr := eng.EvaluateRouting(ctx, &policy.RoutingInput{
-				SovereigntyMode:      mode,
-				ProviderID:           meta.ID,
-				ProviderJurisdiction: meta.Jurisdiction,
-				ProviderRegion:       region,
-				DataTier:             0,
-			})
-			switch {
-			case evalErr != nil:
-				row.Reason = evalErr.Error()
-			case dec.Allowed:
-				row.Allowed = true
-			default:
-				row.Reason = strings.Join(dec.Reasons, "; ")
-			}
-			cfg.LLMProviders = append(cfg.LLMProviders, row)
-		}
+	if err != nil {
+		return nil
 	}
-	return cfg, warnings
+	list := llm.ListForWizard(false)
+	rows := make([]compliance.SovereigntyLLMProvider, 0, len(list))
+	for i := range list {
+		meta := list[i]
+		region := ""
+		if len(meta.EURegions) > 0 {
+			region = meta.EURegions[0]
+		}
+		row := compliance.SovereigntyLLMProvider{ID: meta.ID}
+		dec, evalErr := eng.EvaluateRouting(ctx, &policy.RoutingInput{
+			SovereigntyMode:      mode,
+			ProviderID:           meta.ID,
+			ProviderJurisdiction: meta.Jurisdiction,
+			ProviderRegion:       region,
+			DataTier:             0,
+		})
+		switch {
+		case evalErr != nil:
+			row.Reason = evalErr.Error()
+		case excludedLLM[meta.ID]:
+			row.Status = "excluded_declared"
+			row.Reason = "declared but excluded under eu_strict"
+		case dec.Allowed:
+			row.Allowed = true
+			row.Status = "allowed"
+		default:
+			row.Status = "not_allowed"
+			row.Reason = strings.Join(dec.Reasons, "; ")
+		}
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 var (

--- a/internal/cmd/compliance.go
+++ b/internal/cmd/compliance.go
@@ -354,7 +354,7 @@ func buildSovereigntyPostureConfig(ctx context.Context, opCfg *config.Config, ga
 
 	excludedGateway, excludedLLM := sovereigntyExclusionMaps(sovereignty.EvaluateSovereignty(opCfg, gwCfg.cfg))
 	applyGatewayPostureLabels(cfg.GatewayProviders, excludedGateway)
-	cfg.LLMProviders = buildLLMProviderRowsForPosture(ctx, cfg.DataSovereigntyMode, excludedLLM)
+	cfg.LLMProviders = buildLLMProviderRowsForPosture(ctx, opCfg, cfg.DataSovereigntyMode, excludedLLM)
 	return cfg, warnings
 }
 
@@ -415,10 +415,11 @@ func applyGatewayPostureLabels(providers []compliance.SovereigntyGatewayProvider
 	}
 }
 
-func buildLLMProviderRowsForPosture(ctx context.Context, mode string, excludedLLM map[string]bool) []compliance.SovereigntyLLMProvider {
+func buildLLMProviderRowsForPosture(ctx context.Context, opCfg *config.Config, mode string, excludedLLM map[string]bool) []compliance.SovereigntyLLMProvider {
 	if mode == "" {
 		mode = "global"
 	}
+	declaredRegions := sovereignty.DeclaredOperatorRegions(opCfg)
 	pol := &policy.Policy{VersionTag: "v1", Policies: policy.PoliciesConfig{}}
 	eng, err := policy.NewEngine(ctx, pol)
 	if err != nil {
@@ -428,10 +429,10 @@ func buildLLMProviderRowsForPosture(ctx context.Context, mode string, excludedLL
 	rows := make([]compliance.SovereigntyLLMProvider, 0, len(list))
 	for i := range list {
 		meta := list[i]
-		region := ""
-		if len(meta.EURegions) > 0 {
-			region = meta.EURegions[0]
-		}
+		// Use the operator-declared configured region when present. Never
+		// substitute metadata EURegions[0] for region-aware providers — that
+		// would misreport e.g. AWS_REGION=us-east-1 as an EU-routed Bedrock.
+		region := declaredRegions[meta.ID]
 		row := compliance.SovereigntyLLMProvider{ID: meta.ID}
 		dec, evalErr := eng.EvaluateRouting(ctx, &policy.RoutingInput{
 			SovereigntyMode:      mode,

--- a/internal/cmd/compliance_test.go
+++ b/internal/cmd/compliance_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -299,6 +300,77 @@ gateway:
 	// Gateway providers were loaded (no GatewayConfigError path).
 	gw := findSection(t, doc, "3. Gateway upstream providers")
 	require.NotNil(t, gw.Table)
+}
+
+func TestComplianceSovereignty_ExcludedDeclaredProvider(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	seedComplianceEvidence(t)
+
+	gwPath := filepath.Join(dir, "gw.mixed.yaml")
+	gwYAML := `sovereignty:
+  mode: eu_strict
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "shadow"
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      region: "US"
+      secret_name: "openai-api-key"
+    ollama:
+      enabled: true
+      base_url: "http://127.0.0.1:11434"
+      region: "LOCAL"
+      secret_name: "ollama-api-key"
+  callers:
+    - name: "local"
+      tenant_key: "k-local"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+`
+	require.NoError(t, os.WriteFile(gwPath, []byte(gwYAML), 0o600))
+
+	outPath := filepath.Join(dir, "sov.json")
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"compliance", "sovereignty",
+		"--format", "json",
+		"--gateway-config", gwPath,
+		"--from", "2020-01-01",
+		"--output", outPath,
+	})
+	t.Cleanup(func() {
+		rootCmd.SetErr(nil)
+		complianceFormat, complianceFrom, complianceGatewayConfig, complianceOutput = "html", "", "", ""
+	})
+
+	require.NoError(t, rootCmd.Execute())
+
+	raw, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	var doc compliance.Document
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	foundExcluded := false
+	for _, w := range doc.Warnings {
+		if strings.Contains(w, "excluded") && strings.Contains(w, "openai") {
+			foundExcluded = true
+		}
+	}
+	assert.True(t, foundExcluded, "warnings should mention excluded openai")
+
+	gwSection := findSection(t, doc, "3. Gateway upstream providers")
+	require.NotNil(t, gwSection.Table)
+	for _, row := range gwSection.Table.Rows {
+		if row[0] == "openai" {
+			assert.Equal(t, "excluded", row[3])
+		}
+	}
 }
 
 // TestComplianceSovereignty_ExplicitInvalidGatewayConfigFails verifies that an

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -27,6 +27,7 @@ import (
 	talonprompt "github.com/dativo-io/talon/internal/prompt"
 	"github.com/dativo-io/talon/internal/secrets"
 	talonsession "github.com/dativo-io/talon/internal/session"
+	"github.com/dativo-io/talon/internal/sovereignty"
 )
 
 var (
@@ -328,6 +329,8 @@ func runPlanExecute(cmd *cobra.Command, args []string) error {
 	cls := classifier.MustNewScanner()
 	attScanner := attachment.MustNewScanner()
 	extractor := attachment.NewExtractor(cfg.MaxAttachmentMB)
+
+	sovereignty.ApplySovereigntyGate(cfg, nil)
 
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, baseDir)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -140,9 +140,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	attScanner := attachment.MustNewScanner()
 	extractor := attachment.NewExtractor(cfg.MaxAttachmentMB)
 
-	if err := sovereignty.ValidateSovereignty(cfg, nil); err != nil {
-		return fmt.Errorf("sovereignty validation: %w", err)
-	}
+	sovereignty.ApplySovereigntyGate(cfg, nil)
 
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, baseDir)
@@ -321,9 +319,8 @@ func runAgent(cmd *cobra.Command, args []string) error {
 // so vault-only keys work. Use "talon secrets set openai-api-key <key>" etc.
 //
 // When the effective sovereignty mode is eu_strict, providers that are not
-// EU/LOCAL (and have no EU regions) are filtered out so the available set
-// reflects the declared sovereignty; explicitly keyed non-sovereign providers are
-// rejected earlier by sovereignty.ValidateSovereignty (fail closed).
+// EU/LOCAL (and have no EU regions) are filtered out; explicitly declared
+// non-sovereign providers are logged at ERROR by ApplySovereigntyGate.
 func buildProviders(cfg *config.Config) map[string]llm.Provider {
 	mode := cfg.EffectiveSovereigntyMode()
 	providers := make(map[string]llm.Provider)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -325,10 +325,11 @@ func buildProviders(cfg *config.Config) map[string]llm.Provider {
 	mode := cfg.EffectiveSovereigntyMode()
 	providers := make(map[string]llm.Provider)
 
-	register := func(providerType string, configYAML []byte) {
-		if !sovereignty.AllowsProvider(mode, providerType) {
+	registerRegion := func(providerType, region string, configYAML []byte) {
+		if !sovereignty.AllowsProviderRegion(mode, providerType, region) {
 			log.Debug().
 				Str("provider", providerType).
+				Str("region", region).
 				Str("sovereignty_mode", mode).
 				Msg("provider excluded by sovereignty mode")
 			return
@@ -336,6 +337,9 @@ func buildProviders(cfg *config.Config) map[string]llm.Provider {
 		if p, err := llm.NewProvider(providerType, configYAML); err == nil {
 			providers[providerType] = p
 		}
+	}
+	register := func(providerType string, configYAML []byte) {
+		registerRegion(providerType, "", configYAML)
 	}
 
 	openaiCfg := map[string]string{"api_key": os.Getenv("OPENAI_API_KEY")}
@@ -365,7 +369,7 @@ func buildProviders(cfg *config.Config) map[string]llm.Provider {
 	if region := os.Getenv("AWS_REGION"); region != "" {
 		bedrockCfg := map[string]string{"region": region}
 		bedrockYAML, _ := yaml.Marshal(bedrockCfg)
-		register("bedrock", bedrockYAML)
+		registerRegion("bedrock", region, bedrockYAML)
 	}
 
 	return providers

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -100,6 +100,20 @@ func TestBuildProviders_EUStrictFiltersNonSovereignProviders(t *testing.T) {
 	assert.Contains(t, providers, "bedrock")
 }
 
+func TestBuildProviders_EUStrictExcludesBedrockUSRegion(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	cfg := &config.Config{
+		OllamaBaseURL: "http://localhost:11434",
+		Sovereignty:   &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	providers := buildProviders(cfg)
+	assert.NotContains(t, providers, "bedrock", "us-east-1 Bedrock must be excluded under eu_strict")
+	assert.Contains(t, providers, "ollama")
+}
+
 func TestValidatePolicyFile_Valid(t *testing.T) {
 	dir := t.TempDir()
 	policyPath := testutil.WriteTestPolicyFile(t, dir, "valid-agent")

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -128,9 +128,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := sovereignty.ValidateSovereignty(cfg, nil); err != nil {
-		return fmt.Errorf("sovereignty validation: %w", err)
+	var preloadedGatewayCfg *gateway.GatewayConfig
+	if serveGateway {
+		preloadedGatewayCfg, err = gateway.LoadGatewayConfig(serveGatewayConfig)
+		if err != nil {
+			return fmt.Errorf("loading gateway config for sovereignty: %w", err)
+		}
 	}
+	sovereignty.ApplySovereigntyGate(cfg, preloadedGatewayCfg)
 
 	providers := buildProviders(cfg)
 	pricingTable := loadPricingTable(cfg, policyBaseDir)
@@ -366,13 +371,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var gatewayCfgForMode *gateway.GatewayConfig
 	tenantKeys := map[string]string{}
 	if serveGateway {
-		gatewayCfg, err := gateway.LoadGatewayConfig(serveGatewayConfig)
-		if err != nil {
-			return fmt.Errorf("loading gateway config: %w", err)
-		}
-		if err := sovereignty.ValidateSovereignty(cfg, gatewayCfg); err != nil {
-			return fmt.Errorf("sovereignty validation: %w", err)
-		}
+		gatewayCfg := preloadedGatewayCfg
 		if err := sovereignty.ValidateAirGap(cfg, gatewayCfg); err != nil {
 			return fmt.Errorf("air-gap validation: %w", err)
 		}
@@ -393,6 +392,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			log.Info().Msg("--gateway flag set; enabling gateway (config had enabled: false)")
 			gatewayCfg.Enabled = true
 		}
+		gatewayCfg.EffectiveSovereigntyMode = cfg.EffectiveSovereigntyMode()
 		{
 			gatewayPolicy, err := policy.NewGatewayEngine(ctx)
 			if err != nil {
@@ -427,6 +427,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if guard != nil {
 			quickstartCfg.UpstreamTransport = guard
 		}
+		quickstartCfg.EffectiveSovereigntyMode = cfg.EffectiveSovereigntyMode()
 		gatewayPolicy, err := policy.NewGatewayEngine(ctx)
 		if err != nil {
 			return fmt.Errorf("gateway policy engine: %w", err)

--- a/internal/compliance/sovereignty.go
+++ b/internal/compliance/sovereignty.go
@@ -33,6 +33,8 @@ type SovereigntyGatewayProvider struct {
 	Name    string
 	Region  string
 	Enabled bool
+	// Posture is allowed, excluded (declared under eu_strict), or disabled.
+	Posture string
 }
 
 // SovereigntyLLMProvider is one registry provider evaluated under the
@@ -41,6 +43,8 @@ type SovereigntyLLMProvider struct {
 	ID      string
 	Allowed bool
 	Reason  string
+	// Status is allowed, not_allowed, or excluded_declared.
+	Status string
 }
 
 // SovereigntyPostureOptions scopes the export and carries presentation inputs.
@@ -155,6 +159,16 @@ func sovereigntyWarnings(cfg SovereigntyPostureConfig, destinations []Destinatio
 			warnings = append(warnings, fmt.Sprintf("observed egress to non-EU region %q via %s (%s)", d.Region, d.Name, d.Kind))
 		}
 	}
+	for _, p := range cfg.LLMProviders {
+		if p.Status == "excluded_declared" {
+			warnings = append(warnings, fmt.Sprintf("declared provider %q excluded under %s", p.ID, cfg.DataSovereigntyMode))
+		}
+	}
+	for _, p := range cfg.GatewayProviders {
+		if p.Posture == "excluded" {
+			warnings = append(warnings, fmt.Sprintf("declared gateway provider %q excluded under %s", p.Name, cfg.DataSovereigntyMode))
+		}
+	}
 	if stats.egressDenials > 0 && cfg.DataSovereigntyMode != "eu_strict" {
 		warnings = append(warnings, "egress denials observed while data_sovereignty_mode is not eu_strict — align routing and egress policy")
 	}
@@ -181,17 +195,20 @@ func sovereigntyLLMProvidersSection(cfg SovereigntyPostureConfig) DocSection {
 	}
 	rows := make([][]string, 0, len(cfg.LLMProviders))
 	for _, p := range cfg.LLMProviders {
-		allowed := "no"
-		if p.Allowed {
-			allowed = "yes"
+		status := p.Status
+		if status == "" {
+			status = "not_allowed"
+			if p.Allowed {
+				status = "allowed"
+			}
 		}
-		rows = append(rows, []string{p.ID, allowed, p.Reason})
+		rows = append(rows, []string{p.ID, status, p.Reason})
 	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
 	return DocSection{
 		Heading: "2. LLM providers (registry evaluation)",
 		Body:    "Providers evaluated under the configured data_sovereignty_mode using routing.rego.",
-		Table:   &DocTable{Headers: []string{"Provider", "Allowed", "Reason"}, Rows: rows},
+		Table:   &DocTable{Headers: []string{"Provider", "Status", "Reason"}, Rows: rows},
 	}
 }
 
@@ -211,12 +228,19 @@ func sovereigntyGatewaySection(cfg SovereigntyPostureConfig) DocSection {
 	}
 	rows := make([][]string, 0, len(cfg.GatewayProviders))
 	for _, p := range cfg.GatewayProviders {
-		rows = append(rows, []string{p.Name, p.Region, boolLabel(p.Enabled)})
+		posture := p.Posture
+		if posture == "" {
+			posture = "allowed"
+			if !p.Enabled {
+				posture = "disabled"
+			}
+		}
+		rows = append(rows, []string{p.Name, p.Region, boolLabel(p.Enabled), posture})
 	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
 	return DocSection{
 		Heading: "3. Gateway upstream providers",
-		Table:   &DocTable{Headers: []string{"Provider", "Region", "Enabled"}, Rows: rows},
+		Table:   &DocTable{Headers: []string{"Provider", "Region", "Enabled", "Posture"}, Rows: rows},
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -550,11 +551,24 @@ func checkSovereignty(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckRes
 			Message: "no sovereignty restriction (mode unset or global)",
 		}
 	}
-	if err := sovereignty.ValidateSovereignty(cfg, gwCfg); err != nil {
+	eval := sovereignty.EvaluateSovereignty(cfg, gwCfg)
+	if mode == config.DataSovereigntyEUStrict && !eval.HasRoutableProvider {
 		return CheckResult{
 			Name: "sovereignty_providers", Category: "sovereignty", Status: "fail",
-			Message: err.Error(),
-			Fix:     "Use EU/LOCAL providers only, or relax sovereignty.mode",
+			Message: fmt.Sprintf("sovereignty mode %q but no EU/LOCAL provider is routable", mode),
+			Fix:     "Configure at least one EU or LOCAL gateway/LLM provider, or relax sovereignty.mode",
+		}
+	}
+	if len(eval.Excluded) > 0 {
+		names := make([]string, 0, len(eval.Excluded))
+		for _, ex := range eval.Excluded {
+			names = append(names, ex.Provider)
+		}
+		sort.Strings(names)
+		return CheckResult{
+			Name: "sovereignty_providers", Category: "sovereignty", Status: "warn",
+			Message: fmt.Sprintf("sovereignty mode %q: excluded declared provider(s): %s", mode, strings.Join(names, ", ")),
+			Fix:     "Remove non-EU providers or relax sovereignty.mode; compliant providers remain available",
 		}
 	}
 	return CheckResult{
@@ -606,7 +620,7 @@ func checkAirGap(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckResult {
 		return CheckResult{
 			Name: "air_gap_config", Category: "sovereignty", Status: "fail",
 			Message: err.Error(),
-			Fix:     "Use EU/LOCAL gateway providers only; set llm.routing.data_sovereignty_mode: eu_strict",
+			Fix:     "Set explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY before enabling air_gap mode",
 		}
 	}
 	return CheckResult{

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -552,11 +552,23 @@ func checkSovereignty(cfg *config.Config, gwCfg *gateway.GatewayConfig) CheckRes
 		}
 	}
 	eval := sovereignty.EvaluateSovereignty(cfg, gwCfg)
-	if mode == config.DataSovereigntyEUStrict && !eval.HasRoutableProvider {
-		return CheckResult{
-			Name: "sovereignty_providers", Category: "sovereignty", Status: "fail",
-			Message: fmt.Sprintf("sovereignty mode %q but no EU/LOCAL provider is routable", mode),
-			Fix:     "Configure at least one EU or LOCAL gateway/LLM provider, or relax sovereignty.mode",
+	if mode == config.DataSovereigntyEUStrict {
+		// Gateway and native routability are evaluated separately: a compliant
+		// native/LLM provider must not mask a gateway whose providers are all
+		// excluded, and vice versa.
+		if eval.GatewayEvaluated && !eval.HasCompliantGatewayProvider {
+			return CheckResult{
+				Name: "sovereignty_providers", Category: "sovereignty", Status: "fail",
+				Message: fmt.Sprintf("sovereignty mode %q but the gateway has no EU/LOCAL provider routable", mode),
+				Fix:     "Configure at least one enabled EU or LOCAL gateway provider, or relax sovereignty.mode",
+			}
+		}
+		if !eval.GatewayEvaluated && !eval.HasCompliantOperatorProvider {
+			return CheckResult{
+				Name: "sovereignty_providers", Category: "sovereignty", Status: "fail",
+				Message: fmt.Sprintf("sovereignty mode %q but no EU/LOCAL provider is routable", mode),
+				Fix:     "Configure at least one EU or LOCAL LLM provider, or relax sovereignty.mode",
+			}
 		}
 	}
 	if len(eval.Excluded) > 0 {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -243,6 +243,63 @@ gateway:
 	assert.Contains(t, sov.Message, "openai")
 }
 
+// TestDoctorGatewaySovereignty_NativeProviderDoesNotMaskGateway is the
+// regression for the "doctor mixes native and gateway routability" bug: a
+// gateway config whose providers are all excluded must fail even when an
+// unrelated compliant native provider (here Bedrock in an EU region) is
+// configured. Gateway routability is evaluated independently of native.
+func TestDoctorGatewaySovereignty_NativeProviderDoesNotMaskGateway(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	// A compliant native provider (Bedrock in an EU region) is configured.
+	t.Setenv("AWS_REGION", "eu-central-1")
+
+	viper.Set("sovereignty", map[string]interface{}{"mode": "eu_strict"})
+	t.Cleanup(func() {
+		viper.Reset()
+		viper.SetEnvPrefix("TALON")
+		viper.AutomaticEnv()
+		viper.SetDefault(config.KeyDefaultPolicy, config.DefaultPolicy)
+		viper.SetDefault(config.KeyMaxAttachmentMB, config.DefaultMaxAttachMB)
+		viper.SetDefault(config.KeyOllamaBaseURL, config.DefaultOllamaURL)
+	})
+
+	gwCfgPath := filepath.Join(dir, "talon.config.yaml")
+	gwYAML := `sovereignty:
+  mode: eu_strict
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "shadow"
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      region: "US"
+      secret_name: "openai-api-key"
+  callers:
+    - name: "test"
+      tenant_key: "test-key"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+    forbidden_tools: ["rm_rf"]
+`
+	require.NoError(t, os.WriteFile(gwCfgPath, []byte(gwYAML), 0o600))
+
+	gwCfg, err := gateway.LoadGatewayConfig(gwCfgPath)
+	require.NoError(t, err)
+
+	sov := checkSovereigntyFromGateway(gwCfg, gwCfgPath)
+	assert.Equal(t, "fail", sov.Status,
+		"gateway has no compliant provider; a compliant native provider must not mask it")
+	assert.Contains(t, sov.Message, "gateway")
+}
+
 // TestCheckLLMKeys_RecognizesLocalProviders guards the air-gap operator path:
 // an Ollama-only deployment declares a local provider in llm.providers and must
 // satisfy the LLM-provider check without any cloud key set.

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -182,12 +182,65 @@ gateway:
 	require.NoError(t, err)
 
 	res := checkAirGapFromGateway(gwCfg, gwCfgPath)
-	assert.Equal(t, "fail", res.Status,
-		"gateway air_gap + US upstream must fail even when operator carries a standard sovereignty block")
+	assert.Equal(t, "pass", res.Status,
+		"air_gap crypto keys are set; provider exclusions are non-fatal")
 
 	sov := checkSovereigntyFromGateway(gwCfg, gwCfgPath)
 	assert.Equal(t, "fail", sov.Status,
-		"sovereignty provider gate must fail for US gateway upstream under merged eu_strict")
+		"US-only gateway under eu_strict has no routable EU/LOCAL provider")
+}
+
+func TestDoctorGatewaySovereignty_MixedProvidersWarns(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+	t.Setenv("TALON_SIGNING_KEY", "my-signing-key-at-least-32-chars!")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	viper.Set("sovereignty", map[string]interface{}{"mode": "eu_strict"})
+	t.Cleanup(func() {
+		viper.Reset()
+		viper.SetEnvPrefix("TALON")
+		viper.AutomaticEnv()
+		viper.SetDefault(config.KeyDefaultPolicy, config.DefaultPolicy)
+		viper.SetDefault(config.KeyMaxAttachmentMB, config.DefaultMaxAttachMB)
+		viper.SetDefault(config.KeyOllamaBaseURL, config.DefaultOllamaURL)
+	})
+
+	gwCfgPath := filepath.Join(dir, "talon.config.yaml")
+	gwYAML := `sovereignty:
+  mode: eu_strict
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "shadow"
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      region: "US"
+      secret_name: "openai-api-key"
+    ollama:
+      enabled: true
+      base_url: "http://127.0.0.1:11434"
+      region: "LOCAL"
+      secret_name: "ollama-api-key"
+  callers:
+    - name: "test"
+      tenant_key: "test-key"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+    forbidden_tools: ["rm_rf"]
+`
+	require.NoError(t, os.WriteFile(gwCfgPath, []byte(gwYAML), 0o600))
+
+	gwCfg, err := gateway.LoadGatewayConfig(gwCfgPath)
+	require.NoError(t, err)
+
+	sov := checkSovereigntyFromGateway(gwCfg, gwCfgPath)
+	assert.Equal(t, "warn", sov.Status)
+	assert.Contains(t, sov.Message, "openai")
 }
 
 // TestCheckLLMKeys_RecognizesLocalProviders guards the air-gap operator path:

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -52,6 +52,8 @@ type GatewayConfig struct {
 	QuickstartUnsafeListen bool `yaml:"-" json:"-"`
 	// UpstreamTransport when set wraps the gateway upstream HTTP client (air-gap egress guard).
 	UpstreamTransport http.RoundTripper `yaml:"-" json:"-"`
+	// EffectiveSovereigntyMode is set at runtime by serve from operator config (not YAML).
+	EffectiveSovereigntyMode string `yaml:"-" json:"-"`
 }
 
 // ProviderConfig holds per-provider gateway settings.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -375,7 +375,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if g.denySovereigntyExcluded(w, ctx, caller, route, start, correlationID, extracted, classification, attSummary) {
+	if g.denySovereigntyExcluded(w, ctx, caller, route, start, correlationID, extracted, classification, attSummary, isShadow, &shadowViolations) {
 		return
 	}
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -375,6 +375,10 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if g.denySovereigntyExcluded(w, ctx, caller, route, start, correlationID, extracted, classification, attSummary) {
+		return
+	}
+
 	// Step 6: Evaluate policy
 	piiAction := g.config.ServerDefaults.DefaultPIIAction
 	if caller.PolicyOverrides != nil && caller.PolicyOverrides.PIIAction != "" {

--- a/internal/gateway/metrics.go
+++ b/internal/gateway/metrics.go
@@ -12,16 +12,17 @@ import (
 var gatewayMeter = otel.Meter("github.com/dativo-io/talon/internal/gateway")
 
 var (
-	gatewayRequestsCounter  metric.Int64Counter
-	gatewayErrorsCounter    metric.Int64Counter
-	dataTierCounter         metric.Int64Counter
-	toolGovernanceCounter   metric.Int64Counter
-	cacheHitsCounter        metric.Int64Counter
-	cacheMissesCounter      metric.Int64Counter
-	shadowViolationsCounter metric.Int64Counter
-	egressDecisionsCounter  metric.Int64Counter
-	budgetUtilizationGauge  metric.Float64Gauge
-	budgetAlertsCounter     metric.Int64Counter
+	gatewayRequestsCounter   metric.Int64Counter
+	gatewayErrorsCounter     metric.Int64Counter
+	dataTierCounter          metric.Int64Counter
+	toolGovernanceCounter    metric.Int64Counter
+	cacheHitsCounter         metric.Int64Counter
+	cacheMissesCounter       metric.Int64Counter
+	shadowViolationsCounter  metric.Int64Counter
+	egressDecisionsCounter   metric.Int64Counter
+	sovereigntyDeniedCounter metric.Int64Counter
+	budgetUtilizationGauge   metric.Float64Gauge
+	budgetAlertsCounter      metric.Int64Counter
 
 	gwMetricsOnce       sync.Once
 	gwMetricsRegistered bool
@@ -96,6 +97,13 @@ func initGatewayMetrics() {
 	budgetAlertsCounter, err = gatewayMeter.Int64Counter("talon.budget.alerts.total",
 		metric.WithDescription("Budget threshold breach alerts"),
 		metric.WithUnit("{alert}"))
+	if err != nil {
+		return
+	}
+
+	sovereigntyDeniedCounter, err = gatewayMeter.Int64Counter("talon.sovereignty.provider_denied_total",
+		metric.WithDescription("Gateway requests denied because provider is excluded under eu_strict"),
+		metric.WithUnit("{request}"))
 	if err != nil {
 		return
 	}
@@ -221,4 +229,13 @@ func RecordBudgetAlert(ctx context.Context, tenantID string, threshold float64) 
 		attribute.String("tenant_id", tenantID),
 		attribute.Float64("threshold", threshold),
 	))
+}
+
+// RecordSovereigntyProviderDenied increments the sovereignty runtime denial counter.
+func RecordSovereigntyProviderDenied(ctx context.Context, provider string) {
+	ensureGatewayMetrics()
+	if !gwMetricsRegistered {
+		return
+	}
+	sovereigntyDeniedCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("provider", provider)))
 }

--- a/internal/gateway/sovereignty.go
+++ b/internal/gateway/sovereignty.go
@@ -2,18 +2,23 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/rs/zerolog/log"
 )
 
 const sovereigntyDenyReason = "sovereignty: provider not EU/LOCAL"
 
 // denySovereigntyExcluded responds with 403 when the routed provider is excluded
-// under eu_strict (non-EU/LOCAL region). Returns true when the request was denied.
+// under eu_strict (non-EU/LOCAL region). In shadow mode it records a violation
+// and returns false so the request continues to upstream. Returns true when the
+// request was hard-denied (enforce mode only).
 func (g *Gateway) denySovereigntyExcluded(
 	w http.ResponseWriter,
 	ctx context.Context,
@@ -24,6 +29,8 @@ func (g *Gateway) denySovereigntyExcluded(
 	extracted ExtractedRequest,
 	classification *classifier.Classification,
 	attSummary *AttachmentsScanSummary,
+	isShadow bool,
+	shadowViolations *[]evidence.ShadowViolation,
 ) bool {
 	mode := g.config.EffectiveSovereigntyMode
 	if mode != config.DataSovereigntyEUStrict {
@@ -31,6 +38,17 @@ func (g *Gateway) denySovereigntyExcluded(
 	}
 	region := strings.ToUpper(strings.TrimSpace(g.providerRegion(route.Provider)))
 	if region == "EU" || region == "LOCAL" {
+		return false
+	}
+
+	if isShadow {
+		*shadowViolations = append(*shadowViolations, evidence.ShadowViolation{
+			Type:   "sovereignty_deny",
+			Detail: fmt.Sprintf("provider %s region %s blocked by sovereignty.mode=eu_strict", route.Provider, region),
+			Action: "block",
+		})
+		log.Warn().Str("caller", caller.Name).Str("provider", route.Provider).Str("region", region).Str("enforcement_mode", "shadow").Msg("shadow_sovereignty_deny")
+		RecordSovereigntyProviderDenied(ctx, route.Provider)
 		return false
 	}
 

--- a/internal/gateway/sovereignty.go
+++ b/internal/gateway/sovereignty.go
@@ -1,0 +1,49 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/config"
+)
+
+const sovereigntyDenyReason = "sovereignty: provider not EU/LOCAL"
+
+// denySovereigntyExcluded responds with 403 when the routed provider is excluded
+// under eu_strict (non-EU/LOCAL region). Returns true when the request was denied.
+func (g *Gateway) denySovereigntyExcluded(
+	w http.ResponseWriter,
+	ctx context.Context,
+	caller *CallerConfig,
+	route RouteResult,
+	start time.Time,
+	correlationID string,
+	extracted ExtractedRequest,
+	classification *classifier.Classification,
+	attSummary *AttachmentsScanSummary,
+) bool {
+	mode := g.config.EffectiveSovereigntyMode
+	if mode != config.DataSovereigntyEUStrict {
+		return false
+	}
+	region := strings.ToUpper(strings.TrimSpace(g.providerRegion(route.Provider)))
+	if region == "EU" || region == "LOCAL" {
+		return false
+	}
+
+	durationMS := time.Since(start).Milliseconds()
+	msg := "provider blocked by sovereignty.mode=eu_strict (non-EU/LOCAL region)"
+	WriteProviderError(w, route.Provider, http.StatusForbidden, msg)
+	RecordSovereigntyProviderDenied(ctx, route.Provider)
+	persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
+		classification, nil, 0, durationMS, "", false, []string{sovereigntyDenyReason}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
+	if err != nil {
+		g.handleEvidenceWriteFailure(ctx, err)
+		return true
+	}
+	g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, "", false, 0, 0, 0, persisted)
+	return true
+}

--- a/internal/gateway/sovereignty_deny_test.go
+++ b/internal/gateway/sovereignty_deny_test.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGateway_SovereigntyDeny_USProvider(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:                  true,
+		ListenPrefix:             "/v1/proxy",
+		Mode:                     ModeEnforce,
+		EffectiveSovereigntyMode: config.DataSovereigntyEUStrict,
+		Providers: map[string]ProviderConfig{
+			"openai": {
+				Enabled:    true,
+				BaseURL:    upstream.URL,
+				SecretName: "openai-api-key",
+				Region:     "US",
+			},
+		},
+		Callers: []CallerConfig{
+			{
+				Name:      "test",
+				TenantKey: "talon-gw-sov-deny",
+				TenantID:  "default",
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "openai-api-key",
+		[]byte("sk-test"), secrets.ACL{Tenants: []string{"default"}, Agents: []string{"*"}}))
+
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	w := makeGatewayRequestWithKey(gw, "/v1/proxy/openai/v1/chat/completions", body, "talon-gw-sov-deny")
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "sovereignty.mode=eu_strict")
+	assert.Equal(t, int64(0), upstreamCalls.Load())
+
+	records, err := evStore.List(context.Background(), "default", "", time.Time{}, time.Now(), 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	assert.False(t, records[0].PolicyDecision.Allowed)
+}
+
+func TestGateway_SovereigntyAllow_EUProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:                  true,
+		ListenPrefix:             "/v1/proxy",
+		Mode:                     ModeEnforce,
+		EffectiveSovereigntyMode: config.DataSovereigntyEUStrict,
+		Providers: map[string]ProviderConfig{
+			"ollama": {
+				Enabled:    true,
+				BaseURL:    upstream.URL,
+				SecretName: "ollama-api-key",
+				Region:     "LOCAL",
+			},
+		},
+		Callers: []CallerConfig{
+			{
+				Name:      "test",
+				TenantKey: "talon-gw-sov-allow",
+				TenantID:  "default",
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "ollama-api-key",
+		[]byte("local"), secrets.ACL{Tenants: []string{"default"}, Agents: []string{"*"}}))
+
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+
+	body := `{"model":"llama3.2:1b","messages":[{"role":"user","content":"hi"}]}`
+	w := makeGatewayRequestWithKey(gw, "/v1/proxy/ollama/v1/chat/completions", body, "talon-gw-sov-allow")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func makeGatewayRequestWithKey(gw *Gateway, path, body, tenantKey string) *httptest.ResponseRecorder {
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) {
+		r.Handle("/*", gw)
+	})
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://test"+path,
+		bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+tenantKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/internal/gateway/sovereignty_deny_test.go
+++ b/internal/gateway/sovereignty_deny_test.go
@@ -139,6 +139,79 @@ func TestGateway_SovereigntyAllow_EUProvider(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGateway_SovereigntyDeny_ShadowModeForwardsAndRecords(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:                  true,
+		ListenPrefix:             "/v1/proxy",
+		Mode:                     ModeShadow,
+		EffectiveSovereigntyMode: config.DataSovereigntyEUStrict,
+		Providers: map[string]ProviderConfig{
+			"openai": {
+				Enabled:    true,
+				BaseURL:    upstream.URL,
+				SecretName: "openai-api-key",
+				Region:     "US",
+			},
+		},
+		Callers: []CallerConfig{
+			{
+				Name:      "test",
+				TenantKey: "talon-gw-sov-shadow",
+				TenantID:  "default",
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "openai-api-key",
+		[]byte("sk-test"), secrets.ACL{Tenants: []string{"default"}, Agents: []string{"*"}}))
+
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+
+	body := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`
+	w := makeGatewayRequestWithKey(gw, "/v1/proxy/openai/v1/chat/completions", body, "talon-gw-sov-shadow")
+
+	assert.Equal(t, http.StatusOK, w.Code, "shadow mode should forward sovereignty-denied requests")
+	assert.Equal(t, int64(1), upstreamCalls.Load(), "shadow mode must reach upstream")
+
+	records, err := evStore.List(context.Background(), "default", "", time.Time{}, time.Now(), 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+
+	ev := records[0]
+	assert.True(t, ev.ObservationModeOverride, "shadow violation should flag observation mode override")
+	hasSovereigntyViolation := false
+	for _, sv := range ev.ShadowViolations {
+		if sv.Type == "sovereignty_deny" {
+			hasSovereigntyViolation = true
+		}
+	}
+	assert.True(t, hasSovereigntyViolation, "should record sovereignty_deny shadow violation, got %+v", ev.ShadowViolations)
+}
+
 func makeGatewayRequestWithKey(gw *Gateway, path, body, tenantKey string) *httptest.ResponseRecorder {
 	r := chi.NewRouter()
 	r.Route("/v1/proxy", func(r chi.Router) {

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -93,6 +94,44 @@ func JurisdictionForProvider(providerType string) string {
 		return ""
 	}
 	return meta.Jurisdiction
+}
+
+// RegionAwareProvider reports whether the provider type has a region dimension
+// that affects data residency (e.g. Bedrock, Azure OpenAI, Vertex). For these
+// providers the configured region — not just the jurisdiction — determines
+// whether traffic stays in the EU.
+func RegionAwareProvider(providerType string) bool {
+	meta, ok := ProviderMetadataByType(providerType)
+	if !ok {
+		return false
+	}
+	return meta.Wizard.RequiresRegion || len(meta.EURegions) > 0
+}
+
+// IsEURegion reports whether the given configured region for a provider type is
+// an EU region. It consults the provider's declared EURegions first, then the
+// wizard AvailableRegions IsEU flags. Returns false for unknown providers,
+// empty regions, or regions not declared as EU (fail closed).
+func IsEURegion(providerType, region string) bool {
+	meta, ok := ProviderMetadataByType(providerType)
+	if !ok {
+		return false
+	}
+	r := strings.TrimSpace(region)
+	if r == "" {
+		return false
+	}
+	for _, er := range meta.EURegions {
+		if strings.EqualFold(er, r) {
+			return true
+		}
+	}
+	for _, ar := range meta.Wizard.AvailableRegions {
+		if strings.EqualFold(ar.ID, r) {
+			return ar.IsEU
+		}
+	}
+	return false
 }
 
 // ProviderMetadataByType returns the static metadata for a registered provider

--- a/internal/sovereignty/metrics.go
+++ b/internal/sovereignty/metrics.go
@@ -1,0 +1,45 @@
+package sovereignty
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var sovereigntyMeter = otel.Meter("github.com/dativo-io/talon/internal/sovereignty")
+
+var (
+	providerExcludedCounter metric.Int64Counter
+
+	sovMetricsOnce       sync.Once
+	sovMetricsRegistered bool
+)
+
+func initSovereigntyMetrics() {
+	var err error
+
+	providerExcludedCounter, err = sovereigntyMeter.Int64Counter("talon.sovereignty.provider_excluded_total",
+		metric.WithDescription("Declared providers excluded at startup under eu_strict"),
+		metric.WithUnit("{provider}"))
+	if err != nil {
+		return
+	}
+
+	sovMetricsRegistered = true
+}
+
+// RecordProviderExcluded increments the startup exclusion counter.
+func RecordProviderExcluded(ctx context.Context, provider, scope string) {
+	sovMetricsOnce.Do(initSovereigntyMetrics)
+	if !sovMetricsRegistered {
+		return
+	}
+	providerExcludedCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("provider", provider),
+			attribute.String("scope", scope),
+		))
+}

--- a/internal/sovereignty/preset_test.go
+++ b/internal/sovereignty/preset_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -109,7 +110,37 @@ func TestApplyAirGapPreset_EmptyEgressStillAppliesPreset(t *testing.T) {
 	assert.NotEmpty(t, gw.ServerDefaults.Egress.Rules)
 }
 
-func TestValidateAirGap_RejectsUSProvider(t *testing.T) {
+func TestValidateAirGap_RejectsDefaultCryptoKeys(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SECRETS_KEY", "")
+	t.Setenv("TALON_SIGNING_KEY", "")
+
+	viper.Set("sovereignty", map[string]interface{}{"deployment_mode": ModeAirGap})
+	t.Cleanup(func() {
+		viper.Reset()
+		viper.SetEnvPrefix("TALON")
+		viper.AutomaticEnv()
+		viper.SetDefault(config.KeyDefaultPolicy, config.DefaultPolicy)
+		viper.SetDefault(config.KeyMaxAttachmentMB, config.DefaultMaxAttachMB)
+		viper.SetDefault(config.KeyOllamaBaseURL, config.DefaultOllamaURL)
+	})
+
+	op, err := config.Load()
+	require.NoError(t, err)
+	require.True(t, op.UsingDefaultKeys())
+
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+		},
+	}
+	err = ValidateAirGap(op, gw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TALON_SECRETS_KEY")
+}
+
+func TestValidateAirGap_USProviderIsNonFatal(t *testing.T) {
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{DeploymentMode: ModeAirGap},
 		SecretsKey:  testutil.TestEncryptionKey,
@@ -120,9 +151,10 @@ func TestValidateAirGap_RejectsUSProvider(t *testing.T) {
 			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
 		},
 	}
-	err := ValidateAirGap(op, gw)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "openai")
+	require.NoError(t, ValidateAirGap(op, gw))
+	eval := EvaluateSovereignty(op, gw)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
 }
 
 func TestBuildAllowlist_IncludesOllamaAndProviders(t *testing.T) {

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -305,3 +305,29 @@ func IsGatewayProviderExcluded(eval Evaluation, provider string) bool {
 	}
 	return false
 }
+
+// DeclaredOperatorRegions returns configured regions for operator-declared
+// providers (env keys and llm.providers). Used by compliance reporting so
+// region-aware providers are evaluated against their actual configured region,
+// not a metadata default EU region.
+func DeclaredOperatorRegions(op *config.Config) map[string]string {
+	regions := make(map[string]string)
+	if region := strings.TrimSpace(os.Getenv("AWS_REGION")); region != "" {
+		regions["bedrock"] = region
+	}
+	if op != nil && op.LLM != nil {
+		for id, p := range op.LLM.Providers {
+			if !p.Enabled {
+				continue
+			}
+			providerType := p.Type
+			if providerType == "" {
+				providerType = id
+			}
+			if r := providerRegionFromConfig(p); r != "" {
+				regions[providerType] = r
+			}
+		}
+	}
+	return regions
+}

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -35,7 +35,21 @@ type Exclusion struct {
 type Evaluation struct {
 	Excluded                  []Exclusion
 	CompliantGatewayProviders []string
-	HasRoutableProvider       bool
+
+	// GatewayEvaluated is true when a non-nil gateway config was evaluated
+	// (the doctor/serve gateway path). When false, this is a native run/plan
+	// path that routes to operator/native providers only.
+	GatewayEvaluated bool
+	// HasCompliantGatewayProvider is true when at least one enabled gateway
+	// provider satisfies the sovereignty mode (EU/LOCAL region).
+	HasCompliantGatewayProvider bool
+	// HasCompliantOperatorProvider is true when at least one operator/native
+	// provider (env keys, llm.providers, implicit local ollama) is routable.
+	HasCompliantOperatorProvider bool
+	// HasRoutableProvider is the union of gateway and operator routability.
+	// Callers that need gateway-only routability (e.g. talon doctor with
+	// --gateway-config) must use HasCompliantGatewayProvider instead.
+	HasRoutableProvider bool
 }
 
 // operatorKeyedProviders maps an operator-level env var to the provider type it
@@ -50,23 +64,52 @@ var operatorKeyedProviders = []struct {
 }
 
 // AllowsProvider reports whether a provider type is permitted under the given
-// data-sovereignty mode. Only eu_strict imposes a hard gate: a provider is
-// allowed when its jurisdiction is EU or LOCAL, or it exposes at least one EU
-// region (e.g. Bedrock eu-central-1, Azure westeurope). eu_preferred and global
-// allow all providers (routing applies preference). Unknown provider types are
-// rejected under eu_strict (fail closed).
+// data-sovereignty mode without a configured region. It is a convenience
+// wrapper over AllowsProviderRegion with an empty region. For region-aware
+// providers (Bedrock, Azure OpenAI, Vertex) callers SHOULD use
+// AllowsProviderRegion with the configured region; with an empty region this
+// only trusts EU-jurisdiction providers (fail closed for US-based providers
+// that merely *offer* EU regions).
 func AllowsProvider(mode, providerType string) bool {
-	switch mode {
-	case config.DataSovereigntyEUStrict:
-		meta, ok := llm.ProviderMetadataByType(providerType)
-		if !ok {
-			return false
-		}
-		j := strings.ToUpper(strings.TrimSpace(meta.Jurisdiction))
-		return j == "EU" || j == "LOCAL" || len(meta.EURegions) > 0
-	default:
+	return AllowsProviderRegion(mode, providerType, "")
+}
+
+// AllowsProviderRegion reports whether a provider type with a specific
+// configured region is permitted under the given data-sovereignty mode. Only
+// eu_strict imposes a hard gate:
+//
+//   - LOCAL jurisdiction providers (e.g. ollama) are always allowed.
+//   - Region-aware providers (Bedrock, Azure OpenAI, Vertex — those that
+//     require/accept a region) are allowed only when the *configured* region is
+//     an EU region. When no region is configured, only EU-jurisdiction
+//     providers are trusted; US-based providers that merely offer EU regions
+//     (e.g. Bedrock) are excluded (fail closed).
+//   - All other providers are allowed only when their jurisdiction is EU.
+//
+// eu_preferred and global allow all providers (routing applies preference).
+// Unknown provider types are rejected under eu_strict (fail closed).
+func AllowsProviderRegion(mode, providerType, region string) bool {
+	if mode != config.DataSovereigntyEUStrict {
 		return true
 	}
+	meta, ok := llm.ProviderMetadataByType(providerType)
+	if !ok {
+		return false
+	}
+	j := strings.ToUpper(strings.TrimSpace(meta.Jurisdiction))
+	if j == "LOCAL" {
+		return true
+	}
+	if llm.RegionAwareProvider(providerType) {
+		r := strings.TrimSpace(region)
+		if r == "" {
+			// Cannot affirm EU residency without a region; trust only
+			// providers whose base jurisdiction is EU.
+			return j == "EU"
+		}
+		return llm.IsEURegion(providerType, r)
+	}
+	return j == "EU"
 }
 
 // EvaluateSovereignty classifies declared providers as compliant or excluded
@@ -74,26 +117,34 @@ func AllowsProvider(mode, providerType string) bool {
 // providers are excluded (non-fatal); eu_preferred and global impose no gate.
 func EvaluateSovereignty(op *config.Config, gw *gateway.GatewayConfig) Evaluation {
 	if op == nil {
-		return Evaluation{HasRoutableProvider: true}
+		return Evaluation{HasRoutableProvider: true, HasCompliantOperatorProvider: true}
 	}
 	mode := op.EffectiveSovereigntyMode()
 	if mode != config.DataSovereigntyEUStrict {
-		return Evaluation{HasRoutableProvider: true}
+		return Evaluation{
+			GatewayEvaluated:             gw != nil,
+			HasRoutableProvider:          true,
+			HasCompliantOperatorProvider: true,
+			HasCompliantGatewayProvider:  gw != nil,
+		}
 	}
 
-	eval := Evaluation{}
+	eval := Evaluation{GatewayEvaluated: gw != nil}
 	evalExcluded, compliantOperator := evaluateOperatorProviders(op, mode)
 	eval.Excluded = append(eval.Excluded, evalExcluded...)
 
 	gwExcluded, compliantGW := evaluateGatewayProviders(gw, mode)
 	eval.Excluded = append(eval.Excluded, gwExcluded...)
 	eval.CompliantGatewayProviders = compliantGW
+	eval.HasCompliantGatewayProvider = len(compliantGW) > 0
 
-	eval.HasRoutableProvider = len(compliantGW) > 0 || compliantOperator
-	if gw == nil && !eval.HasRoutableProvider {
+	eval.HasCompliantOperatorProvider = compliantOperator
+	if gw == nil {
 		// Native run/plan always registers ollama (LOCAL) via buildProviders.
-		eval.HasRoutableProvider = true
+		eval.HasCompliantOperatorProvider = true
 	}
+
+	eval.HasRoutableProvider = eval.HasCompliantGatewayProvider || eval.HasCompliantOperatorProvider
 	return eval
 }
 
@@ -123,7 +174,7 @@ func evaluateOperatorProviders(op *config.Config, mode string) (excluded []Exclu
 		if os.Getenv(kp.env) == "" {
 			continue
 		}
-		if AllowsProvider(mode, kp.provider) {
+		if AllowsProviderRegion(mode, kp.provider, "") {
 			hasCompliant = true
 			continue
 		}
@@ -135,8 +186,27 @@ func evaluateOperatorProviders(op *config.Config, mode string) (excluded []Exclu
 				kp.env, kp.provider, llm.JurisdictionForProvider(kp.provider)),
 		})
 	}
+
+	// AWS_REGION implicitly registers Bedrock (see buildProviders). Bedrock is a
+	// US-jurisdiction, region-aware provider, so its sovereignty status depends
+	// on the *configured* AWS_REGION, not merely on metadata EU-region support.
+	if region := strings.TrimSpace(os.Getenv("AWS_REGION")); region != "" {
+		if AllowsProviderRegion(mode, "bedrock", region) {
+			hasCompliant = true
+		} else {
+			excluded = append(excluded, Exclusion{
+				Provider: "bedrock",
+				Scope:    ExclusionScopeEnv,
+				Reason: fmt.Sprintf(
+					"AWS_REGION=%s selects a non-EU Bedrock region; not permitted under %s",
+					region, mode),
+			})
+		}
+	}
+
 	if op.LLM != nil {
-		for id, p := range op.LLM.Providers {
+		for id := range op.LLM.Providers {
+			p := op.LLM.Providers[id]
 			if !p.Enabled {
 				continue
 			}
@@ -144,20 +214,52 @@ func evaluateOperatorProviders(op *config.Config, mode string) (excluded []Exclu
 			if providerType == "" {
 				providerType = id
 			}
-			if AllowsProvider(mode, providerType) {
+			region := providerRegionFromConfig(p)
+			if AllowsProviderRegion(mode, providerType, region) {
 				hasCompliant = true
 				continue
 			}
 			excluded = append(excluded, Exclusion{
 				Provider: providerType,
 				Scope:    ExclusionScopeLLMProviders,
-				Reason: fmt.Sprintf(
-					"llm.providers includes %q (type %q, %s jurisdiction) which is not EU/LOCAL",
-					id, providerType, llm.JurisdictionForProvider(providerType)),
+				Reason:   operatorExclusionReason(id, providerType, region, mode),
 			})
 		}
 	}
 	return excluded, hasCompliant
+}
+
+// providerRegionFromConfig extracts a configured region from an llm.providers
+// entry, if present. Returns "" when no region is configured.
+func providerRegionFromConfig(p config.LLMProviderConfig) string {
+	if p.Config == nil {
+		return ""
+	}
+	if v, ok := p.Config["region"]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// operatorExclusionReason builds a human-readable exclusion reason for an
+// llm.providers entry, distinguishing region-aware providers from
+// jurisdiction-only ones.
+func operatorExclusionReason(id, providerType, region, mode string) string {
+	if llm.RegionAwareProvider(providerType) {
+		if region == "" {
+			return fmt.Sprintf(
+				"llm.providers includes %q (type %q) with no EU region configured; not permitted under %s",
+				id, providerType, mode)
+		}
+		return fmt.Sprintf(
+			"llm.providers includes %q (type %q, region %q) which is not an EU region; not permitted under %s",
+			id, providerType, region, mode)
+	}
+	return fmt.Sprintf(
+		"llm.providers includes %q (type %q, %s jurisdiction) which is not EU/LOCAL",
+		id, providerType, llm.JurisdictionForProvider(providerType))
 }
 
 func evaluateGatewayProviders(gw *gateway.GatewayConfig, mode string) (excluded []Exclusion, compliant []string) {

--- a/internal/sovereignty/providers.go
+++ b/internal/sovereignty/providers.go
@@ -1,18 +1,46 @@
 package sovereignty
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/gateway"
 	"github.com/dativo-io/talon/internal/llm"
 )
 
+// ExclusionScope identifies where a declared provider was configured.
+type ExclusionScope string
+
+const (
+	ExclusionScopeEnv          ExclusionScope = "env"
+	ExclusionScopeLLMProviders ExclusionScope = "llm.providers"
+	ExclusionScopeGateway      ExclusionScope = "gateway"
+)
+
+// Exclusion describes a provider explicitly declared by the operator that is
+// excluded from routing under the effective sovereignty mode.
+type Exclusion struct {
+	Provider string
+	Scope    ExclusionScope
+	Reason   string
+}
+
+// Evaluation is the result of evaluating declared providers against the
+// effective data-sovereignty mode.
+type Evaluation struct {
+	Excluded                  []Exclusion
+	CompliantGatewayProviders []string
+	HasRoutableProvider       bool
+}
+
 // operatorKeyedProviders maps an operator-level env var to the provider type it
 // configures. When the env var is set the operator has explicitly declared that
-// provider, so it must satisfy the sovereignty gate (fail closed).
+// provider.
 var operatorKeyedProviders = []struct {
 	env      string
 	provider string
@@ -41,38 +69,71 @@ func AllowsProvider(mode, providerType string) bool {
 	}
 }
 
-// ValidateSovereignty enforces the effective data-sovereignty mode against every
-// declared provider (fail closed). For eu_strict, operator-keyed providers,
-// llm.providers entries, and enabled gateway providers must all be EU/LOCAL (or
-// EU-region capable). eu_preferred and global impose no hard provider gate.
-// air_gap implies eu_strict via config resolution, so this also covers air-gap.
-func ValidateSovereignty(op *config.Config, gw *gateway.GatewayConfig) error {
+// EvaluateSovereignty classifies declared providers as compliant or excluded
+// under the effective sovereignty mode. Under eu_strict, non-EU/LOCAL declared
+// providers are excluded (non-fatal); eu_preferred and global impose no gate.
+func EvaluateSovereignty(op *config.Config, gw *gateway.GatewayConfig) Evaluation {
 	if op == nil {
-		return nil
+		return Evaluation{HasRoutableProvider: true}
 	}
 	mode := op.EffectiveSovereigntyMode()
 	if mode != config.DataSovereigntyEUStrict {
-		return nil
+		return Evaluation{HasRoutableProvider: true}
 	}
-	if err := validateOperatorProviders(op, mode); err != nil {
-		return err
+
+	eval := Evaluation{}
+	evalExcluded, compliantOperator := evaluateOperatorProviders(op, mode)
+	eval.Excluded = append(eval.Excluded, evalExcluded...)
+
+	gwExcluded, compliantGW := evaluateGatewayProviders(gw, mode)
+	eval.Excluded = append(eval.Excluded, gwExcluded...)
+	eval.CompliantGatewayProviders = compliantGW
+
+	eval.HasRoutableProvider = len(compliantGW) > 0 || compliantOperator
+	if gw == nil && !eval.HasRoutableProvider {
+		// Native run/plan always registers ollama (LOCAL) via buildProviders.
+		eval.HasRoutableProvider = true
 	}
-	return validateGatewayProviders(gw, mode)
+	return eval
 }
 
-// validateOperatorProviders fails closed when an operator has explicitly
-// configured a provider (via env key or the llm.providers block) that is not
-// permitted under the sovereignty mode.
-func validateOperatorProviders(op *config.Config, mode string) error {
+// LogSovereigntyExclusions emits ERROR logs and metrics for each declared
+// provider excluded under eu_strict.
+func LogSovereigntyExclusions(excluded []Exclusion) {
+	for _, ex := range excluded {
+		log.Error().
+			Str("provider", ex.Provider).
+			Str("scope", string(ex.Scope)).
+			Str("reason", ex.Reason).
+			Msg("provider excluded by sovereignty mode")
+		RecordProviderExcluded(context.Background(), ex.Provider, string(ex.Scope))
+	}
+}
+
+// ApplySovereigntyGate evaluates exclusions and logs them. Call before
+// buildProviders in serve, run, and plan.
+func ApplySovereigntyGate(op *config.Config, gw *gateway.GatewayConfig) Evaluation {
+	eval := EvaluateSovereignty(op, gw)
+	LogSovereigntyExclusions(eval.Excluded)
+	return eval
+}
+
+func evaluateOperatorProviders(op *config.Config, mode string) (excluded []Exclusion, hasCompliant bool) {
 	for _, kp := range operatorKeyedProviders {
 		if os.Getenv(kp.env) == "" {
 			continue
 		}
-		if !AllowsProvider(mode, kp.provider) {
-			return fmt.Errorf(
-				"sovereignty mode %s: %s is set but provider %q (%s jurisdiction) is not EU/LOCAL — remove the key or relax sovereignty.mode",
-				mode, kp.env, kp.provider, llm.JurisdictionForProvider(kp.provider))
+		if AllowsProvider(mode, kp.provider) {
+			hasCompliant = true
+			continue
 		}
+		excluded = append(excluded, Exclusion{
+			Provider: kp.provider,
+			Scope:    ExclusionScopeEnv,
+			Reason: fmt.Sprintf(
+				"%s is set but provider %q (%s jurisdiction) is not EU/LOCAL",
+				kp.env, kp.provider, llm.JurisdictionForProvider(kp.provider)),
+		})
 	}
 	if op.LLM != nil {
 		for id, p := range op.LLM.Providers {
@@ -83,21 +144,25 @@ func validateOperatorProviders(op *config.Config, mode string) error {
 			if providerType == "" {
 				providerType = id
 			}
-			if !AllowsProvider(mode, providerType) {
-				return fmt.Errorf(
-					"sovereignty mode %s: llm.providers includes %q (type %q, %s jurisdiction) which is not EU/LOCAL",
-					mode, id, providerType, llm.JurisdictionForProvider(providerType))
+			if AllowsProvider(mode, providerType) {
+				hasCompliant = true
+				continue
 			}
+			excluded = append(excluded, Exclusion{
+				Provider: providerType,
+				Scope:    ExclusionScopeLLMProviders,
+				Reason: fmt.Sprintf(
+					"llm.providers includes %q (type %q, %s jurisdiction) which is not EU/LOCAL",
+					id, providerType, llm.JurisdictionForProvider(providerType)),
+			})
 		}
 	}
-	return nil
+	return excluded, hasCompliant
 }
 
-// validateGatewayProviders fails closed when an enabled gateway upstream is
-// declared in a region that is not permitted under the sovereignty mode.
-func validateGatewayProviders(gw *gateway.GatewayConfig, mode string) error {
+func evaluateGatewayProviders(gw *gateway.GatewayConfig, mode string) (excluded []Exclusion, compliant []string) {
 	if gw == nil {
-		return nil
+		return nil, nil
 	}
 	for name := range gw.Providers {
 		p := gw.Providers[name]
@@ -106,11 +171,35 @@ func validateGatewayProviders(gw *gateway.GatewayConfig, mode string) error {
 		}
 		region := strings.ToUpper(strings.TrimSpace(p.Region))
 		if region == "" {
-			return fmt.Errorf("sovereignty mode %s: gateway provider %q region must be set (EU or LOCAL)", mode, name)
+			excluded = append(excluded, Exclusion{
+				Provider: name,
+				Scope:    ExclusionScopeGateway,
+				Reason:   fmt.Sprintf("gateway provider %q region must be set (EU or LOCAL)", name),
+			})
+			continue
 		}
 		if region != "EU" && region != "LOCAL" {
-			return fmt.Errorf("sovereignty mode %s: gateway provider %q region %q is not permitted (use EU or LOCAL)", mode, name, region)
+			excluded = append(excluded, Exclusion{
+				Provider: name,
+				Scope:    ExclusionScopeGateway,
+				Reason: fmt.Sprintf(
+					"gateway provider %q region %q is not permitted under %s (use EU or LOCAL)",
+					name, region, mode),
+			})
+			continue
+		}
+		compliant = append(compliant, name)
+	}
+	return excluded, compliant
+}
+
+// IsGatewayProviderExcluded reports whether a gateway provider name was
+// excluded during sovereignty evaluation (eu_strict, non-EU/LOCAL region).
+func IsGatewayProviderExcluded(eval Evaluation, provider string) bool {
+	for _, ex := range eval.Excluded {
+		if ex.Scope == ExclusionScopeGateway && ex.Provider == provider {
+			return true
 		}
 	}
-	return nil
+	return false
 }

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -35,7 +35,7 @@ func TestAllowsProvider(t *testing.T) {
 	}
 }
 
-func TestValidateSovereignty_EUStrictRejectsGatewayUSProvider(t *testing.T) {
+func TestEvaluateSovereignty_EUStrictExcludesGatewayUSProvider(t *testing.T) {
 	clearProviderKeys(t)
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
@@ -45,13 +45,14 @@ func TestValidateSovereignty_EUStrictRejectsGatewayUSProvider(t *testing.T) {
 			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
 		},
 	}
-	err := ValidateSovereignty(op, gw)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "openai")
-	assert.Contains(t, err.Error(), "eu_strict")
+	eval := EvaluateSovereignty(op, gw)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
+	assert.Equal(t, ExclusionScopeGateway, eval.Excluded[0].Scope)
+	assert.False(t, eval.HasRoutableProvider)
 }
 
-func TestValidateSovereignty_EUStrictAllowsEUAndLocal(t *testing.T) {
+func TestEvaluateSovereignty_EUStrictAllowsEUAndLocal(t *testing.T) {
 	clearProviderKeys(t)
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
@@ -60,24 +61,46 @@ func TestValidateSovereignty_EUStrictAllowsEUAndLocal(t *testing.T) {
 		Providers: map[string]gateway.ProviderConfig{
 			"mistral":  {Enabled: true, BaseURL: "https://api.mistral.ai", Region: "EU"},
 			"ollama":   {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
-			"disabled": {Enabled: false, BaseURL: "https://api.openai.com", Region: "US"}, // ignored: not enabled
+			"disabled": {Enabled: false, BaseURL: "https://api.openai.com", Region: "US"},
 		},
 	}
-	require.NoError(t, ValidateSovereignty(op, gw))
+	eval := EvaluateSovereignty(op, gw)
+	assert.Empty(t, eval.Excluded)
+	assert.True(t, eval.HasRoutableProvider)
+	assert.ElementsMatch(t, []string{"mistral", "ollama"}, eval.CompliantGatewayProviders)
 }
 
-func TestValidateSovereignty_EUStrictRejectsKeyedOpenAI(t *testing.T) {
+func TestEvaluateSovereignty_EUStrictMixedProviders(t *testing.T) {
+	clearProviderKeys(t)
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+	gw := &gateway.GatewayConfig{
+		Providers: map[string]gateway.ProviderConfig{
+			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
+			"ollama": {Enabled: true, BaseURL: "http://127.0.0.1:11434", Region: "LOCAL"},
+		},
+	}
+	eval := EvaluateSovereignty(op, gw)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
+	assert.True(t, eval.HasRoutableProvider)
+}
+
+func TestEvaluateSovereignty_EUStrictExcludesKeyedOpenAI(t *testing.T) {
 	clearProviderKeys(t)
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
 	}
-	err := ValidateSovereignty(op, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
+	eval := EvaluateSovereignty(op, nil)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
+	assert.Equal(t, ExclusionScopeEnv, eval.Excluded[0].Scope)
+	assert.True(t, eval.HasRoutableProvider, "native run still has implicit ollama")
 }
 
-func TestValidateSovereignty_EUStrictRejectsLLMProvidersBlock(t *testing.T) {
+func TestEvaluateSovereignty_EUStrictExcludesLLMProvidersBlock(t *testing.T) {
 	clearProviderKeys(t)
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
@@ -85,12 +108,12 @@ func TestValidateSovereignty_EUStrictRejectsLLMProvidersBlock(t *testing.T) {
 			Providers: map[string]config.LLMProviderConfig{"openai": {Enabled: true}},
 		},
 	}
-	err := ValidateSovereignty(op, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "llm.providers")
+	eval := EvaluateSovereignty(op, nil)
+	require.Len(t, eval.Excluded, 1)
+	assert.Contains(t, eval.Excluded[0].Reason, "llm.providers")
 }
 
-func TestValidateSovereignty_GlobalAllowsAll(t *testing.T) {
+func TestEvaluateSovereignty_GlobalAllowsAll(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyGlobal},
@@ -100,23 +123,32 @@ func TestValidateSovereignty_GlobalAllowsAll(t *testing.T) {
 			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
 		},
 	}
-	require.NoError(t, ValidateSovereignty(op, gw))
+	eval := EvaluateSovereignty(op, gw)
+	assert.Empty(t, eval.Excluded)
+	assert.True(t, eval.HasRoutableProvider)
 }
 
-func TestValidateSovereignty_NoSovereigntyBlockIsNoop(t *testing.T) {
+func TestEvaluateSovereignty_NoSovereigntyBlockIsNoop(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 	op := &config.Config{}
-	require.NoError(t, ValidateSovereignty(op, nil))
+	eval := EvaluateSovereignty(op, nil)
+	assert.Empty(t, eval.Excluded)
+	assert.True(t, eval.HasRoutableProvider)
 }
 
-// TestValidateOperatorProviders_UsesProviderTypeNotAlias is the regression for
+func clearProviderKeys(t *testing.T) {
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+}
+
+// TestEvaluateOperatorProviders_UsesProviderTypeNotAlias is the regression for
 // the "provider gate uses map key" bug: the gate must classify llm.providers
 // entries by their Type field, not by the (operator-chosen) map alias.
-func TestValidateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
+func TestEvaluateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
 	clearProviderKeys(t)
 
-	// Alias looks EU-friendly but the real type is openai (US) → must be rejected.
-	t.Run("rejects by type not alias", func(t *testing.T) {
+	t.Run("excludes by type not alias", func(t *testing.T) {
 		op := &config.Config{
 			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
 			LLM: &config.LLMConfig{
@@ -125,12 +157,12 @@ func TestValidateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
 				},
 			},
 		}
-		err := validateOperatorProviders(op, config.DataSovereigntyEUStrict)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "openai")
+		excluded, compliant := evaluateOperatorProviders(op, config.DataSovereigntyEUStrict)
+		require.Len(t, excluded, 1)
+		assert.Equal(t, "openai", excluded[0].Provider)
+		assert.False(t, compliant)
 	})
 
-	// Alias looks like a US provider but the real type is mistral (EU) → allowed.
 	t.Run("allows by type not alias", func(t *testing.T) {
 		op := &config.Config{
 			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
@@ -140,14 +172,8 @@ func TestValidateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, validateOperatorProviders(op, config.DataSovereigntyEUStrict))
+		excluded, compliant := evaluateOperatorProviders(op, config.DataSovereigntyEUStrict)
+		assert.Empty(t, excluded)
+		assert.True(t, compliant)
 	})
-}
-
-// clearProviderKeys ensures operator-keyed provider env vars are unset so the
-// fail-closed gate is exercised deterministically regardless of the dev shell.
-func clearProviderKeys(t *testing.T) {
-	t.Helper()
-	t.Setenv("OPENAI_API_KEY", "")
-	t.Setenv("ANTHROPIC_API_KEY", "")
 }

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -274,3 +274,18 @@ func TestEvaluateOperatorProviders_UsesProviderTypeNotAlias(t *testing.T) {
 		assert.True(t, compliant)
 	})
 }
+
+func TestDeclaredOperatorRegions(t *testing.T) {
+	clearProviderKeys(t)
+	t.Setenv("AWS_REGION", "us-east-1")
+	op := &config.Config{
+		LLM: &config.LLMConfig{
+			Providers: map[string]config.LLMProviderConfig{
+				"azure": {Type: "azure-openai", Enabled: true, Config: map[string]interface{}{"region": "westeurope"}},
+			},
+		},
+	}
+	regions := DeclaredOperatorRegions(op)
+	assert.Equal(t, "us-east-1", regions["bedrock"])
+	assert.Equal(t, "westeurope", regions["azure-openai"])
+}

--- a/internal/sovereignty/providers_test.go
+++ b/internal/sovereignty/providers_test.go
@@ -20,7 +20,9 @@ func TestAllowsProvider(t *testing.T) {
 	}{
 		{"eu_strict allows ollama (LOCAL)", config.DataSovereigntyEUStrict, "ollama", true},
 		{"eu_strict allows mistral (EU)", config.DataSovereigntyEUStrict, "mistral", true},
-		{"eu_strict allows bedrock (US + EU regions)", config.DataSovereigntyEUStrict, "bedrock", true},
+		// Bedrock is US-jurisdiction and region-aware: with no configured region
+		// it is excluded (fail closed) even though it offers EU regions.
+		{"eu_strict excludes bedrock without region", config.DataSovereigntyEUStrict, "bedrock", false},
 		{"eu_strict rejects openai (US)", config.DataSovereigntyEUStrict, "openai", false},
 		{"eu_strict rejects anthropic (US)", config.DataSovereigntyEUStrict, "anthropic", false},
 		{"eu_strict rejects unknown provider (fail closed)", config.DataSovereigntyEUStrict, "made-up", false},
@@ -31,6 +33,38 @@ func TestAllowsProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, AllowsProvider(tt.mode, tt.provider))
+		})
+	}
+}
+
+func TestAllowsProviderRegion(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		provider string
+		region   string
+		want     bool
+	}{
+		// Bedrock (US jurisdiction, region-aware).
+		{"bedrock eu-central-1 allowed", config.DataSovereigntyEUStrict, "bedrock", "eu-central-1", true},
+		{"bedrock us-east-1 excluded", config.DataSovereigntyEUStrict, "bedrock", "us-east-1", false},
+		{"bedrock no region excluded", config.DataSovereigntyEUStrict, "bedrock", "", false},
+		// Vertex (US jurisdiction, region-aware).
+		{"vertex europe-west1 allowed", config.DataSovereigntyEUStrict, "vertex", "europe-west1", true},
+		{"vertex us-central1 excluded", config.DataSovereigntyEUStrict, "vertex", "us-central1", false},
+		// Azure OpenAI (EU jurisdiction, but region-aware: a US region excludes).
+		{"azure westeurope allowed", config.DataSovereigntyEUStrict, "azure-openai", "westeurope", true},
+		{"azure eastus excluded", config.DataSovereigntyEUStrict, "azure-openai", "eastus", false},
+		{"azure no region trusts EU jurisdiction", config.DataSovereigntyEUStrict, "azure-openai", "", true},
+		// Non-region providers ignore the region argument.
+		{"openai region ignored, still US", config.DataSovereigntyEUStrict, "openai", "eu-central-1", false},
+		{"ollama LOCAL always allowed", config.DataSovereigntyEUStrict, "ollama", "us-east-1", true},
+		// Non-strict modes allow everything regardless of region.
+		{"global bedrock us-east-1 allowed", config.DataSovereigntyGlobal, "bedrock", "us-east-1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, AllowsProviderRegion(tt.mode, tt.provider, tt.region))
 		})
 	}
 }
@@ -140,6 +174,69 @@ func clearProviderKeys(t *testing.T) {
 	t.Helper()
 	t.Setenv("OPENAI_API_KEY", "")
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_REGION", "")
+}
+
+// TestEvaluateSovereignty_EUStrictBedrockRegionAware is the regression for the
+// "Bedrock metadata has EU regions so any region is allowed" bug: under
+// eu_strict the *configured* AWS_REGION decides routability.
+func TestEvaluateSovereignty_EUStrictBedrockRegionAware(t *testing.T) {
+	clearProviderKeys(t)
+	op := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+	}
+
+	t.Run("us region excluded", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "us-east-1")
+		eval := EvaluateSovereignty(op, nil)
+		require.Len(t, eval.Excluded, 1)
+		assert.Equal(t, "bedrock", eval.Excluded[0].Provider)
+		assert.Equal(t, ExclusionScopeEnv, eval.Excluded[0].Scope)
+		assert.Contains(t, eval.Excluded[0].Reason, "us-east-1")
+	})
+
+	t.Run("eu region compliant", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "eu-central-1")
+		eval := EvaluateSovereignty(op, nil)
+		assert.Empty(t, eval.Excluded)
+		assert.True(t, eval.HasCompliantOperatorProvider)
+	})
+}
+
+// TestEvaluateSovereignty_EUStrictLLMProvidersRegionAware verifies an
+// llm.providers entry for a region-aware provider is gated on its configured
+// region, not just its type.
+func TestEvaluateSovereignty_EUStrictLLMProvidersRegionAware(t *testing.T) {
+	clearProviderKeys(t)
+
+	t.Run("bedrock us region in llm.providers excluded", func(t *testing.T) {
+		op := &config.Config{
+			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+			LLM: &config.LLMConfig{
+				Providers: map[string]config.LLMProviderConfig{
+					"aws": {Type: "bedrock", Enabled: true, Config: map[string]interface{}{"region": "us-east-1"}},
+				},
+			},
+		}
+		excluded, compliant := evaluateOperatorProviders(op, config.DataSovereigntyEUStrict)
+		require.Len(t, excluded, 1)
+		assert.Equal(t, "bedrock", excluded[0].Provider)
+		assert.False(t, compliant)
+	})
+
+	t.Run("bedrock eu region in llm.providers compliant", func(t *testing.T) {
+		op := &config.Config{
+			Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+			LLM: &config.LLMConfig{
+				Providers: map[string]config.LLMProviderConfig{
+					"aws": {Type: "bedrock", Enabled: true, Config: map[string]interface{}{"region": "eu-west-1"}},
+				},
+			},
+		}
+		excluded, compliant := evaluateOperatorProviders(op, config.DataSovereigntyEUStrict)
+		assert.Empty(t, excluded)
+		assert.True(t, compliant)
+	})
 }
 
 // TestEvaluateOperatorProviders_UsesProviderTypeNotAlias is the regression for

--- a/internal/sovereignty/validate.go
+++ b/internal/sovereignty/validate.go
@@ -7,18 +7,17 @@ import (
 	"github.com/dativo-io/talon/internal/gateway"
 )
 
-// ValidateAirGap checks operator and gateway configuration for air-gap mode.
-// Returns an error when the deployment cannot be considered provably in-region.
-// The provider/region gate (eu_strict) is enforced by ValidateSovereignty;
-// ValidateAirGap adds the air-gap-specific requirement that crypto keys are
-// explicit so signed evidence cannot be forged with a derived default key.
+// ValidateAirGap checks operator configuration for air-gap mode. Returns an
+// error when explicit crypto keys are missing. Provider exclusions under
+// eu_strict are non-fatal and enforced at runtime via EvaluateSovereignty and
+// gateway per-request denial.
 func ValidateAirGap(op *config.Config, gw *gateway.GatewayConfig) error {
+	_ = gw
 	if op == nil || op.Sovereignty == nil || !op.Sovereignty.AirGapEnabled() {
 		return nil
 	}
 	if op.UsingDefaultKeys() {
 		return fmt.Errorf("air_gap mode requires explicit TALON_SECRETS_KEY and TALON_SIGNING_KEY (no generated defaults)")
 	}
-	// air_gap implies eu_strict (config resolution); enforce the provider gate.
-	return ValidateSovereignty(op, gw)
+	return nil
 }

--- a/tests/integration/airgap_test.go
+++ b/tests/integration/airgap_test.go
@@ -99,6 +99,7 @@ gateway:
 	require.NoError(t, err)
 	require.NotNil(t, guard)
 	gwCfg.UpstreamTransport = guard
+	gwCfg.EffectiveSovereigntyMode = opCfg.EffectiveSovereigntyMode()
 	require.NoError(t, gwCfg.ApplyDefaults())
 
 	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
@@ -150,7 +151,7 @@ gateway:
 	assert.True(t, evStore.VerifyRecord(&records[0]))
 }
 
-func TestAirGap_RejectsUSProviderAtValidation(t *testing.T) {
+func TestAirGap_USProviderExcludedNotFatal(t *testing.T) {
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{DeploymentMode: sovereignty.ModeAirGap},
 		SecretsKey:  testutil.TestEncryptionKey,
@@ -161,7 +162,9 @@ func TestAirGap_RejectsUSProviderAtValidation(t *testing.T) {
 			"openai": {Enabled: true, BaseURL: "https://api.openai.com", Region: "US"},
 		},
 	}
-	err := sovereignty.ValidateAirGap(op, gw)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "US")
+	require.NoError(t, sovereignty.ValidateAirGap(op, gw))
+	eval := sovereignty.EvaluateSovereignty(op, gw)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
+	assert.False(t, eval.HasRoutableProvider)
 }

--- a/tests/integration/airgap_test.go
+++ b/tests/integration/airgap_test.go
@@ -152,6 +152,9 @@ gateway:
 }
 
 func TestAirGap_USProviderExcludedNotFatal(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_REGION", "")
 	op := &config.Config{
 		Sovereignty: &config.SovereigntyConfig{DeploymentMode: sovereignty.ModeAirGap},
 		SecretsKey:  testutil.TestEncryptionKey,

--- a/tests/integration/sovereignty_gate_test.go
+++ b/tests/integration/sovereignty_gate_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/sovereignty"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// TestSovereigntyGate_NonFatalStartupAndGatewayDeny proves eu_strict excludes
+// declared US providers without refusing startup, and denies gateway requests
+// at runtime with signed evidence.
+func TestSovereigntyGate_NonFatalStartupAndGatewayDeny(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	configYAML := fmt.Sprintf(`
+sovereignty:
+  mode: eu_strict
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: enforce
+  providers:
+    openai:
+      enabled: true
+      secret_name: "openai-api-key"
+      base_url: %q
+      region: "US"
+  callers:
+    - name: sov-e2e
+      tenant_key: "talon-gw-sov-e2e"
+      tenant_id: "e2e-tenant"
+  default_policy:
+    default_pii_action: warn
+  timeouts:
+    connect_timeout: "5s"
+    request_timeout: "30s"
+    stream_idle_timeout: "60s"
+`, upstream.URL)
+	configPath := filepath.Join(dir, "talon.config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configYAML), 0o600))
+
+	opCfg := &config.Config{
+		Sovereignty: &config.SovereigntyConfig{SovereigntyMode: config.DataSovereigntyEUStrict},
+		SecretsKey:  testutil.TestEncryptionKey,
+		SigningKey:  testutil.TestSigningKey,
+	}
+	gwCfg, err := gateway.LoadGatewayConfig(configPath)
+	require.NoError(t, err)
+
+	eval := sovereignty.EvaluateSovereignty(opCfg, gwCfg)
+	require.Len(t, eval.Excluded, 1)
+	assert.Equal(t, "openai", eval.Excluded[0].Provider)
+	assert.False(t, eval.HasRoutableProvider)
+
+	gwCfg.EffectiveSovereigntyMode = config.DataSovereigntyEUStrict
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "openai-api-key",
+		[]byte("sk-test"), secrets.ACL{Tenants: []string{"e2e-tenant"}, Agents: []string{"*"}}))
+
+	gw, err := gateway.NewGateway(gwCfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) {
+		r.Handle("/*", gw)
+	})
+	send := func(body string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://test/v1/proxy/openai/v1/chat/completions",
+			bytes.NewReader([]byte(body)))
+		req.Header.Set("Authorization", "Bearer talon-gw-sov-e2e")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	w := send(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "sovereignty.mode=eu_strict")
+	assert.Equal(t, int64(0), upstreamCalls.Load())
+
+	records, err := evStore.List(context.Background(), "e2e-tenant", "", time.Time{}, time.Time{}, 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	assert.False(t, records[0].PolicyDecision.Allowed)
+}

--- a/tests/integration/sovereignty_gate_test.go
+++ b/tests/integration/sovereignty_gate_test.go
@@ -31,6 +31,12 @@ import (
 // declared US providers without refusing startup, and denies gateway requests
 // at runtime with signed evidence.
 func TestSovereigntyGate_NonFatalStartupAndGatewayDeny(t *testing.T) {
+	// Keep operator/native routability deterministic: no ambient provider keys
+	// or AWS_REGION should make an operator provider compliant.
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("AWS_REGION", "")
+
 	var upstreamCalls atomic.Int64
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		upstreamCalls.Add(1)


### PR DESCRIPTION
## Summary
- `eu_strict` no longer refuses startup when non-EU/LOCAL providers are declared; they are excluded from routing with ERROR logs and OTel counter `talon.sovereignty.provider_excluded_total`
- Gateway denies requests to excluded providers at runtime (HTTP 403 + signed evidence + `talon.sovereignty.provider_denied_total`)
- `talon doctor` warns when compliant EU/LOCAL providers remain alongside exclusions (exit 0); fails only when nothing is routable under `eu_strict`
- `talon compliance sovereignty` report distinguishes declared-but-excluded providers (`excluded_declared` / gateway `excluded` posture)
- `air_gap` missing explicit crypto keys remains a hard startup failure (unchanged)

## Breaking change
Operators who relied on startup failure to discover misconfigured US providers under `eu_strict` must now check ERROR logs, `talon doctor`, gateway 403 responses, or the sovereignty posture report. Recommended: run `talon doctor --gateway-config ... --skip-upstream` in CI.

## Test plan
- [x] `make test && make check && make lint`
- [x] Unit: `EvaluateSovereignty`, gateway 403+evidence, doctor warn vs fail-unroutable, compliance excluded-declared provider
- [x] Integration: `TestSovereigntyGate_NonFatalStartupAndGatewayDeny`, updated air-gap tests
- [x] Manual smoke: `eu_strict` + OpenAI key + Ollama gateway → serve starts, OpenAI 403, Ollama 200, doctor warn exit 0
- [x] Manual smoke: `eu_strict` US-only gateway → doctor fail, serve starts, OpenAI 403
- [x] Manual smoke: `air_gap` without crypto keys → serve exits immediately

Relates to #111

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a behavioral breaking change for operators who relied on startup failure under eu_strict, and it touches sovereignty enforcement on the gateway request path and LLM routing selection.
> 
> **Overview**
> Under **`eu_strict`**, Talon no longer **fails startup** when operators declare non-EU/LOCAL providers. Those providers are **excluded from routing** (ERROR logs + `talon.sovereignty.provider_excluded_total`), while **compliant providers keep the process running**. **`air_gap`** still hard-fails only on missing explicit crypto keys.
> 
> **Region-aware gating** (Bedrock, Azure OpenAI, Vertex) now uses the **configured region** (`AWS_REGION`, `llm.providers` region)—e.g. `us-east-1` excludes Bedrock even when metadata lists EU regions.
> 
> The **gateway** enforces exclusions per request: **HTTP 403**, signed evidence, and `talon.sovereignty.provider_denied_total` (shadow mode records violations but still forwards). **`talon doctor`** **warns** when exclusions exist but something EU/LOCAL remains routable; it **fails** only when nothing is routable, with **gateway vs native checks separated** so a compliant Bedrock does not mask an all-US gateway.
> 
> **`talon compliance sovereignty`** labels declared exclusions (`excluded` / `excluded_declared`). **`serve` / `run` / `plan`** call **`ApplySovereigntyGate`** instead of **`ValidateSovereignty`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1132274f7c38e5d488e805dec0fdcbd51c63bb86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->