### PR TITLE
feat(reliability): error-driven, sovereignty-respecting provider fallback chains (#138)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -381,25 +381,46 @@ gateway:
 
 #### Provider fallback chains (error-driven failover)
 
+**Scope: this is same-wire-format failover, not cross-provider translation.**
+A chain moves traffic between endpoints that speak the same API — an
+OpenAI-compatible endpoint to another OpenAI-compatible endpoint, or an
+Anthropic-compatible endpoint to another Anthropic-compatible one. Talon does
+not translate request/response schemas between families (e.g. OpenAI ↔
+Anthropic); the body is forwarded as-is except for an optional model rewrite,
+and cross-family chains are rejected at config load.
+
 On a **transient** upstream failure (timeout, connection failure, HTTP 429 or
-5xx) Talon can retry the request against an ordered fallback chain. A
+5xx) Talon retries the request against the ordered fallback chain. A
 permanent error from the **primary** (401/403/4xx) passes through unchanged —
 it never triggers failover. Once failover **is** engaged, only a successful
 response ends the chain: a fallback candidate that fails for any reason
 (including a permanent 401 from a misconfigured secret) is recorded as a
-failed attempt and the walk continues to the next candidate. Every candidate
-passes a filter pipeline before dispatch — under `sovereignty.mode: eu_strict`
-a non-EU/LOCAL candidate is skipped, never called. When the chain is exhausted
-the request **fails closed**: the caller gets an error and the refusal is
-recorded as a governance outcome — a failed fallback is never evidenced as
-"the provider actually used".
+failed attempt and the walk continues to the next candidate. When the chain
+is exhausted the request **fails closed**: the caller gets an error and the
+refusal is recorded as a governance outcome — a failed fallback is never
+evidenced as "the provider actually used".
+
+Every candidate passes a filter pipeline before dispatch:
+
+- **Sovereignty (hard invariant):** under `sovereignty.mode: eu_strict` a
+  non-EU/LOCAL candidate is skipped in every gateway mode, shadow included —
+  Talon never dispatches outside EU/LOCAL under eu_strict.
+- **Caller provider allowlist (hard):** a candidate outside the caller's
+  `allowed_providers` is never dispatched.
+- **Target tool policy and gateway policy (mode-aware):** each candidate
+  re-runs the target provider's tool policy and the full gateway policy with
+  the candidate's provider, model, recomputed cost estimate, destination
+  region, and session context — the same input surface as the primary. In
+  `enforce` mode a denial skips the candidate; in `shadow` mode the would-be
+  denial is recorded as a shadow violation and the dispatch proceeds (shadow
+  never changes runtime behavior).
 
 Gateway (proxy path) — chain per provider; all members must share the
-provider's API family (the body is forwarded as-is except an optional model
-rewrite). The family defaults by name (`anthropic` → Anthropic Messages API,
-everything else → OpenAI-compatible); set `api_family` explicitly for aliased
-endpoints so validation and upstream auth conventions (x-api-key +
-anthropic-version vs bearer) apply correctly:
+provider's API family. The family defaults by name (`anthropic` → Anthropic
+Messages API, everything else → OpenAI-compatible); set `api_family`
+explicitly for aliased endpoints — it drives request parsing, PII redaction,
+tool filtering, provider-native error shape, chain validation, and upstream
+auth conventions (x-api-key + anthropic-version vs bearer):
 
 ```yaml
 gateway:
@@ -437,12 +458,17 @@ policies:
 
 Evidence: each failed attempt is a separate signed record
 (`gateway_failover_attempt` / `llm_failover_attempt`, `failover.role:
-failed_attempt`), and the request's final record carries the fallback decision
-(`failover.role: fallback_decision` with the provider actually used and links
-to the failed attempts) or the fail-closed outcome (`failover.role:
-fail_closed`). Verify chains with `talon audit verify --failover
-[correlation-id]`. OTel spans expose `talon.provider.original`,
-`talon.provider.selected`, and `talon.provider.fallback_reason`.
+failed_attempt`), and each failover engagement gets exactly one terminal
+record — the fallback decision (`failover.role: fallback_decision` with the
+provider actually used and links to the failed attempts) or the fail-closed
+outcome (`failover.role: fail_closed`). For gateway requests the terminal
+lives on the request's final record; agent runs persist a dedicated
+`llm_failover_decision` record per engagement. All records of one engagement
+share a `failover_group_id` — an agentic run makes many LLM calls under one
+correlation ID, and each call's chain verifies independently. Verify with
+`talon audit verify --failover [correlation-id]`. OTel spans expose
+`talon.provider.original`, `talon.provider.selected`, and
+`talon.provider.fallback_reason`.
 
 **Relationship to `compliance.data_residency` (agent policy):** that field is
 a *declaration*, not an enforcement knob — it is stamped into evidence and

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -379,6 +379,58 @@ gateway:
   preference order only makes sense when Talon picks the provider, not when
   it admits a caller-chosen one.)
 
+#### Provider fallback chains (error-driven failover)
+
+On a **transient** upstream failure (timeout, connection failure, HTTP 429 or
+5xx) Talon can retry the request against an ordered fallback chain. Permanent
+errors (401/403/4xx) never trigger failover. Every candidate passes a filter
+pipeline before dispatch — under `sovereignty.mode: eu_strict` a non-EU/LOCAL
+candidate is skipped, never called. When no policy-valid candidate succeeds
+the request **fails closed**: the caller gets an error and the refusal is
+recorded as a governance outcome.
+
+Gateway (proxy path) — chain per provider; all members must share the
+provider's API family (the body is forwarded as-is except an optional model
+rewrite):
+
+```yaml
+gateway:
+  providers:
+    openai:
+      base_url: "https://api.openai.com"
+      secret_name: "openai-api-key"
+      region: "EU"
+      fallback:
+        - provider: "mistral-eu"        # tried in order on transient failure
+          model: "mistral-large-latest" # optional: rewrite the body's model field
+    mistral-eu:
+      base_url: "https://api.mistral.ai"
+      secret_name: "mistral-api-key"
+      region: "EU"
+```
+
+Agent runs (`talon run`) — chain per routing tier; candidates are re-checked
+against the compliance routing policy (sovereignty) before dispatch:
+
+```yaml
+policies:
+  model_routing:
+    tier_1:
+      primary: gpt-4o
+      fallback_chain:        # supersedes the legacy single `fallback` for error-driven failover
+        - mistral-large-latest
+        - llama3:70b
+```
+
+Evidence: each failed attempt is a separate signed record
+(`gateway_failover_attempt` / `llm_failover_attempt`, `failover.role:
+failed_attempt`), and the request's final record carries the fallback decision
+(`failover.role: fallback_decision` with the provider actually used and links
+to the failed attempts) or the fail-closed outcome (`failover.role:
+fail_closed`). Verify chains with `talon audit verify --failover
+[correlation-id]`. OTel spans expose `talon.provider.original`,
+`talon.provider.selected`, and `talon.provider.fallback_reason`.
+
 **Relationship to `compliance.data_residency` (agent policy):** that field is
 a *declaration*, not an enforcement knob — it is stamped into evidence and
 used by auditor exports. If you declare `data_residency: eu` but run with

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -382,16 +382,24 @@ gateway:
 #### Provider fallback chains (error-driven failover)
 
 On a **transient** upstream failure (timeout, connection failure, HTTP 429 or
-5xx) Talon can retry the request against an ordered fallback chain. Permanent
-errors (401/403/4xx) never trigger failover. Every candidate passes a filter
-pipeline before dispatch — under `sovereignty.mode: eu_strict` a non-EU/LOCAL
-candidate is skipped, never called. When no policy-valid candidate succeeds
+5xx) Talon can retry the request against an ordered fallback chain. A
+permanent error from the **primary** (401/403/4xx) passes through unchanged —
+it never triggers failover. Once failover **is** engaged, only a successful
+response ends the chain: a fallback candidate that fails for any reason
+(including a permanent 401 from a misconfigured secret) is recorded as a
+failed attempt and the walk continues to the next candidate. Every candidate
+passes a filter pipeline before dispatch — under `sovereignty.mode: eu_strict`
+a non-EU/LOCAL candidate is skipped, never called. When the chain is exhausted
 the request **fails closed**: the caller gets an error and the refusal is
-recorded as a governance outcome.
+recorded as a governance outcome — a failed fallback is never evidenced as
+"the provider actually used".
 
 Gateway (proxy path) — chain per provider; all members must share the
 provider's API family (the body is forwarded as-is except an optional model
-rewrite):
+rewrite). The family defaults by name (`anthropic` → Anthropic Messages API,
+everything else → OpenAI-compatible); set `api_family` explicitly for aliased
+endpoints so validation and upstream auth conventions (x-api-key +
+anthropic-version vs bearer) apply correctly:
 
 ```yaml
 gateway:
@@ -407,6 +415,11 @@ gateway:
       base_url: "https://api.mistral.ai"
       secret_name: "mistral-api-key"
       region: "EU"
+    anthropic-eu:
+      base_url: "https://eu.anthropic.example.com"
+      secret_name: "anthropic-eu-key"
+      region: "EU"
+      api_family: "anthropic"   # anthropic-compatible alias: joins anthropic chains
 ```
 
 Agent runs (`talon run`) — chain per routing tier; candidates are re-checked

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -1093,6 +1093,16 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 		r.recordEarlyTermination(ctx, correlationID, req, "provider_resolution_failed: "+err.Error(), startTime)
 		return nil, err
 	}
+	// Error-driven provider failover across the tier's fallback_chain (#138).
+	fo := r.newRunFailover(ctx, req, correlationID, tier, routingEngine, req.SovereigntyMode, &secretsAccessed)
+	fo.dataFlow = func(providerName, m string) *evidence.DataFlow {
+		return buildRunDataFlow(runFlowInputs{
+			TenantID: req.TenantID, InvocationType: req.InvocationType,
+			Provider: providerName, Model: m,
+			InputTier: tier, InputPIITypes: piiNames, InputPIIRedacted: inputPIIRedacted,
+			Detector: piiScanner.Detector(),
+		})
+	}
 	const preRunEstimateInput, preRunEstimateOutput = 300, 300
 	var evRouting *evidence.RoutingDecision
 	if routeDecision != nil {
@@ -1371,7 +1381,8 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				Tools:       llmTools,
 			}
 			iterStart := time.Now()
-			resp, err := provider.Generate(ctx, llmReq)
+			resp, usedProvider, usedModel, err := fo.generate(ctx, provider, model, llmReq)
+			provider, model = usedProvider, usedModel
 			if err != nil {
 				span.RecordError(err)
 				llmFailReason := FailureLLMError
@@ -1399,6 +1410,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					}),
 					Status:        string(RunStatusFailed),
 					FailureReason: string(llmFailReason),
+					Failover:      fo.decision,
 				}); evErr != nil {
 					log.Error().Err(evErr).
 						Str("correlation_id", correlationID).
@@ -1660,7 +1672,8 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			MaxTokens:   2000,
 		}
 		singleStart := time.Now()
-		resp, err := provider.Generate(ctx, llmReq)
+		resp, usedProvider, usedModel, err := fo.generate(ctx, provider, model, llmReq)
+		provider, model = usedProvider, usedModel
 		if err != nil {
 			span.RecordError(err)
 			singleFailReason := FailureLLMError
@@ -1686,6 +1699,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				}),
 				Status:        string(RunStatusFailed),
 				FailureReason: string(singleFailReason),
+				Failover:      fo.decision,
 			}); evErr != nil {
 				log.Error().Err(evErr).
 					Str("correlation_id", correlationID).
@@ -1924,7 +1938,8 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			PolicyRef:       explanationPolicyRef(pol.VersionTag),
 			VersionIdentity: pol.VersionTag,
 		}},
-		Status: string(RunStatusCompleted),
+		Status:   string(RunStatusCompleted),
+		Failover: fo.decision,
 	})
 	evidenceID := ""
 	if err != nil {

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -1410,7 +1410,6 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 					}),
 					Status:        string(RunStatusFailed),
 					FailureReason: string(llmFailReason),
-					Failover:      fo.decision,
 				}); evErr != nil {
 					log.Error().Err(evErr).
 						Str("correlation_id", correlationID).
@@ -1699,7 +1698,6 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 				}),
 				Status:        string(RunStatusFailed),
 				FailureReason: string(singleFailReason),
-				Failover:      fo.decision,
 			}); evErr != nil {
 				log.Error().Err(evErr).
 					Str("correlation_id", correlationID).
@@ -1938,8 +1936,7 @@ func (r *Runner) executeLLMPipeline(ctx context.Context, span trace.Span, startT
 			PolicyRef:       explanationPolicyRef(pol.VersionTag),
 			VersionIdentity: pol.VersionTag,
 		}},
-		Status:   string(RunStatusCompleted),
-		Failover: fo.decision,
+		Status: string(RunStatusCompleted),
 	})
 	evidenceID := ""
 	if err != nil {

--- a/internal/agent/runner_failover.go
+++ b/internal/agent/runner_failover.go
@@ -1,0 +1,223 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/failover"
+	"github.com/dativo-io/talon/internal/llm"
+)
+
+// runFailover drives error-driven provider failover for a single agent run
+// (issue #138): on a transient Generate failure the tier's remaining
+// fallback_chain candidates are tried in order. Candidates were already
+// filtered by the compliance routing policy at resolve time (sovereignty:
+// under eu_strict a non-EU candidate never enters the list), so failover
+// cannot become a policy bypass. Each failed runtime attempt is persisted as
+// its own signed evidence record; the final run record carries the fallback
+// decision (or fail-closed outcome) linked by correlation ID.
+type runFailover struct {
+	r               *Runner
+	req             *RunRequest
+	correlationID   string
+	tier            int
+	sovereigntyMode string
+	complianceMode  bool
+	remaining       []llm.ResolvedCandidate
+	// skipped are chain candidates refused by the compliance routing policy
+	// at resolve time — never dispatched, evidenced distinctly from failures.
+	skipped        []evidence.SkippedCandidate
+	failedAttempts []string
+	secrets        *[]string
+	// dataFlow builds the data-flow section for a failed-attempt record (the
+	// prompt did egress to the failed provider). Set by the caller; nil skips.
+	dataFlow func(providerName, model string) *evidence.DataFlow
+	// decision is the FailoverContext for the run's final evidence record;
+	// nil until failover is engaged.
+	decision *evidence.FailoverContext
+}
+
+// newRunFailover resolves the tier's fallback candidates (positions >= 1).
+// Resolution failures disable failover for the run but never fail it — the
+// primary path continues exactly as before.
+func (r *Runner) newRunFailover(ctx context.Context, req *RunRequest, correlationID string, tier int, routingEngine llm.RoutingPolicyEvaluator, sovereigntyMode string, secrets *[]string) *runFailover {
+	fo := &runFailover{
+		r:               r,
+		req:             req,
+		correlationID:   correlationID,
+		tier:            tier,
+		sovereigntyMode: sovereigntyMode,
+		complianceMode:  routingEngine != nil && sovereigntyMode != "",
+		secrets:         secrets,
+	}
+	if r.router == nil {
+		return fo
+	}
+	var opts *llm.RouteOptions
+	if fo.complianceMode {
+		opts = &llm.RouteOptions{PolicyEngine: routingEngine, SovereigntyMode: sovereigntyMode, DataTier: tier}
+	}
+	resolved, rejected, err := r.router.ResolveCandidates(ctx, tier, opts)
+	if err != nil {
+		log.Warn().Err(err).Str("correlation_id", correlationID).Msg("failover_candidates_unavailable")
+		return fo
+	}
+	for _, c := range resolved {
+		if c.ChainPosition >= 1 {
+			fo.remaining = append(fo.remaining, c)
+		}
+	}
+	for _, rej := range rejected {
+		fo.skipped = append(fo.skipped, evidence.SkippedCandidate{
+			Provider: rej.ProviderID,
+			Filter:   "routing_policy",
+			Reason:   rej.Reason,
+		})
+	}
+	return fo
+}
+
+// generate calls provider.Generate and, on a transient failure, walks the
+// remaining fallback candidates. Returns the response plus the provider and
+// model actually used so the caller's evidence stays truthful.
+func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model string, llmReq *llm.Request) (*llm.Response, llm.Provider, string, error) {
+	resp, err := provider.Generate(ctx, llmReq)
+	if err == nil || f == nil {
+		return resp, provider, model, err
+	}
+	class := llm.ClassifyGenerateError(err)
+	if !class.Transient || (len(f.remaining) == 0 && len(f.skipped) == 0) {
+		// Permanent failure, or no fallback chain configured at all:
+		// failover was never engaged; behave exactly as before.
+		return resp, provider, model, err
+	}
+
+	originalModel := model
+	f.recordAttempt(ctx, provider.Name(), providerJurisdiction(provider), model, class, 0, "", err, 0)
+
+	for len(f.remaining) > 0 {
+		if ctx.Err() != nil {
+			break
+		}
+		cand := f.remaining[0]
+		f.remaining = f.remaining[1:]
+		if cand.ProviderName == provider.Name() && cand.Model == model {
+			continue
+		}
+
+		p := cand.Provider
+		if llm.ProviderUsesAPIKey(cand.ProviderName) && f.r.secrets != nil {
+			var accessed []string
+			p, accessed = f.r.applyProviderKeyFromVaultOrEnv(ctx, f.req, p)
+			if f.secrets != nil {
+				*f.secrets = append(*f.secrets, accessed...)
+			}
+		}
+
+		log.Info().
+			Str("correlation_id", f.correlationID).
+			Str("from_model", model).
+			Str("to_model", cand.Model).
+			Str("error_class", class.Class).
+			Int("chain_position", cand.ChainPosition).
+			Msg("llm_failover_attempt")
+
+		attemptReq := *llmReq
+		attemptReq.Model = cand.Model
+		attemptStart := time.Now()
+		resp, err = p.Generate(ctx, &attemptReq)
+		if err == nil {
+			f.decision = &evidence.FailoverContext{
+				Role:              evidence.FailoverRoleFallbackDecision,
+				Provider:          cand.ProviderName,
+				Region:            cand.Jurisdiction,
+				Model:             cand.Model,
+				ChainPosition:     cand.ChainPosition,
+				FallbackRuleID:    cand.RuleID,
+				SovereigntyMode:   f.sovereigntyMode,
+				SovereigntyCheck:  f.sovereigntyCheck(),
+				FailedAttemptIDs:  f.failedAttempts,
+				SkippedCandidates: f.skipped,
+			}
+			llm.RecordFailover(ctx, originalModel, cand.Model, class.Class)
+			return resp, p, cand.Model, nil
+		}
+		class = llm.ClassifyGenerateError(err)
+		f.recordAttempt(ctx, cand.ProviderName, cand.Jurisdiction, cand.Model, class, cand.ChainPosition, cand.RuleID, err, time.Since(attemptStart).Milliseconds())
+		if !class.Transient {
+			break
+		}
+	}
+
+	// Chain exhausted (or a permanent failure ended the walk): fail closed.
+	// The caller receives the error; the refusal to dispatch further is a
+	// governance outcome recorded on the final run record.
+	f.decision = &evidence.FailoverContext{
+		Role:              evidence.FailoverRoleFailClosed,
+		ErrorClass:        class.Class,
+		SovereigntyMode:   f.sovereigntyMode,
+		FailedAttemptIDs:  f.failedAttempts,
+		SkippedCandidates: f.skipped,
+	}
+	return nil, provider, model, err
+}
+
+func (f *runFailover) sovereigntyCheck() string {
+	if f.complianceMode {
+		return "allowed"
+	}
+	return "not_evaluated"
+}
+
+// recordAttempt persists one failed provider attempt as a signed evidence
+// record linked to the run by correlation ID (evidence-by-default).
+func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdiction, model string, class failover.Classification, chainPosition int, ruleID string, genErr error, durationMS int64) {
+	var flow *evidence.DataFlow
+	if f.dataFlow != nil {
+		flow = f.dataFlow(providerName, model)
+	}
+	ev, err := f.r.evidence.Generate(ctx, evidence.GenerateParams{
+		CorrelationID:   f.correlationID,
+		TenantID:        f.req.TenantID,
+		AgentID:         f.req.AgentName,
+		InvocationType:  "llm_failover_attempt",
+		RequestSourceID: f.req.InvocationType,
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Classification:  evidence.Classification{InputTier: f.tier},
+		ModelUsed:       model,
+		DataFlow:        flow,
+		DurationMS:      durationMS,
+		Error:           genErr.Error(),
+		Status:          string(RunStatusFailed),
+		FailureReason:   evidence.FailureReasonProviderTransient,
+		Failover: &evidence.FailoverContext{
+			Role:            evidence.FailoverRoleFailedAttempt,
+			Provider:        providerName,
+			Region:          jurisdiction,
+			Model:           model,
+			ErrorClass:      class.Class,
+			ChainPosition:   chainPosition,
+			FallbackRuleID:  ruleID,
+			SovereigntyMode: f.sovereigntyMode,
+		},
+	})
+	if err != nil {
+		log.Error().Err(err).
+			Str("correlation_id", f.correlationID).
+			Str("tenant_id", f.req.TenantID).
+			Str("agent_id", f.req.AgentName).
+			Msg("evidence_write_failed_failover_attempt")
+		return
+	}
+	f.failedAttempts = append(f.failedAttempts, ev.ID)
+}
+
+func providerJurisdiction(p llm.Provider) string {
+	if p == nil {
+		return ""
+	}
+	return p.Metadata().Jurisdiction
+}

--- a/internal/agent/runner_failover.go
+++ b/internal/agent/runner_failover.go
@@ -147,14 +147,14 @@ func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model
 		}
 		class = llm.ClassifyGenerateError(err)
 		f.recordAttempt(ctx, cand.ProviderName, cand.Jurisdiction, cand.Model, class, cand.ChainPosition, cand.RuleID, err, time.Since(attemptStart).Milliseconds())
-		if !class.Transient {
-			break
-		}
+		// Once failover is engaged, only success ends the chain: a fallback
+		// candidate failing permanently (bad key, model not on that provider)
+		// is that candidate's problem, not the request's — keep walking.
 	}
 
-	// Chain exhausted (or a permanent failure ended the walk): fail closed.
-	// The caller receives the error; the refusal to dispatch further is a
-	// governance outcome recorded on the final run record.
+	// Chain exhausted: fail closed. The caller receives the error; the
+	// refusal to dispatch further is a governance outcome recorded on the
+	// final run record.
 	f.decision = &evidence.FailoverContext{
 		Role:              evidence.FailoverRoleFailClosed,
 		ErrorClass:        class.Class,
@@ -179,6 +179,10 @@ func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdict
 	if f.dataFlow != nil {
 		flow = f.dataFlow(providerName, model)
 	}
+	failureReason := evidence.FailureReasonProviderTransient
+	if !class.Transient {
+		failureReason = evidence.FailureReasonProviderPermanent
+	}
 	ev, err := f.r.evidence.Generate(ctx, evidence.GenerateParams{
 		CorrelationID:   f.correlationID,
 		TenantID:        f.req.TenantID,
@@ -192,7 +196,7 @@ func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdict
 		DurationMS:      durationMS,
 		Error:           genErr.Error(),
 		Status:          string(RunStatusFailed),
-		FailureReason:   evidence.FailureReasonProviderTransient,
+		FailureReason:   failureReason,
 		Failover: &evidence.FailoverContext{
 			Role:            evidence.FailoverRoleFailedAttempt,
 			Provider:        providerName,

--- a/internal/agent/runner_failover.go
+++ b/internal/agent/runner_failover.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"github.com/dativo-io/talon/internal/evidence"
@@ -11,14 +12,17 @@ import (
 	"github.com/dativo-io/talon/internal/llm"
 )
 
-// runFailover drives error-driven provider failover for a single agent run
-// (issue #138): on a transient Generate failure the tier's remaining
-// fallback_chain candidates are tried in order. Candidates were already
-// filtered by the compliance routing policy at resolve time (sovereignty:
-// under eu_strict a non-EU candidate never enters the list), so failover
-// cannot become a policy bypass. Each failed runtime attempt is persisted as
-// its own signed evidence record; the final run record carries the fallback
-// decision (or fail-closed outcome) linked by correlation ID.
+// runFailover drives error-driven provider failover for an agent run (issue
+// #138). It is a run-level FACTORY: the candidate list is resolved once and
+// held immutable, and every Generate call gets its own failover engagement
+// with a fresh chain walk and its own failover_group_id — an agentic run
+// makes many LLM calls, and each call's failover chain must be independently
+// evidenced and verifiable. Candidates were already filtered by the
+// compliance routing policy at resolve time (sovereignty: under eu_strict a
+// non-EU candidate never enters the list), so failover cannot become a policy
+// bypass. Each engagement persists its failed attempts as separate signed
+// records plus one terminal record (fallback decision or fail-closed), all
+// linked by correlation ID and the shared group ID.
 type runFailover struct {
 	r               *Runner
 	req             *RunRequest
@@ -26,18 +30,16 @@ type runFailover struct {
 	tier            int
 	sovereigntyMode string
 	complianceMode  bool
-	remaining       []llm.ResolvedCandidate
+	// candidates are the tier's fallback candidates (chain positions >= 1),
+	// resolved once and never mutated: every engagement walks a fresh copy.
+	candidates []llm.ResolvedCandidate
 	// skipped are chain candidates refused by the compliance routing policy
 	// at resolve time — never dispatched, evidenced distinctly from failures.
-	skipped        []evidence.SkippedCandidate
-	failedAttempts []string
-	secrets        *[]string
+	skipped []evidence.SkippedCandidate
+	secrets *[]string
 	// dataFlow builds the data-flow section for a failed-attempt record (the
 	// prompt did egress to the failed provider). Set by the caller; nil skips.
 	dataFlow func(providerName, model string) *evidence.DataFlow
-	// decision is the FailoverContext for the run's final evidence record;
-	// nil until failover is engaged.
-	decision *evidence.FailoverContext
 }
 
 // newRunFailover resolves the tier's fallback candidates (positions >= 1).
@@ -67,7 +69,7 @@ func (r *Runner) newRunFailover(ctx context.Context, req *RunRequest, correlatio
 	}
 	for _, c := range resolved {
 		if c.ChainPosition >= 1 {
-			fo.remaining = append(fo.remaining, c)
+			fo.candidates = append(fo.candidates, c)
 		}
 	}
 	for _, rej := range rejected {
@@ -80,30 +82,41 @@ func (r *Runner) newRunFailover(ctx context.Context, req *RunRequest, correlatio
 	return fo
 }
 
-// generate calls provider.Generate and, on a transient failure, walks the
-// remaining fallback candidates. Returns the response plus the provider and
-// model actually used so the caller's evidence stays truthful.
+// failoverEngagement is the per-LLM-call failover state: one chain walk, one
+// group ID, one terminal record.
+type failoverEngagement struct {
+	fo             *runFailover
+	groupID        string
+	failedAttempts []string
+}
+
+// generate calls provider.Generate and, on a transient failure, opens a fresh
+// failover engagement over the tier's fallback candidates. Returns the
+// response plus the provider and model actually used so the caller's evidence
+// stays truthful.
 func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model string, llmReq *llm.Request) (*llm.Response, llm.Provider, string, error) {
 	resp, err := provider.Generate(ctx, llmReq)
 	if err == nil || f == nil {
 		return resp, provider, model, err
 	}
 	class := llm.ClassifyGenerateError(err)
-	if !class.Transient || (len(f.remaining) == 0 && len(f.skipped) == 0) {
+	if !class.Transient || (len(f.candidates) == 0 && len(f.skipped) == 0) {
 		// Permanent failure, or no fallback chain configured at all:
 		// failover was never engaged; behave exactly as before.
 		return resp, provider, model, err
 	}
 
+	eng := &failoverEngagement{fo: f, groupID: "fog_" + uuid.New().String()[:12]}
 	originalModel := model
-	f.recordAttempt(ctx, provider.Name(), providerJurisdiction(provider), model, class, 0, "", err, 0)
+	eng.recordAttempt(ctx, provider.Name(), providerJurisdiction(provider), model, class, 0, "", err, 0)
 
-	for len(f.remaining) > 0 {
+	remaining := make([]llm.ResolvedCandidate, len(f.candidates))
+	copy(remaining, f.candidates)
+
+	for _, cand := range remaining {
 		if ctx.Err() != nil {
 			break
 		}
-		cand := f.remaining[0]
-		f.remaining = f.remaining[1:]
 		if cand.ProviderName == provider.Name() && cand.Model == model {
 			continue
 		}
@@ -119,6 +132,7 @@ func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model
 
 		log.Info().
 			Str("correlation_id", f.correlationID).
+			Str("failover_group_id", eng.groupID).
 			Str("from_model", model).
 			Str("to_model", cand.Model).
 			Str("error_class", class.Class).
@@ -130,8 +144,9 @@ func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model
 		attemptStart := time.Now()
 		resp, err = p.Generate(ctx, &attemptReq)
 		if err == nil {
-			f.decision = &evidence.FailoverContext{
+			eng.recordTerminal(ctx, &evidence.FailoverContext{
 				Role:              evidence.FailoverRoleFallbackDecision,
+				FailoverGroupID:   eng.groupID,
 				Provider:          cand.ProviderName,
 				Region:            cand.Jurisdiction,
 				Model:             cand.Model,
@@ -139,29 +154,30 @@ func (f *runFailover) generate(ctx context.Context, provider llm.Provider, model
 				FallbackRuleID:    cand.RuleID,
 				SovereigntyMode:   f.sovereigntyMode,
 				SovereigntyCheck:  f.sovereigntyCheck(),
-				FailedAttemptIDs:  f.failedAttempts,
+				FailedAttemptIDs:  eng.failedAttempts,
 				SkippedCandidates: f.skipped,
-			}
+			}, cand.ProviderName, cand.Model)
 			llm.RecordFailover(ctx, originalModel, cand.Model, class.Class)
 			return resp, p, cand.Model, nil
 		}
 		class = llm.ClassifyGenerateError(err)
-		f.recordAttempt(ctx, cand.ProviderName, cand.Jurisdiction, cand.Model, class, cand.ChainPosition, cand.RuleID, err, time.Since(attemptStart).Milliseconds())
+		eng.recordAttempt(ctx, cand.ProviderName, cand.Jurisdiction, cand.Model, class, cand.ChainPosition, cand.RuleID, err, time.Since(attemptStart).Milliseconds())
 		// Once failover is engaged, only success ends the chain: a fallback
 		// candidate failing permanently (bad key, model not on that provider)
 		// is that candidate's problem, not the request's — keep walking.
 	}
 
 	// Chain exhausted: fail closed. The caller receives the error; the
-	// refusal to dispatch further is a governance outcome recorded on the
-	// final run record.
-	f.decision = &evidence.FailoverContext{
+	// refusal to dispatch further is a governance outcome with its own
+	// signed terminal record.
+	eng.recordTerminal(ctx, &evidence.FailoverContext{
 		Role:              evidence.FailoverRoleFailClosed,
+		FailoverGroupID:   eng.groupID,
 		ErrorClass:        class.Class,
 		SovereigntyMode:   f.sovereigntyMode,
-		FailedAttemptIDs:  f.failedAttempts,
+		FailedAttemptIDs:  eng.failedAttempts,
 		SkippedCandidates: f.skipped,
-	}
+	}, "", "")
 	return nil, provider, model, err
 }
 
@@ -173,8 +189,10 @@ func (f *runFailover) sovereigntyCheck() string {
 }
 
 // recordAttempt persists one failed provider attempt as a signed evidence
-// record linked to the run by correlation ID (evidence-by-default).
-func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdiction, model string, class failover.Classification, chainPosition int, ruleID string, genErr error, durationMS int64) {
+// record linked to the run by correlation ID and to this engagement by
+// failover_group_id (evidence-by-default).
+func (e *failoverEngagement) recordAttempt(ctx context.Context, providerName, jurisdiction, model string, class failover.Classification, chainPosition int, ruleID string, genErr error, durationMS int64) {
+	f := e.fo
 	var flow *evidence.DataFlow
 	if f.dataFlow != nil {
 		flow = f.dataFlow(providerName, model)
@@ -199,6 +217,7 @@ func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdict
 		FailureReason:   failureReason,
 		Failover: &evidence.FailoverContext{
 			Role:            evidence.FailoverRoleFailedAttempt,
+			FailoverGroupID: e.groupID,
 			Provider:        providerName,
 			Region:          jurisdiction,
 			Model:           model,
@@ -216,7 +235,44 @@ func (f *runFailover) recordAttempt(ctx context.Context, providerName, jurisdict
 			Msg("evidence_write_failed_failover_attempt")
 		return
 	}
-	f.failedAttempts = append(f.failedAttempts, ev.ID)
+	e.failedAttempts = append(e.failedAttempts, ev.ID)
+}
+
+// recordTerminal persists this engagement's terminal record (fallback
+// decision or fail-closed) as its own signed evidence record. Each LLM call's
+// failover engagement gets exactly one terminal, so the verifier can check
+// every (correlation_id, failover_group_id) chain independently.
+func (e *failoverEngagement) recordTerminal(ctx context.Context, fc *evidence.FailoverContext, selectedProvider, selectedModel string) {
+	f := e.fo
+	params := evidence.GenerateParams{
+		CorrelationID:   f.correlationID,
+		TenantID:        f.req.TenantID,
+		AgentID:         f.req.AgentName,
+		InvocationType:  "llm_failover_decision",
+		RequestSourceID: f.req.InvocationType,
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Classification:  evidence.Classification{InputTier: f.tier},
+		Status:          string(RunStatusCompleted),
+		Failover:        fc,
+	}
+	if fc.Role == evidence.FailoverRoleFailClosed {
+		params.Status = string(RunStatusFailed)
+		params.FailureReason = evidence.FailureReasonNoValidFallbackCandidate
+		params.Error = "no policy-valid fallback candidate succeeded (fail-closed)"
+	} else {
+		params.ModelUsed = selectedModel
+		if f.dataFlow != nil {
+			params.DataFlow = f.dataFlow(selectedProvider, selectedModel)
+		}
+	}
+	if _, err := f.r.evidence.Generate(ctx, params); err != nil {
+		log.Error().Err(err).
+			Str("correlation_id", f.correlationID).
+			Str("failover_group_id", e.groupID).
+			Str("tenant_id", f.req.TenantID).
+			Str("agent_id", f.req.AgentName).
+			Msg("evidence_write_failed_failover_terminal")
+	}
 }
 
 func providerJurisdiction(p llm.Provider) string {

--- a/internal/agent/runner_failover_test.go
+++ b/internal/agent/runner_failover_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/dativo-io/talon/internal/testutil"
 )
 
-// flakyProvider fails Generate with the given error until failCount calls
-// have happened, then succeeds.
+// flakyProvider fails Generate with the given error until failWith is
+// cleared, then succeeds.
 type flakyProvider struct {
 	name         string
 	jurisdiction string
@@ -59,6 +59,23 @@ func newFailoverTestRunner(t *testing.T, providers map[string]llm.Provider, rout
 	}, store
 }
 
+// runFailoverRecords splits a correlation's records into failed attempts and
+// per-engagement terminal records.
+func runFailoverRecords(t *testing.T, store *evidence.Store, correlationID string) (attempts, terminals []*evidence.Evidence) {
+	t.Helper()
+	records, err := store.ListByCorrelationID(context.Background(), correlationID)
+	require.NoError(t, err)
+	for _, ev := range records {
+		switch ev.InvocationType {
+		case "llm_failover_attempt":
+			attempts = append(attempts, ev)
+		case "llm_failover_decision":
+			terminals = append(terminals, ev)
+		}
+	}
+	return attempts, terminals
+}
+
 func TestRunFailover_TransientErrorFailsOverToChainCandidate(t *testing.T) {
 	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "server_error", Provider: "openai", Message: "boom"}}
 	backup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL"}
@@ -79,21 +96,28 @@ func TestRunFailover_TransientErrorFailsOverToChainCandidate(t *testing.T) {
 	assert.Equal(t, 1, primary.calls)
 	assert.Equal(t, 1, backup.calls)
 
-	require.NotNil(t, fo.decision)
-	assert.Equal(t, evidence.FailoverRoleFallbackDecision, fo.decision.Role)
-	assert.Equal(t, "ollama", fo.decision.Provider)
-	assert.Len(t, fo.decision.FailedAttemptIDs, 1)
-
-	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-1")
-	require.NoError(t, err)
-	require.Len(t, records, 1, "one failed-attempt record")
-	att := records[0]
-	assert.Equal(t, "llm_failover_attempt", att.InvocationType)
+	attempts, terminals := runFailoverRecords(t, store, "corr-fo-1")
+	require.Len(t, attempts, 1, "one failed-attempt record")
+	att := attempts[0]
 	assert.Equal(t, evidence.FailoverRoleFailedAttempt, att.Failover.Role)
 	assert.Equal(t, "openai", att.Failover.Provider)
 	assert.Equal(t, "upstream_5xx", att.Failover.ErrorClass)
 	assert.Equal(t, evidence.FailureReasonProviderTransient, att.FailureReason)
+	assert.NotEmpty(t, att.Failover.FailoverGroupID)
 	assert.True(t, store.VerifyRecord(att))
+
+	require.Len(t, terminals, 1, "one terminal record per engagement")
+	dec := terminals[0]
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, dec.Failover.Role)
+	assert.Equal(t, "ollama", dec.Failover.Provider)
+	assert.Equal(t, att.Failover.FailoverGroupID, dec.Failover.FailoverGroupID, "attempt and terminal share a group")
+	assert.Equal(t, []string{att.ID}, dec.Failover.FailedAttemptIDs)
+	assert.True(t, store.VerifyRecord(dec))
+
+	finding, err := store.VerifyFailoverChain(context.Background(), "corr-fo-1")
+	require.NoError(t, err)
+	require.NotNil(t, finding)
+	assert.Equal(t, evidence.FailoverVerdictValidFallback, finding.Verdict, "details: %v", finding.Details)
 }
 
 func TestRunFailover_PermanentErrorDoesNotFailOver(t *testing.T) {
@@ -111,7 +135,6 @@ func TestRunFailover_PermanentErrorDoesNotFailOver(t *testing.T) {
 		primary, "gpt-4o", &llm.Request{Model: "gpt-4o"})
 	require.Error(t, err)
 	assert.Equal(t, 0, backup.calls, "permanent errors must not trigger failover")
-	assert.Nil(t, fo.decision)
 
 	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-2")
 	require.NoError(t, err)
@@ -133,13 +156,16 @@ func TestRunFailover_AllCandidatesFail_FailsClosed(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, 1, backup.calls)
 
-	require.NotNil(t, fo.decision)
-	assert.Equal(t, evidence.FailoverRoleFailClosed, fo.decision.Role)
-	assert.Len(t, fo.decision.FailedAttemptIDs, 2)
+	attempts, terminals := runFailoverRecords(t, store, "corr-fo-3")
+	assert.Len(t, attempts, 2, "both failed attempts evidenced")
+	require.Len(t, terminals, 1)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, terminals[0].Failover.Role)
+	assert.Equal(t, evidence.FailureReasonNoValidFallbackCandidate, terminals[0].FailureReason)
+	assert.Len(t, terminals[0].Failover.FailedAttemptIDs, 2)
 
-	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-3")
+	finding, err := store.VerifyFailoverChain(context.Background(), "corr-fo-3")
 	require.NoError(t, err)
-	assert.Len(t, records, 2, "both failed attempts evidenced")
+	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
 }
 
 // Once failover is engaged, a permanently failing fallback candidate is
@@ -164,18 +190,15 @@ func TestRunFailover_ChainContinuesPastPermanentFallback(t *testing.T) {
 	assert.Equal(t, 1, badBackup.calls)
 	assert.Equal(t, 1, goodBackup.calls)
 
-	require.NotNil(t, fo.decision)
-	assert.Equal(t, evidence.FailoverRoleFallbackDecision, fo.decision.Role)
-	assert.Equal(t, "ollama", fo.decision.Provider)
-	assert.Len(t, fo.decision.FailedAttemptIDs, 2)
-
-	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-5")
-	require.NoError(t, err)
-	require.Len(t, records, 2)
-	assert.Equal(t, evidence.FailureReasonProviderTransient, records[0].FailureReason)
-	assert.Equal(t, "auth_error", records[1].Failover.ErrorClass)
-	assert.Equal(t, evidence.FailureReasonProviderPermanent, records[1].FailureReason,
+	attempts, terminals := runFailoverRecords(t, store, "corr-fo-5")
+	require.Len(t, attempts, 2)
+	assert.Equal(t, evidence.FailureReasonProviderTransient, attempts[0].FailureReason)
+	assert.Equal(t, "auth_error", attempts[1].Failover.ErrorClass)
+	assert.Equal(t, evidence.FailureReasonProviderPermanent, attempts[1].FailureReason,
 		"failure_reason must not contradict the error class")
+	require.Len(t, terminals, 1)
+	assert.Equal(t, "ollama", terminals[0].Failover.Provider)
+	assert.Len(t, terminals[0].Failover.FailedAttemptIDs, 2)
 }
 
 func TestRunFailover_ComplianceModeExcludesSovereigntyRejectedCandidates(t *testing.T) {
@@ -193,21 +216,56 @@ func TestRunFailover_ComplianceModeExcludesSovereigntyRejectedCandidates(t *test
 	require.Error(t, err)
 	assert.Equal(t, 0, usBackup.calls, "sovereignty-rejected candidate must never be dispatched")
 
-	require.NotNil(t, fo.decision)
-	assert.Equal(t, evidence.FailoverRoleFailClosed, fo.decision.Role)
+	attempts, terminals := runFailoverRecords(t, store, "corr-fo-4")
+	require.Len(t, attempts, 1)
+	require.Len(t, terminals, 1)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, terminals[0].Failover.Role)
+	assert.NotEmpty(t, terminals[0].Failover.SkippedCandidates)
 
-	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-4")
+	finding, err := store.VerifyFailoverChain(context.Background(), "corr-fo-4")
 	require.NoError(t, err)
-	require.Len(t, records, 1)
-	finding := evidence.VerifyFailoverRecords("corr-fo-4", append(records, failClosedRunRecord("corr-fo-4", fo.decision)), nil)
 	require.NotNil(t, finding)
 	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
 }
 
-// failClosedRunRecord simulates the run's final evidence record carrying the
-// fail-closed decision (the real record is written by executeLLMPipeline).
-func failClosedRunRecord(correlationID string, fc *evidence.FailoverContext) *evidence.Evidence {
-	return &evidence.Evidence{ID: "req_final", CorrelationID: correlationID, Failover: fc}
+// An agentic run makes many LLM calls under one correlation ID: every call
+// gets its own failover engagement with a fresh chain walk and its own group,
+// and each group verifies independently.
+func TestRunFailover_MultipleEngagementsPerRun_GetSeparateGroups(t *testing.T) {
+	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "server_error", Provider: "openai"}}
+	backup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL"}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"llama3:70b"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"openai": primary, "ollama": backup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-6", 1, nil, "", nil)
+
+	// Call 1: primary fails, fallback succeeds.
+	_, p1, m1, err := fo.generate(context.Background(), primary, "gpt-4o", &llm.Request{Model: "gpt-4o"})
+	require.NoError(t, err)
+
+	// Call 2 (same run, later loop iteration): the now-current provider
+	// fails too — the engagement must walk a FRESH chain copy, not the
+	// consumed remainder of call 1.
+	backup.failWith = &llm.ProviderError{Code: "server_error", Provider: "ollama"}
+	_, _, _, err = fo.generate(context.Background(), p1, m1, &llm.Request{Model: m1})
+	require.Error(t, err, "no other candidate remains for call 2")
+
+	attempts, terminals := runFailoverRecords(t, store, "corr-fo-6")
+	require.Len(t, terminals, 2, "each engagement gets its own terminal record")
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, terminals[0].Failover.Role)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, terminals[1].Failover.Role,
+		"call 2's outcome must not inherit call 1's successful decision")
+	assert.NotEqual(t, terminals[0].Failover.FailoverGroupID, terminals[1].Failover.FailoverGroupID,
+		"engagements must not share a failover group")
+	require.Len(t, attempts, 2)
+
+	finding, err := store.VerifyFailoverChain(context.Background(), "corr-fo-6")
+	require.NoError(t, err)
+	require.NotNil(t, finding)
+	assert.True(t, finding.OK(), "both groups must verify independently: %v", finding.Details)
 }
 
 // euOnlyRoutingEvaluator rejects non-EU/LOCAL jurisdictions (eu_strict stub).

--- a/internal/agent/runner_failover_test.go
+++ b/internal/agent/runner_failover_test.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/llm"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// flakyProvider fails Generate with the given error until failCount calls
+// have happened, then succeeds.
+type flakyProvider struct {
+	name         string
+	jurisdiction string
+	failWith     error
+	calls        int
+}
+
+func (p *flakyProvider) Name() string { return p.name }
+func (p *flakyProvider) Metadata() llm.ProviderMetadata {
+	return llm.ProviderMetadata{ID: p.name, DisplayName: p.name, Jurisdiction: p.jurisdiction}
+}
+
+func (p *flakyProvider) Generate(_ context.Context, req *llm.Request) (*llm.Response, error) {
+	p.calls++
+	if p.failWith != nil {
+		return nil, p.failWith
+	}
+	return &llm.Response{Content: "ok from " + p.name, Model: req.Model, InputTokens: 1, OutputTokens: 1}, nil
+}
+
+func (p *flakyProvider) Stream(_ context.Context, _ *llm.Request, ch chan<- llm.StreamChunk) error {
+	close(ch)
+	return nil
+}
+func (p *flakyProvider) EstimateCost(string, int, int) float64    { return 0.0001 }
+func (p *flakyProvider) ValidateConfig() error                    { return nil }
+func (p *flakyProvider) HealthCheck(context.Context) error        { return nil }
+func (p *flakyProvider) WithHTTPClient(*http.Client) llm.Provider { return p }
+
+func newFailoverTestRunner(t *testing.T, providers map[string]llm.Provider, routing *policy.ModelRoutingConfig) (*Runner, *evidence.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return &Runner{
+		router:        llm.NewRouter(routing, providers, nil),
+		evidence:      evidence.NewGenerator(store),
+		evidenceStore: store,
+	}, store
+}
+
+func TestRunFailover_TransientErrorFailsOverToChainCandidate(t *testing.T) {
+	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "server_error", Provider: "openai", Message: "boom"}}
+	backup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL"}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"llama3:70b"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"openai": primary, "ollama": backup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-1", 1, nil, "", nil)
+
+	resp, usedProvider, usedModel, err := fo.generate(context.Background(),
+		primary, "gpt-4o", &llm.Request{Model: "gpt-4o", Messages: []llm.Message{{Role: "user", Content: "hi"}}})
+	require.NoError(t, err)
+	assert.Equal(t, "ok from ollama", resp.Content)
+	assert.Equal(t, "ollama", usedProvider.Name())
+	assert.Equal(t, "llama3:70b", usedModel)
+	assert.Equal(t, 1, primary.calls)
+	assert.Equal(t, 1, backup.calls)
+
+	require.NotNil(t, fo.decision)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, fo.decision.Role)
+	assert.Equal(t, "ollama", fo.decision.Provider)
+	assert.Len(t, fo.decision.FailedAttemptIDs, 1)
+
+	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-1")
+	require.NoError(t, err)
+	require.Len(t, records, 1, "one failed-attempt record")
+	att := records[0]
+	assert.Equal(t, "llm_failover_attempt", att.InvocationType)
+	assert.Equal(t, evidence.FailoverRoleFailedAttempt, att.Failover.Role)
+	assert.Equal(t, "openai", att.Failover.Provider)
+	assert.Equal(t, "upstream_5xx", att.Failover.ErrorClass)
+	assert.Equal(t, evidence.FailureReasonProviderTransient, att.FailureReason)
+	assert.True(t, store.VerifyRecord(att))
+}
+
+func TestRunFailover_PermanentErrorDoesNotFailOver(t *testing.T) {
+	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "auth_failed", Provider: "openai", Message: "bad key"}}
+	backup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL"}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"llama3:70b"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"openai": primary, "ollama": backup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-2", 1, nil, "", nil)
+
+	_, _, _, err := fo.generate(context.Background(),
+		primary, "gpt-4o", &llm.Request{Model: "gpt-4o"})
+	require.Error(t, err)
+	assert.Equal(t, 0, backup.calls, "permanent errors must not trigger failover")
+	assert.Nil(t, fo.decision)
+
+	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-2")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestRunFailover_AllCandidatesFail_FailsClosed(t *testing.T) {
+	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "server_error", Provider: "openai"}}
+	backup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL", failWith: &llm.ProviderError{Code: "rate_limit", Provider: "ollama"}}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"llama3:70b"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"openai": primary, "ollama": backup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-3", 1, nil, "", nil)
+
+	_, _, _, err := fo.generate(context.Background(), primary, "gpt-4o", &llm.Request{Model: "gpt-4o"})
+	require.Error(t, err)
+	assert.Equal(t, 1, backup.calls)
+
+	require.NotNil(t, fo.decision)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, fo.decision.Role)
+	assert.Len(t, fo.decision.FailedAttemptIDs, 2)
+
+	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-3")
+	require.NoError(t, err)
+	assert.Len(t, records, 2, "both failed attempts evidenced")
+}
+
+func TestRunFailover_ComplianceModeExcludesSovereigntyRejectedCandidates(t *testing.T) {
+	primary := &flakyProvider{name: "ollama", jurisdiction: "LOCAL", failWith: &llm.ProviderError{Code: "server_error", Provider: "ollama"}}
+	usBackup := &flakyProvider{name: "openai", jurisdiction: "US"}
+	routing := &policy.ModelRoutingConfig{
+		Tier2: &policy.TierConfig{Primary: "llama3:70b", FallbackChain: []string{"gpt-4o"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"ollama": primary, "openai": usBackup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-4", 2, euOnlyRoutingEvaluator{}, "eu_strict", nil)
+
+	_, _, _, err := fo.generate(context.Background(), primary, "llama3:70b", &llm.Request{Model: "llama3:70b"})
+	require.Error(t, err)
+	assert.Equal(t, 0, usBackup.calls, "sovereignty-rejected candidate must never be dispatched")
+
+	require.NotNil(t, fo.decision)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, fo.decision.Role)
+
+	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-4")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	finding := evidence.VerifyFailoverRecords("corr-fo-4", append(records, failClosedRunRecord("corr-fo-4", fo.decision)), nil)
+	require.NotNil(t, finding)
+	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
+}
+
+// failClosedRunRecord simulates the run's final evidence record carrying the
+// fail-closed decision (the real record is written by executeLLMPipeline).
+func failClosedRunRecord(correlationID string, fc *evidence.FailoverContext) *evidence.Evidence {
+	return &evidence.Evidence{ID: "req_final", CorrelationID: correlationID, Failover: fc}
+}
+
+// euOnlyRoutingEvaluator rejects non-EU/LOCAL jurisdictions (eu_strict stub).
+type euOnlyRoutingEvaluator struct{}
+
+func (euOnlyRoutingEvaluator) EvaluateRouting(_ context.Context, in *policy.RoutingInput) (*policy.Decision, error) {
+	if in.ProviderJurisdiction == "EU" || in.ProviderJurisdiction == "LOCAL" {
+		return &policy.Decision{Allowed: true}, nil
+	}
+	return &policy.Decision{Allowed: false, Reasons: []string{"sovereignty: not allowed"}}, nil
+}

--- a/internal/agent/runner_failover_test.go
+++ b/internal/agent/runner_failover_test.go
@@ -142,6 +142,42 @@ func TestRunFailover_AllCandidatesFail_FailsClosed(t *testing.T) {
 	assert.Len(t, records, 2, "both failed attempts evidenced")
 }
 
+// Once failover is engaged, a permanently failing fallback candidate is
+// evidenced (with a permanent failure reason) and the chain keeps walking.
+func TestRunFailover_ChainContinuesPastPermanentFallback(t *testing.T) {
+	primary := &flakyProvider{name: "openai", jurisdiction: "US", failWith: &llm.ProviderError{Code: "server_error", Provider: "openai"}}
+	badBackup := &flakyProvider{name: "anthropic", jurisdiction: "US", failWith: &llm.ProviderError{Code: "auth_failed", Provider: "anthropic"}}
+	goodBackup := &flakyProvider{name: "ollama", jurisdiction: "LOCAL"}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"claude-sonnet-4-20250514", "llama3:70b"}},
+	}
+	r, store := newFailoverTestRunner(t, map[string]llm.Provider{"openai": primary, "anthropic": badBackup, "ollama": goodBackup}, routing)
+
+	req := &RunRequest{TenantID: "t1", AgentName: "a1", InvocationType: "manual"}
+	fo := r.newRunFailover(context.Background(), req, "corr-fo-5", 1, nil, "", nil)
+
+	resp, usedProvider, usedModel, err := fo.generate(context.Background(), primary, "gpt-4o", &llm.Request{Model: "gpt-4o"})
+	require.NoError(t, err)
+	assert.Equal(t, "ok from ollama", resp.Content)
+	assert.Equal(t, "ollama", usedProvider.Name())
+	assert.Equal(t, "llama3:70b", usedModel)
+	assert.Equal(t, 1, badBackup.calls)
+	assert.Equal(t, 1, goodBackup.calls)
+
+	require.NotNil(t, fo.decision)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, fo.decision.Role)
+	assert.Equal(t, "ollama", fo.decision.Provider)
+	assert.Len(t, fo.decision.FailedAttemptIDs, 2)
+
+	records, err := store.ListByCorrelationID(context.Background(), "corr-fo-5")
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, evidence.FailureReasonProviderTransient, records[0].FailureReason)
+	assert.Equal(t, "auth_error", records[1].Failover.ErrorClass)
+	assert.Equal(t, evidence.FailureReasonProviderPermanent, records[1].FailureReason,
+		"failure_reason must not contradict the error class")
+}
+
 func TestRunFailover_ComplianceModeExcludesSovereigntyRejectedCandidates(t *testing.T) {
 	primary := &flakyProvider{name: "ollama", jurisdiction: "LOCAL", failWith: &llm.ProviderError{Code: "server_error", Provider: "ollama"}}
 	usBackup := &flakyProvider{name: "openai", jurisdiction: "US"}

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -30,6 +30,7 @@ var (
 	auditViolationsOnly bool
 	auditOutputFile     string
 	auditVerifyFile     string
+	auditVerifyFailover bool
 )
 
 var auditCmd = &cobra.Command{
@@ -52,7 +53,7 @@ var auditShowCmd = &cobra.Command{
 
 var auditVerifyCmd = &cobra.Command{
 	Use:   "verify [evidence-id]",
-	Short: "Verify HMAC signature of an evidence record",
+	Short: "Verify HMAC signature of an evidence record (--failover: semantic fallback-chain verification)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  auditVerify,
 }
@@ -69,6 +70,7 @@ func init() {
 	auditListCmd.Flags().IntVar(&auditLimit, "limit", 20, "Maximum records to show")
 
 	auditVerifyCmd.Flags().StringVar(&auditVerifyFile, "file", "", "Verify all records from a signed export file")
+	auditVerifyCmd.Flags().BoolVar(&auditVerifyFailover, "failover", false, "Verify provider fallback chains: with a correlation ID argument verifies that chain; without, verifies all failover evidence")
 	auditExportCmd.Flags().StringVar(&auditExportFmt, "format", "csv", "Output format: csv, json, ndjson, signed-json, signed-ndjson, or html")
 	auditExportCmd.Flags().StringVar(&auditFrom, "from", "", "Start date (YYYY-MM-DD)")
 	auditExportCmd.Flags().StringVar(&auditTo, "to", "", "End date (YYYY-MM-DD)")
@@ -166,6 +168,13 @@ func auditVerify(cmd *cobra.Command, args []string) error {
 	}
 	defer store.Close()
 
+	if auditVerifyFailover {
+		if auditVerifyFile != "" {
+			return fmt.Errorf("use either --failover or --file, not both")
+		}
+		return auditVerifyFailoverChains(ctx, store, args)
+	}
+
 	if auditVerifyFile != "" {
 		if len(args) > 0 {
 			return fmt.Errorf("use either evidence ID or --file, not both")
@@ -202,6 +211,59 @@ func auditVerify(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("signature verification failed for %s", evidenceID)
 	}
 	return nil
+}
+
+// auditVerifyFailoverChains runs the semantic failover verifier: with an
+// argument, over that correlation ID; without, over all correlation IDs that
+// carry failover evidence. Non-zero exit when any chain is invalid or
+// insufficient.
+func auditVerifyFailoverChains(ctx context.Context, store *evidence.Store, args []string) error {
+	var correlationIDs []string
+	if len(args) > 0 {
+		correlationIDs = []string{args[0]}
+	} else {
+		ids, err := store.ListFailoverCorrelationIDs(ctx, 1000)
+		if err != nil {
+			return fmt.Errorf("listing failover evidence: %w", err)
+		}
+		correlationIDs = ids
+	}
+	if len(correlationIDs) == 0 {
+		fmt.Fprintln(os.Stdout, "No failover evidence found.")
+		return nil
+	}
+	failed := 0
+	checked := 0
+	for _, id := range correlationIDs {
+		finding, err := store.VerifyFailoverChain(ctx, id)
+		if err != nil {
+			return fmt.Errorf("verifying failover chain %s: %w", id, err)
+		}
+		if finding == nil {
+			continue
+		}
+		checked++
+		renderFailoverFinding(os.Stdout, finding)
+		if !finding.OK() {
+			failed++
+		}
+	}
+	fmt.Fprintf(os.Stdout, "\nFailover chains checked: %d, failed: %d\n", checked, failed)
+	if failed > 0 {
+		return fmt.Errorf("%d failover chain(s) failed verification", failed)
+	}
+	return nil
+}
+
+func renderFailoverFinding(w io.Writer, f *evidence.FailoverFinding) {
+	status := "PASS"
+	if !f.OK() {
+		status = "FAIL"
+	}
+	fmt.Fprintf(w, "[%s] %s  verdict=%s  records=%s\n", status, f.CorrelationID, f.Verdict, strings.Join(f.EvidenceIDs, ","))
+	for _, d := range f.Details {
+		fmt.Fprintf(w, "       - %s\n", d)
+	}
 }
 
 func auditExport(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -160,12 +160,14 @@ func initConfig() {
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Search in ~/.talon/ and current directory
+		// Search the current directory first, then ~/.talon — the project's
+		// own talon.config.yaml must win over a machine-wide one (this is
+		// also the documented order of the --config default).
+		viper.AddConfigPath(".")
 		home, err := os.UserHomeDir()
 		if err == nil {
 			viper.AddConfigPath(home + "/.talon")
 		}
-		viper.AddConfigPath(".")
 		viper.SetConfigName("talon.config")
 		viper.SetConfigType("yaml")
 	}

--- a/internal/cmd/root_config_order_test.go
+++ b/internal/cmd/root_config_order_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/config"
+)
+
+// The documented --config default is "./talon.config.yaml or
+// ~/.talon/talon.config.yaml": the project-local config must win over a
+// machine-wide one, or per-project settings (sovereignty mode, cache,
+// compliance declarations) are silently overridden by whatever happens to
+// live in the operator's home directory.
+func TestInitConfig_CurrentDirWinsOverHomeConfig(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".talon"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".talon", "talon.config.yaml"),
+		[]byte("log_level: error\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "talon.config.yaml"),
+		[]byte("log_level: debug\n"), 0o644))
+
+	t.Setenv("HOME", homeDir)
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workDir))
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	oldCfgFile := cfgFile
+	cfgFile = ""
+	t.Cleanup(func() {
+		cfgFile = oldCfgFile
+		// viper.Reset wipes the init()-time registrations of the config and
+		// cmd packages; restore them for later tests in this binary (same
+		// pattern as internal/config/config_test.go).
+		viper.Reset()
+		viper.SetEnvPrefix("TALON")
+		viper.AutomaticEnv()
+		viper.SetDefault(config.KeyDefaultPolicy, config.DefaultPolicy)
+		viper.SetDefault(config.KeyMaxAttachmentMB, config.DefaultMaxAttachMB)
+		viper.SetDefault(config.KeyOllamaBaseURL, config.DefaultOllamaURL)
+		_ = viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level"))
+		_ = viper.BindPFlag("log_format", rootCmd.PersistentFlags().Lookup("log-format"))
+	})
+
+	initConfig()
+	require.Equal(t, "debug", viper.GetString("log_level"),
+		"project-local talon.config.yaml must take precedence over ~/.talon")
+}

--- a/internal/compliance/mapping.go
+++ b/internal/compliance/mapping.go
@@ -21,6 +21,7 @@ func DefaultMappings() []ControlMapping {
 		{Framework: "eu-ai-act", Article: "Art. 14", Control: "Human oversight via plan review gate", Source: "internal/agent/plan_review.go"},
 		{Framework: "nis2", Article: "Art. 21", Control: "Risk controls, policy enforcement, and monitoring", Source: "internal/policy/engine.go"},
 		{Framework: "dora", Article: "Art. 6", Control: "ICT risk management via policy-as-code cost and resource limits", Source: "internal/policy/engine.go"},
+		{Framework: "dora", Article: "Art. 7", Control: "Reliable ICT systems: error-driven, sovereignty-filtered provider fallback chains with signed failed-attempt and fallback-decision evidence", Source: "internal/failover/failover.go"},
 		{Framework: "dora", Article: "Art. 11", Control: "ICT incident traceability with signed audit trail", Source: "internal/evidence/store.go"},
 		{Framework: "iso-27001", Article: "A.8.15", Control: "Cryptographic integrity of logs (HMAC)", Source: "internal/evidence/signature.go"},
 		{Framework: "iso-27001", Article: "A.8.16", Control: "Monitoring and governance metrics", Source: "internal/gateway/metrics.go"},

--- a/internal/evidence/failover_verifier.go
+++ b/internal/evidence/failover_verifier.go
@@ -1,0 +1,193 @@
+package evidence
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Failover verifier verdicts (semantic rules layered on top of per-record
+// HMAC verification):
+//
+//   - valid_fallback: failed attempt(s) + fallback decision share the
+//     correlation ID, the dispatched provider passed the sovereignty check.
+//   - valid_fail_closed: failed attempt(s) and/or policy-skipped candidates
+//     with no successful provider dispatch — the governance layer refusing to
+//     route (e.g. out of Europe under eu_strict) is a successful outcome.
+//   - invalid: fallback was dispatched to a provider the sovereignty policy
+//     rejected, or an involved record fails signature verification.
+//   - insufficient: evidence records the final provider without the failed
+//     attempt and decision context (proves where the answer came from but not
+//     why traffic moved there), or attempts exist with no decision record.
+const (
+	FailoverVerdictValidFallback   = "valid_fallback"
+	FailoverVerdictValidFailClosed = "valid_fail_closed"
+	FailoverVerdictInvalid         = "invalid"
+	FailoverVerdictInsufficient    = "insufficient"
+)
+
+// FailoverFinding is the verifier outcome for one correlation ID.
+type FailoverFinding struct {
+	CorrelationID string   `json:"correlation_id"`
+	Verdict       string   `json:"verdict"`
+	Details       []string `json:"details,omitempty"`
+	EvidenceIDs   []string `json:"evidence_ids,omitempty"`
+}
+
+// OK reports whether the finding is a passing verdict.
+func (f *FailoverFinding) OK() bool {
+	return f.Verdict == FailoverVerdictValidFallback || f.Verdict == FailoverVerdictValidFailClosed
+}
+
+// VerifyFailoverChain loads all records sharing a correlation ID and applies
+// the failover verifier rules. Returns nil when the correlation ID has no
+// failover-related evidence.
+func (s *Store) VerifyFailoverChain(ctx context.Context, correlationID string) (*FailoverFinding, error) {
+	records, err := s.ListByCorrelationID(ctx, correlationID)
+	if err != nil {
+		return nil, err
+	}
+	return VerifyFailoverRecords(correlationID, records, s.VerifyRecord), nil
+}
+
+// ListFailoverCorrelationIDs returns correlation IDs that have failover
+// evidence, newest first, up to limit.
+func (s *Store) ListFailoverCorrelationIDs(ctx context.Context, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT correlation_id FROM evidence
+		 WHERE invocation_type IN ('gateway_failover_attempt', 'llm_failover_attempt')
+		    OR evidence_json LIKE '%"failover":%'
+		 GROUP BY correlation_id
+		 ORDER BY MAX(timestamp) DESC
+		 LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying failover correlation ids: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning correlation id: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// VerifyFailoverRecords applies the failover verifier rules to the records of
+// one correlation ID. verifySig verifies a record's HMAC signature (pass
+// Store.VerifyRecord; a nil func skips signature checks — tests only).
+// Returns nil when no record carries failover context.
+//
+//nolint:gocyclo // rule evaluation is a flat sequence of independent checks
+func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig func(*Evidence) bool) *FailoverFinding {
+	attempts := map[string]*Evidence{}
+	var decisions, failClosed []*Evidence
+	var involved []*Evidence
+	for _, ev := range records {
+		if ev.Failover == nil {
+			continue
+		}
+		involved = append(involved, ev)
+		switch ev.Failover.Role {
+		case FailoverRoleFailedAttempt:
+			attempts[ev.ID] = ev
+		case FailoverRoleFallbackDecision:
+			decisions = append(decisions, ev)
+		case FailoverRoleFailClosed:
+			failClosed = append(failClosed, ev)
+		}
+	}
+	if len(involved) == 0 {
+		return nil
+	}
+
+	finding := &FailoverFinding{CorrelationID: correlationID}
+	for _, ev := range involved {
+		finding.EvidenceIDs = append(finding.EvidenceIDs, ev.ID)
+	}
+	worst := ""
+	addDetail := func(verdict, detail string) {
+		finding.Details = append(finding.Details, detail)
+		if verdict == FailoverVerdictInvalid || worst == FailoverVerdictInvalid {
+			worst = FailoverVerdictInvalid
+			return
+		}
+		worst = FailoverVerdictInsufficient
+	}
+
+	// Rule 0: every involved record must carry a valid signature.
+	if verifySig != nil {
+		for _, ev := range involved {
+			if !verifySig(ev) {
+				addDetail(FailoverVerdictInvalid, fmt.Sprintf("record %s fails signature verification", ev.ID))
+			}
+		}
+	}
+
+	checkAttemptRefs := func(ev *Evidence) {
+		if len(ev.Failover.FailedAttemptIDs) == 0 {
+			addDetail(FailoverVerdictInsufficient,
+				fmt.Sprintf("record %s (%s) has no linked failed-attempt records: evidence proves the final provider but not why traffic moved", ev.ID, ev.Failover.Role))
+			return
+		}
+		for _, id := range ev.Failover.FailedAttemptIDs {
+			if _, ok := attempts[id]; !ok {
+				addDetail(FailoverVerdictInsufficient,
+					fmt.Sprintf("record %s references failed attempt %s which is missing from the correlation trail", ev.ID, id))
+			}
+		}
+	}
+
+	// Rule 1+3: fallback decisions must link failed attempts and must not have
+	// dispatched to a sovereignty-rejected provider.
+	for _, ev := range decisions {
+		fc := ev.Failover
+		checkAttemptRefs(ev)
+		if strings.EqualFold(strings.TrimSpace(fc.SovereigntyMode), "eu_strict") {
+			region := strings.ToUpper(strings.TrimSpace(fc.Region))
+			if fc.SovereigntyCheck != "allowed" || (region != "EU" && region != "LOCAL") {
+				addDetail(FailoverVerdictInvalid,
+					fmt.Sprintf("record %s dispatched fallback to provider %s (region %q, sovereignty_check %q) under eu_strict", ev.ID, fc.Provider, fc.Region, fc.SovereigntyCheck))
+			}
+		}
+	}
+
+	// Rule 2: fail-closed outcomes must show why nothing was dispatched
+	// (failed attempts and/or policy-skipped candidates).
+	for _, ev := range failClosed {
+		if len(ev.Failover.FailedAttemptIDs) == 0 && len(ev.Failover.SkippedCandidates) == 0 {
+			addDetail(FailoverVerdictInsufficient,
+				fmt.Sprintf("fail-closed record %s has neither failed attempts nor skipped candidates", ev.ID))
+			continue
+		}
+		for _, id := range ev.Failover.FailedAttemptIDs {
+			if _, ok := attempts[id]; !ok {
+				addDetail(FailoverVerdictInsufficient,
+					fmt.Sprintf("fail-closed record %s references failed attempt %s which is missing from the correlation trail", ev.ID, id))
+			}
+		}
+	}
+
+	// Rule 4: failed attempts with no decision context are insufficient —
+	// the trail shows an error but not the governance outcome.
+	if len(decisions) == 0 && len(failClosed) == 0 {
+		addDetail(FailoverVerdictInsufficient,
+			"failed provider attempt(s) recorded without a fallback decision or fail-closed record")
+	}
+
+	if worst != "" {
+		finding.Verdict = worst
+		return finding
+	}
+	if len(decisions) > 0 {
+		finding.Verdict = FailoverVerdictValidFallback
+		return finding
+	}
+	finding.Verdict = FailoverVerdictValidFailClosed
+	return finding
+}

--- a/internal/evidence/failover_verifier.go
+++ b/internal/evidence/failover_verifier.go
@@ -79,28 +79,26 @@ func (s *Store) ListFailoverCorrelationIDs(ctx context.Context, limit int) ([]st
 }
 
 // VerifyFailoverRecords applies the failover verifier rules to the records of
-// one correlation ID. verifySig verifies a record's HMAC signature (pass
-// Store.VerifyRecord; a nil func skips signature checks — tests only).
+// one correlation ID. Records are grouped by failover_group_id — one group
+// per failover engagement (a gateway request, or one LLM call within an
+// agentic run that may make many) — and each group must independently
+// satisfy the chain invariants. verifySig verifies a record's HMAC signature
+// (pass Store.VerifyRecord; a nil func skips signature checks — tests only).
 // Returns nil when no record carries failover context.
-//
-//nolint:gocyclo // rule evaluation is a flat sequence of independent checks
 func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig func(*Evidence) bool) *FailoverFinding {
-	attempts := map[string]*Evidence{}
-	var decisions, failClosed []*Evidence
+	groups := map[string][]*Evidence{}
+	var groupOrder []string
 	var involved []*Evidence
 	for _, ev := range records {
 		if ev.Failover == nil {
 			continue
 		}
 		involved = append(involved, ev)
-		switch ev.Failover.Role {
-		case FailoverRoleFailedAttempt:
-			attempts[ev.ID] = ev
-		case FailoverRoleFallbackDecision:
-			decisions = append(decisions, ev)
-		case FailoverRoleFailClosed:
-			failClosed = append(failClosed, ev)
+		gid := ev.Failover.FailoverGroupID
+		if _, seen := groups[gid]; !seen {
+			groupOrder = append(groupOrder, gid)
 		}
+		groups[gid] = append(groups[gid], ev)
 	}
 	if len(involved) == 0 {
 		return nil
@@ -129,6 +127,44 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 		}
 	}
 
+	sawDecision := false
+	for _, gid := range groupOrder {
+		if verifyFailoverGroup(groups[gid], addDetail) {
+			sawDecision = true
+		}
+	}
+
+	if worst != "" {
+		finding.Verdict = worst
+		return finding
+	}
+	if sawDecision {
+		finding.Verdict = FailoverVerdictValidFallback
+		return finding
+	}
+	finding.Verdict = FailoverVerdictValidFailClosed
+	return finding
+}
+
+// verifyFailoverGroup applies the chain invariants to one failover
+// engagement's records. Returns true when the group's terminal record is a
+// fallback decision (successful dispatch).
+//
+//nolint:gocyclo // rule evaluation is a flat sequence of independent checks
+func verifyFailoverGroup(records []*Evidence, addDetail func(verdict, detail string)) (hasDecision bool) {
+	attempts := map[string]*Evidence{}
+	var decisions, failClosed []*Evidence
+	for _, ev := range records {
+		switch ev.Failover.Role {
+		case FailoverRoleFailedAttempt:
+			attempts[ev.ID] = ev
+		case FailoverRoleFallbackDecision:
+			decisions = append(decisions, ev)
+		case FailoverRoleFailClosed:
+			failClosed = append(failClosed, ev)
+		}
+	}
+
 	checkAttemptRefs := func(ev *Evidence) {
 		if len(ev.Failover.FailedAttemptIDs) == 0 {
 			addDetail(FailoverVerdictInsufficient,
@@ -144,12 +180,11 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 	}
 
 	// Chain invariant: exactly one terminal record (fallback decision or
-	// fail-closed) per correlation ID. More than one means the chain's
-	// provenance is ambiguous (e.g. a caller reusing correlation IDs across
-	// requests) and the trail cannot be attributed.
+	// fail-closed) per failover engagement. More than one within a group
+	// means the chain's provenance is ambiguous and cannot be attributed.
 	if len(decisions)+len(failClosed) > 1 {
 		addDetail(FailoverVerdictInvalid,
-			fmt.Sprintf("%d terminal failover records share one correlation id (expected exactly one fallback decision or fail-closed record)", len(decisions)+len(failClosed)))
+			fmt.Sprintf("%d terminal failover records share one failover group (expected exactly one fallback decision or fail-closed record)", len(decisions)+len(failClosed)))
 	}
 
 	referenced := map[string]bool{}
@@ -203,24 +238,15 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 	// applies to attempts a terminal record does not account for.
 	if len(decisions) == 0 && len(failClosed) == 0 {
 		addDetail(FailoverVerdictInsufficient,
-			"failed provider attempt(s) recorded without a fallback decision or fail-closed record")
+			"failed provider attempt(s) recorded without a fallback decision or fail-closed record in their failover group")
 	} else {
 		for id := range attempts {
 			if !referenced[id] {
 				addDetail(FailoverVerdictInsufficient,
-					fmt.Sprintf("failed attempt %s is not referenced by any terminal failover record", id))
+					fmt.Sprintf("failed attempt %s is not referenced by any terminal record in its failover group", id))
 			}
 		}
 	}
 
-	if worst != "" {
-		finding.Verdict = worst
-		return finding
-	}
-	if len(decisions) > 0 {
-		finding.Verdict = FailoverVerdictValidFallback
-		return finding
-	}
-	finding.Verdict = FailoverVerdictValidFailClosed
-	return finding
+	return len(decisions) > 0
 }

--- a/internal/evidence/failover_verifier.go
+++ b/internal/evidence/failover_verifier.go
@@ -143,11 +143,35 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 		}
 	}
 
-	// Rule 1+3: fallback decisions must link failed attempts and must not have
-	// dispatched to a sovereignty-rejected provider.
+	// Chain invariant: exactly one terminal record (fallback decision or
+	// fail-closed) per correlation ID. More than one means the chain's
+	// provenance is ambiguous (e.g. a caller reusing correlation IDs across
+	// requests) and the trail cannot be attributed.
+	if len(decisions)+len(failClosed) > 1 {
+		addDetail(FailoverVerdictInvalid,
+			fmt.Sprintf("%d terminal failover records share one correlation id (expected exactly one fallback decision or fail-closed record)", len(decisions)+len(failClosed)))
+	}
+
+	referenced := map[string]bool{}
+
+	// Rule 1+3: fallback decisions must link failed attempts, must sit at a
+	// fallback chain position, must name a provider distinct from every
+	// failed attempt, and must not have dispatched to a sovereignty-rejected
+	// provider.
 	for _, ev := range decisions {
 		fc := ev.Failover
 		checkAttemptRefs(ev)
+		if fc.ChainPosition <= 0 {
+			addDetail(FailoverVerdictInvalid,
+				fmt.Sprintf("record %s claims a fallback decision at chain position %d — the primary cannot be its own fallback", ev.ID, fc.ChainPosition))
+		}
+		for _, id := range fc.FailedAttemptIDs {
+			referenced[id] = true
+			if att, ok := attempts[id]; ok && att.Failover.Provider == fc.Provider {
+				addDetail(FailoverVerdictInvalid,
+					fmt.Sprintf("record %s selects provider %s which also appears as failed attempt %s", ev.ID, fc.Provider, id))
+			}
+		}
 		if strings.EqualFold(strings.TrimSpace(fc.SovereigntyMode), "eu_strict") {
 			region := strings.ToUpper(strings.TrimSpace(fc.Region))
 			if fc.SovereigntyCheck != "allowed" || (region != "EU" && region != "LOCAL") {
@@ -166,6 +190,7 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 			continue
 		}
 		for _, id := range ev.Failover.FailedAttemptIDs {
+			referenced[id] = true
 			if _, ok := attempts[id]; !ok {
 				addDetail(FailoverVerdictInsufficient,
 					fmt.Sprintf("fail-closed record %s references failed attempt %s which is missing from the correlation trail", ev.ID, id))
@@ -174,10 +199,18 @@ func VerifyFailoverRecords(correlationID string, records []*Evidence, verifySig 
 	}
 
 	// Rule 4: failed attempts with no decision context are insufficient —
-	// the trail shows an error but not the governance outcome.
+	// the trail shows an error but not the governance outcome. The same
+	// applies to attempts a terminal record does not account for.
 	if len(decisions) == 0 && len(failClosed) == 0 {
 		addDetail(FailoverVerdictInsufficient,
 			"failed provider attempt(s) recorded without a fallback decision or fail-closed record")
+	} else {
+		for id := range attempts {
+			if !referenced[id] {
+				addDetail(FailoverVerdictInsufficient,
+					fmt.Sprintf("failed attempt %s is not referenced by any terminal failover record", id))
+			}
+		}
 	}
 
 	if worst != "" {

--- a/internal/evidence/failover_verifier_test.go
+++ b/internal/evidence/failover_verifier_test.go
@@ -1,0 +1,162 @@
+package evidence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func attemptRecord(id, provider, region string) *Evidence {
+	return &Evidence{
+		ID:            id,
+		CorrelationID: "corr-1",
+		Failover: &FailoverContext{
+			Role:            FailoverRoleFailedAttempt,
+			Provider:        provider,
+			Region:          region,
+			ErrorClass:      "upstream_5xx",
+			SovereigntyMode: "eu_strict",
+		},
+	}
+}
+
+func decisionRecord(id, provider, region, check string, attemptIDs []string) *Evidence {
+	return &Evidence{
+		ID:            id,
+		CorrelationID: "corr-1",
+		Failover: &FailoverContext{
+			Role:             FailoverRoleFallbackDecision,
+			Provider:         provider,
+			Region:           region,
+			SovereigntyMode:  "eu_strict",
+			SovereigntyCheck: check,
+			FailedAttemptIDs: attemptIDs,
+		},
+	}
+}
+
+func failClosedRecord(id string, attemptIDs []string, skipped []SkippedCandidate) *Evidence {
+	return &Evidence{
+		ID:            id,
+		CorrelationID: "corr-1",
+		Failover: &FailoverContext{
+			Role:              FailoverRoleFailClosed,
+			SovereigntyMode:   "eu_strict",
+			FailedAttemptIDs:  attemptIDs,
+			SkippedCandidates: skipped,
+		},
+	}
+}
+
+func TestVerifyFailoverRecords(t *testing.T) {
+	t.Run("no failover context returns nil", func(t *testing.T) {
+		records := []*Evidence{{ID: "a", CorrelationID: "corr-1"}}
+		assert.Nil(t, VerifyFailoverRecords("corr-1", records, nil))
+	})
+
+	t.Run("failed EU primary + successful EU secondary with matching correlation = valid fallback", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-1"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictValidFallback, f.Verdict, "details: %v", f.Details)
+	})
+
+	t.Run("failed primary + only non-allowed secondary + no dispatch = valid fail-closed", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			failClosedRecord("fc-1", []string{"att-1"}, []SkippedCandidate{
+				{Provider: "openai-us", Filter: "sovereignty", Reason: "region US not EU/LOCAL"},
+			}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictValidFailClosed, f.Verdict, "details: %v", f.Details)
+	})
+
+	t.Run("fallback dispatch to sovereignty-rejected provider = invalid", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			decisionRecord("dec-1", "openai-us", "US", "allowed", []string{"att-1"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("dispatch with sovereignty_check denied = invalid even in EU region", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			decisionRecord("dec-1", "mistral", "EU", "denied", []string{"att-1"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("decision recording only final provider without failed attempt = insufficient", func(t *testing.T) {
+		records := []*Evidence{
+			decisionRecord("dec-1", "mistral", "EU", "allowed", nil),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
+	})
+
+	t.Run("decision referencing missing attempt record = insufficient", func(t *testing.T) {
+		records := []*Evidence{
+			decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-missing"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
+	})
+
+	t.Run("failed attempts without decision context = insufficient", func(t *testing.T) {
+		records := []*Evidence{attemptRecord("att-1", "openai-eu", "EU")}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
+	})
+
+	t.Run("fail-closed with no attempts and no skips = insufficient", func(t *testing.T) {
+		records := []*Evidence{failClosedRecord("fc-1", nil, nil)}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
+	})
+
+	t.Run("invalid signature = invalid, outranks insufficient", func(t *testing.T) {
+		records := []*Evidence{
+			decisionRecord("dec-1", "mistral", "EU", "allowed", nil),
+		}
+		alwaysInvalid := func(*Evidence) bool { return false }
+		f := VerifyFailoverRecords("corr-1", records, alwaysInvalid)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("non-eu_strict mode does not flag US fallback", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai", "US"),
+			{
+				ID:            "dec-1",
+				CorrelationID: "corr-1",
+				Failover: &FailoverContext{
+					Role:             FailoverRoleFallbackDecision,
+					Provider:         "anthropic",
+					Region:           "US",
+					SovereigntyMode:  "global",
+					SovereigntyCheck: "not_evaluated",
+					FailedAttemptIDs: []string{"att-1"},
+				},
+			},
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictValidFallback, f.Verdict, "details: %v", f.Details)
+	})
+}

--- a/internal/evidence/failover_verifier_test.go
+++ b/internal/evidence/failover_verifier_test.go
@@ -29,6 +29,7 @@ func decisionRecord(id, provider, region, check string, attemptIDs []string) *Ev
 			Role:             FailoverRoleFallbackDecision,
 			Provider:         provider,
 			Region:           region,
+			ChainPosition:    1,
 			SovereigntyMode:  "eu_strict",
 			SovereigntyCheck: check,
 			FailedAttemptIDs: attemptIDs,
@@ -129,6 +130,47 @@ func TestVerifyFailoverRecords(t *testing.T) {
 		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
 	})
 
+	t.Run("multiple terminal records for one correlation id = invalid", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-1"}),
+			failClosedRecord("fc-1", []string{"att-1"}, nil),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("fallback decision at chain position 0 = invalid", func(t *testing.T) {
+		dec := decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-1"})
+		dec.Failover.ChainPosition = 0
+		records := []*Evidence{attemptRecord("att-1", "openai-eu", "EU"), dec}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("fallback provider equal to failed attempt provider = invalid", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "mistral", "EU"),
+			decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-1"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInvalid, f.Verdict)
+	})
+
+	t.Run("attempt not referenced by the terminal record = insufficient", func(t *testing.T) {
+		records := []*Evidence{
+			attemptRecord("att-1", "openai-eu", "EU"),
+			attemptRecord("att-orphan", "mistral-old", "EU"),
+			decisionRecord("dec-1", "mistral", "EU", "allowed", []string{"att-1"}),
+		}
+		f := VerifyFailoverRecords("corr-1", records, nil)
+		require.NotNil(t, f)
+		assert.Equal(t, FailoverVerdictInsufficient, f.Verdict)
+	})
+
 	t.Run("invalid signature = invalid, outranks insufficient", func(t *testing.T) {
 		records := []*Evidence{
 			decisionRecord("dec-1", "mistral", "EU", "allowed", nil),
@@ -149,6 +191,7 @@ func TestVerifyFailoverRecords(t *testing.T) {
 					Role:             FailoverRoleFallbackDecision,
 					Provider:         "anthropic",
 					Region:           "US",
+					ChainPosition:    1,
 					SovereigntyMode:  "global",
 					SovereigntyCheck: "not_evaluated",
 					FailedAttemptIDs: []string{"att-1"},

--- a/internal/evidence/generator.go
+++ b/internal/evidence/generator.go
@@ -92,6 +92,7 @@ type GenerateParams struct {
 	FailureReason    string             // Structured classification: cost_exceeded, llm_error, policy_deny, operator_kill, etc.
 	PlanID           string             // Execution plan ID for lineage (links to execution_plans.id)
 	GraphRunID       string             // Graph runtime run ID for external orchestrators (LangGraph, LangChain, etc.)
+	Failover         *FailoverContext   // Provider fallback-chain context (failed attempt / fallback decision / fail-closed)
 }
 
 // StepParams holds inputs for creating a step-level evidence record (one LLM call or one tool call within a run).
@@ -246,6 +247,7 @@ func (g *Generator) Generate(ctx context.Context, params GenerateParams) (*Evide
 		FailureReason:   params.FailureReason,
 		PlanID:          params.PlanID,
 		GraphRunID:      params.GraphRunID,
+		Failover:        params.Failover,
 	}
 	ev.Explanations = g.buildExplanations(params)
 	if len(ev.Explanations) == 0 {

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -96,6 +96,74 @@ type Evidence struct {
 	// pre-existing record signatures remain valid
 	// (see docs/reference/evidence-integrity-spec.md §2).
 	EgressDecision *EgressDecision `json:"egress_decision,omitempty"`
+	// Failover records provider fallback-chain context (failed attempt,
+	// fallback decision, or fail-closed outcome). Appended after
+	// egress_decision so pre-existing record signatures remain valid
+	// (see docs/reference/evidence-integrity-spec.md §2).
+	Failover *FailoverContext `json:"failover,omitempty"`
+}
+
+// Failover evidence roles. A failover produces separate signed facts:
+// one FailoverRoleFailedAttempt record per failed runtime attempt, plus the
+// request's final record carrying FailoverRoleFallbackDecision (a fallback
+// provider was dispatched) or FailoverRoleFailClosed (no policy-valid
+// candidate existed; the caller received an error and that refusal is a
+// successful governance outcome).
+const (
+	FailoverRoleFailedAttempt    = "failed_attempt"
+	FailoverRoleFallbackDecision = "fallback_decision"
+	FailoverRoleFailClosed       = "fail_closed"
+)
+
+// Structured failure reasons for failover outcomes (Evidence.FailureReason).
+const (
+	FailureReasonProviderTransient   = "provider_transient_error"
+	FailureReasonNoSovereignFallback = "no_valid_fallback_candidate"
+)
+
+// FailoverContext captures why traffic moved between providers, so audits can
+// prove both where an answer came from and why it came from there.
+type FailoverContext struct {
+	// Role is one of the FailoverRole* constants.
+	Role string `json:"role"`
+	// Provider/Region/Model describe the attempt (failed_attempt role) or the
+	// provider actually used (fallback_decision role).
+	Provider string `json:"provider"`
+	Region   string `json:"region,omitempty"`
+	Model    string `json:"model,omitempty"`
+	// ErrorClass classifies the upstream failure (failed_attempt role):
+	// timeout, connection_error, rate_limited, upstream_5xx, ...
+	ErrorClass string `json:"error_class,omitempty"`
+	// UpstreamStatus is the upstream HTTP status of a failed attempt (0 for
+	// transport-level failures).
+	UpstreamStatus int `json:"upstream_status,omitempty"`
+	// ChainPosition is the candidate's position in the fallback chain
+	// (0 = primary).
+	ChainPosition int `json:"chain_position"`
+	// FallbackRuleID names the config rule that produced the candidate,
+	// e.g. "gateway.providers.openai.fallback[1]".
+	FallbackRuleID string `json:"fallback_rule_id,omitempty"`
+	// SovereigntyMode is the effective data-sovereignty mode at decision time.
+	SovereigntyMode string `json:"sovereignty_mode,omitempty"`
+	// SovereigntyCheck is the sovereignty filter outcome for the dispatched
+	// candidate: "allowed", "denied", or "not_evaluated".
+	SovereigntyCheck string `json:"sovereignty_check,omitempty"`
+	// FailedAttemptIDs are the evidence IDs of the failed-attempt records this
+	// decision is based on (fallback_decision and fail_closed roles).
+	FailedAttemptIDs []string `json:"failed_attempt_ids,omitempty"`
+	// SkippedCandidates are chain candidates refused by a policy filter before
+	// any provider call was made — distinct from failed runtime attempts.
+	SkippedCandidates []SkippedCandidate `json:"skipped_candidates,omitempty"`
+}
+
+// SkippedCandidate is a fallback candidate refused by a candidate filter
+// (e.g. sovereignty) before dispatch. Talon never called this provider.
+type SkippedCandidate struct {
+	Provider      string `json:"provider"`
+	Model         string `json:"model,omitempty"`
+	ChainPosition int    `json:"chain_position"`
+	Filter        string `json:"filter"`
+	Reason        string `json:"reason"`
 }
 
 // EgressDecision records the outcome of matching a gateway request against
@@ -617,12 +685,16 @@ func (s *Store) ListBySessionID(ctx context.Context, sessionID string) ([]*Evide
 		trace.WithAttributes(attribute.String("session_id", sessionID)))
 	defer span.End()
 
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT evidence_json FROM evidence WHERE session_id = ? ORDER BY timestamp DESC`,
-		sessionID,
-	)
+	return s.queryEvidenceJSON(ctx, "session",
+		`SELECT evidence_json FROM evidence WHERE session_id = ? ORDER BY timestamp DESC`, sessionID)
+}
+
+// queryEvidenceJSON runs a single-argument evidence_json query and unmarshals
+// each row into an Evidence record. scope names the query for error wrapping.
+func (s *Store) queryEvidenceJSON(ctx context.Context, scope, query, arg string) ([]*Evidence, error) {
+	rows, err := s.db.QueryContext(ctx, query, arg)
 	if err != nil {
-		return nil, fmt.Errorf("querying evidence by session: %w", err)
+		return nil, fmt.Errorf("querying evidence by %s: %w", scope, err)
 	}
 	defer rows.Close()
 
@@ -639,6 +711,18 @@ func (s *Store) ListBySessionID(ctx context.Context, sessionID string) ([]*Evide
 		results = append(results, &ev)
 	}
 	return results, rows.Err()
+}
+
+// ListByCorrelationID returns all evidence records sharing a correlation ID,
+// oldest first. Used by the failover verifier to reconstruct a fallback chain
+// (failed attempts + fallback decision) from linked signed records.
+func (s *Store) ListByCorrelationID(ctx context.Context, correlationID string) ([]*Evidence, error) {
+	ctx, span := tracer.Start(ctx, "evidence.list_by_correlation",
+		trace.WithAttributes(attribute.String("correlation_id", correlationID)))
+	defer span.End()
+
+	return s.queryEvidenceJSON(ctx, "correlation",
+		`SELECT evidence_json FROM evidence WHERE correlation_id = ? ORDER BY timestamp ASC`, correlationID)
 }
 
 // Get retrieves evidence by ID.

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -120,9 +120,9 @@ const (
 // transient (timeout/connection/429/5xx) vs permanent (auth/4xx) — the
 // failure_reason and failover.error_class must never contradict each other.
 const (
-	FailureReasonProviderTransient   = "provider_transient_error"
-	FailureReasonProviderPermanent   = "provider_permanent_error"
-	FailureReasonNoSovereignFallback = "no_valid_fallback_candidate"
+	FailureReasonProviderTransient        = "provider_transient_error"
+	FailureReasonProviderPermanent        = "provider_permanent_error"
+	FailureReasonNoValidFallbackCandidate = "no_valid_fallback_candidate"
 )
 
 // FailoverContext captures why traffic moved between providers, so audits can
@@ -130,6 +130,12 @@ const (
 type FailoverContext struct {
 	// Role is one of the FailoverRole* constants.
 	Role string `json:"role"`
+	// FailoverGroupID ties the records of ONE failover engagement together
+	// (one gateway request, or one LLM call within an agent run). A single
+	// correlation ID may legitimately carry several groups — an agentic run
+	// makes many LLM calls — so verification is per group, not per
+	// correlation ID. Empty on records written before this field existed.
+	FailoverGroupID string `json:"failover_group_id,omitempty"`
 	// Provider/Region/Model describe the attempt (failed_attempt role) or the
 	// provider actually used (fallback_decision role).
 	Provider string `json:"provider"`

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -116,8 +116,12 @@ const (
 )
 
 // Structured failure reasons for failover outcomes (Evidence.FailureReason).
+// Failed-attempt records carry the reason matching their error class:
+// transient (timeout/connection/429/5xx) vs permanent (auth/4xx) — the
+// failure_reason and failover.error_class must never contradict each other.
 const (
 	FailureReasonProviderTransient   = "provider_transient_error"
+	FailureReasonProviderPermanent   = "provider_permanent_error"
 	FailureReasonNoSovereignFallback = "no_valid_fallback_candidate"
 )
 

--- a/internal/failover/failover.go
+++ b/internal/failover/failover.go
@@ -1,0 +1,166 @@
+// Package failover provides upstream error classification and fallback
+// candidate filtering for provider fallback chains (error-driven,
+// sovereignty-respecting). It is a leaf package shared by the gateway proxy
+// path (internal/gateway) and the LLM router path (internal/llm): only
+// transient upstream failures may trigger failover, and every candidate must
+// pass the filter pipeline (sovereignty today; model policy facts from #189
+// plug in as additional CandidateFilter implementations without rework).
+package failover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/dativo-io/talon/internal/config"
+)
+
+// Error classes recorded in evidence for failed provider attempts.
+// Transient classes may trigger failover to the next chain candidate;
+// permanent classes never do (retrying a 401 on a second provider would
+// only widen the blast radius of a misconfiguration).
+const (
+	ClassTimeout     = "timeout"
+	ClassConnection  = "connection_error"
+	ClassRateLimited = "rate_limited"
+	ClassUpstream5xx = "upstream_5xx"
+	ClassAuth        = "auth_error"
+	ClassClient      = "client_error"
+	ClassCanceled    = "canceled"
+	ClassNone        = ""
+)
+
+// Classification is the failover-relevant classification of an upstream outcome.
+type Classification struct {
+	Class     string
+	Transient bool
+}
+
+// ClassifyHTTP classifies the outcome of an upstream HTTP attempt from the
+// transport error and/or response status code. Caller-context cancellation is
+// never transient: the client went away, so dispatching the request to another
+// provider would be a policy-relevant action nobody is waiting for.
+func ClassifyHTTP(err error, statusCode int) Classification {
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return Classification{Class: ClassCanceled, Transient: false}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return Classification{Class: ClassTimeout, Transient: true}
+		}
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			return Classification{Class: ClassTimeout, Transient: true}
+		}
+		// Any other transport-level failure (connection refused/reset, DNS,
+		// EOF mid-body) means the provider was unreachable or dropped us.
+		return Classification{Class: ClassConnection, Transient: true}
+	}
+	switch {
+	case statusCode == 429:
+		return Classification{Class: ClassRateLimited, Transient: true}
+	case statusCode >= 500:
+		return Classification{Class: ClassUpstream5xx, Transient: true}
+	case statusCode == 401 || statusCode == 403:
+		return Classification{Class: ClassAuth, Transient: false}
+	case statusCode >= 400:
+		return Classification{Class: ClassClient, Transient: false}
+	}
+	return Classification{Class: ClassNone, Transient: false}
+}
+
+// ClassifyProviderCode maps a typed llm.ProviderError code to a failover
+// classification. Unknown codes are permanent (fail closed: no failover on
+// outcomes we cannot classify).
+func ClassifyProviderCode(code string) Classification {
+	switch code {
+	case "rate_limit":
+		return Classification{Class: ClassRateLimited, Transient: true}
+	case "server_error":
+		return Classification{Class: ClassUpstream5xx, Transient: true}
+	case "timeout":
+		return Classification{Class: ClassTimeout, Transient: true}
+	case "auth_failed":
+		return Classification{Class: ClassAuth, Transient: false}
+	case "model_not_found":
+		return Classification{Class: ClassClient, Transient: false}
+	default:
+		return Classification{Class: ClassNone, Transient: false}
+	}
+}
+
+// Candidate is one entry of an ordered fallback chain, resolved with the
+// metadata filters need. ChainPosition 0 is the primary; fallback entries
+// start at 1. RuleID names the config rule that produced the candidate
+// (e.g. "gateway.providers.openai.fallback[1]" or
+// "policies.model_routing.tier_2.fallback_chain[0]") so evidence can cite it.
+type Candidate struct {
+	Provider      string
+	Model         string
+	Region        string // jurisdiction of the endpoint: "EU", "US", "LOCAL", "unknown"
+	ChainPosition int
+	RuleID        string
+}
+
+// FilterResult reports whether a candidate may be dispatched to, and if not,
+// which filter refused it and why. Skipped candidates are evidenced distinctly
+// from failed runtime attempts (a refusal is a governance outcome, not an error).
+type FilterResult struct {
+	Allowed bool
+	Filter  string // name of the filter that refused (empty when allowed)
+	Reason  string // machine-readable reason (empty when allowed)
+}
+
+// CandidateFilter decides whether a fallback candidate is policy-valid.
+// Implementations must be side-effect free; the caller records the outcome.
+// Issue #189 (model policy facts: availability, ZDR, retention, access scope)
+// adds filters behind this same interface.
+type CandidateFilter interface {
+	Name() string
+	Allows(ctx context.Context, c Candidate) FilterResult
+}
+
+// Pipeline evaluates filters in order; the first refusal wins.
+type Pipeline []CandidateFilter
+
+// Evaluate runs the pipeline for a candidate.
+func (p Pipeline) Evaluate(ctx context.Context, c Candidate) FilterResult {
+	for _, f := range p {
+		if res := f.Allows(ctx, c); !res.Allowed {
+			return res
+		}
+	}
+	return FilterResult{Allowed: true}
+}
+
+// sovereigntyFilter refuses non-EU/LOCAL candidates under eu_strict.
+// Fail-closed: an empty or unknown region is refused under eu_strict.
+type sovereigntyFilter struct {
+	mode string
+}
+
+// NewSovereigntyFilter returns the sovereignty candidate filter for the given
+// data-sovereignty mode. Under any mode other than eu_strict it allows all
+// candidates (routing preference is handled elsewhere).
+func NewSovereigntyFilter(mode string) CandidateFilter {
+	return sovereigntyFilter{mode: mode}
+}
+
+func (f sovereigntyFilter) Name() string { return "sovereignty" }
+
+func (f sovereigntyFilter) Allows(_ context.Context, c Candidate) FilterResult {
+	if f.mode != config.DataSovereigntyEUStrict {
+		return FilterResult{Allowed: true}
+	}
+	region := strings.ToUpper(strings.TrimSpace(c.Region))
+	if region == "EU" || region == "LOCAL" {
+		return FilterResult{Allowed: true}
+	}
+	return FilterResult{
+		Allowed: false,
+		Filter:  f.Name(),
+		Reason:  fmt.Sprintf("sovereignty: provider %s region %q not EU/LOCAL under %s", c.Provider, c.Region, f.mode),
+	}
+}

--- a/internal/failover/failover_test.go
+++ b/internal/failover/failover_test.go
@@ -1,0 +1,122 @@
+package failover
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestClassifyHTTP(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		status        int
+		wantClass     string
+		wantTransient bool
+	}{
+		{name: "success", err: nil, status: 200, wantClass: ClassNone, wantTransient: false},
+		{name: "no status yet", err: nil, status: 0, wantClass: ClassNone, wantTransient: false},
+		{name: "context deadline", err: context.DeadlineExceeded, status: 0, wantClass: ClassTimeout, wantTransient: true},
+		{name: "caller canceled is never transient", err: context.Canceled, status: 0, wantClass: ClassCanceled, wantTransient: false},
+		{name: "net timeout", err: timeoutErr{}, status: 0, wantClass: ClassTimeout, wantTransient: true},
+		{name: "connection refused", err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}, status: 0, wantClass: ClassConnection, wantTransient: true},
+		{name: "generic transport error", err: errors.New("EOF"), status: 0, wantClass: ClassConnection, wantTransient: true},
+		{name: "429 rate limited", err: nil, status: 429, wantClass: ClassRateLimited, wantTransient: true},
+		{name: "500", err: nil, status: 500, wantClass: ClassUpstream5xx, wantTransient: true},
+		{name: "502", err: nil, status: 502, wantClass: ClassUpstream5xx, wantTransient: true},
+		{name: "503", err: nil, status: 503, wantClass: ClassUpstream5xx, wantTransient: true},
+		{name: "504", err: nil, status: 504, wantClass: ClassUpstream5xx, wantTransient: true},
+		{name: "401 auth is permanent", err: nil, status: 401, wantClass: ClassAuth, wantTransient: false},
+		{name: "403 auth is permanent", err: nil, status: 403, wantClass: ClassAuth, wantTransient: false},
+		{name: "404 client error is permanent", err: nil, status: 404, wantClass: ClassClient, wantTransient: false},
+		{name: "422 client error is permanent", err: nil, status: 422, wantClass: ClassClient, wantTransient: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyHTTP(tt.err, tt.status)
+			assert.Equal(t, tt.wantClass, got.Class)
+			assert.Equal(t, tt.wantTransient, got.Transient)
+		})
+	}
+}
+
+func TestClassifyProviderCode(t *testing.T) {
+	tests := []struct {
+		code          string
+		wantClass     string
+		wantTransient bool
+	}{
+		{code: "rate_limit", wantClass: ClassRateLimited, wantTransient: true},
+		{code: "server_error", wantClass: ClassUpstream5xx, wantTransient: true},
+		{code: "timeout", wantClass: ClassTimeout, wantTransient: true},
+		{code: "auth_failed", wantClass: ClassAuth, wantTransient: false},
+		{code: "model_not_found", wantClass: ClassClient, wantTransient: false},
+		{code: "something_else", wantClass: ClassNone, wantTransient: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got := ClassifyProviderCode(tt.code)
+			assert.Equal(t, tt.wantClass, got.Class)
+			assert.Equal(t, tt.wantTransient, got.Transient)
+		})
+	}
+}
+
+func TestSovereigntyFilter(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		mode    string
+		region  string
+		allowed bool
+	}{
+		{name: "eu_strict allows EU", mode: "eu_strict", region: "EU", allowed: true},
+		{name: "eu_strict allows LOCAL", mode: "eu_strict", region: "LOCAL", allowed: true},
+		{name: "eu_strict allows lowercase eu", mode: "eu_strict", region: "eu", allowed: true},
+		{name: "eu_strict denies US", mode: "eu_strict", region: "US", allowed: false},
+		{name: "eu_strict fails closed on empty region", mode: "eu_strict", region: "", allowed: false},
+		{name: "eu_strict fails closed on unknown region", mode: "eu_strict", region: "unknown", allowed: false},
+		{name: "eu_preferred allows US", mode: "eu_preferred", region: "US", allowed: true},
+		{name: "global allows US", mode: "global", region: "US", allowed: true},
+		{name: "empty mode allows US", mode: "", region: "US", allowed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewSovereigntyFilter(tt.mode)
+			res := f.Allows(ctx, Candidate{Provider: "p", Region: tt.region})
+			assert.Equal(t, tt.allowed, res.Allowed)
+			if !tt.allowed {
+				assert.Equal(t, "sovereignty", res.Filter)
+				assert.NotEmpty(t, res.Reason)
+			}
+		})
+	}
+}
+
+func TestPipeline_FirstRefusalWins(t *testing.T) {
+	ctx := context.Background()
+	p := Pipeline{NewSovereigntyFilter("eu_strict")}
+	res := p.Evaluate(ctx, Candidate{Provider: "us-provider", Region: "US"})
+	assert.False(t, res.Allowed)
+	assert.Equal(t, "sovereignty", res.Filter)
+
+	res = p.Evaluate(ctx, Candidate{Provider: "eu-provider", Region: "EU"})
+	assert.True(t, res.Allowed)
+}
+
+// A timeout error wrapped inside a net.OpError still classifies as timeout.
+func TestClassifyHTTP_WrappedTimeout(t *testing.T) {
+	err := &net.OpError{Op: "read", Err: timeoutErr{}}
+	got := ClassifyHTTP(err, 0)
+	assert.Equal(t, ClassTimeout, got.Class)
+	assert.True(t, got.Transient)
+}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -74,6 +74,13 @@ type ProviderConfig struct {
 	BlockedModels    []string `yaml:"blocked_models,omitempty" json:"blocked_models,omitempty"`
 	ForbiddenTools   []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`
 	ToolPolicyAction string   `yaml:"tool_policy_action,omitempty" json:"tool_policy_action,omitempty"` // filter | block
+	// APIFamily declares the provider's wire format: "openai" or "anthropic".
+	// Used for fallback-chain validation and upstream auth conventions
+	// (x-api-key + anthropic-version vs Authorization: Bearer). When empty it
+	// defaults by provider name: "anthropic" → anthropic, everything else →
+	// openai-compatible. Set it explicitly for aliased endpoints (e.g. an
+	// "anthropic-eu" provider pointing at an Anthropic-compatible base_url).
+	APIFamily string `yaml:"api_family,omitempty" json:"api_family,omitempty"`
 	// Fallback is the ordered error-driven fallback chain for this provider:
 	// on a transient upstream failure (timeout / connection error / 429 / 5xx)
 	// the gateway retries the request against each target in order, subject to
@@ -91,10 +98,14 @@ type FallbackTarget struct {
 	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 }
 
-// providerAPIFamily groups providers by wire format for fallback chain
-// validation. Anthropic uses its own Messages API; every other gateway
-// provider is treated as OpenAI-compatible (matching WriteProviderError).
-func providerAPIFamily(name string) string {
+// providerAPIFamily resolves a provider's wire format: the explicit
+// api_family config field wins; otherwise the name convention applies —
+// "anthropic" uses the Anthropic Messages API, every other provider is
+// treated as OpenAI-compatible (matching WriteProviderError).
+func (c *GatewayConfig) providerAPIFamily(name string) string {
+	if p, ok := c.Providers[name]; ok && p.APIFamily != "" {
+		return p.APIFamily
+	}
 	if name == "anthropic" {
 		return "anthropic"
 	}
@@ -325,6 +336,7 @@ func normalizeProviderRegions(providers map[string]ProviderConfig) {
 		for i := range p.Fallback {
 			p.Fallback[i].Provider = strings.ToLower(strings.TrimSpace(p.Fallback[i].Provider))
 		}
+		p.APIFamily = strings.ToLower(strings.TrimSpace(p.APIFamily))
 		providers[name] = p
 	}
 }
@@ -371,6 +383,11 @@ func (c *GatewayConfig) Validate() error {
 		case "secret", "client_bearer":
 		default:
 			return fmt.Errorf("gateway provider %q: upstream_auth_mode must be secret or client_bearer", name)
+		}
+		switch p.APIFamily {
+		case "", "openai", "anthropic":
+		default:
+			return fmt.Errorf("gateway provider %q: api_family must be openai or anthropic", name)
 		}
 		if p.BaseURL == "" && (name == "openai" || name == "anthropic" || name == "ollama") {
 			return fmt.Errorf("gateway provider %q: base_url is required", name)
@@ -435,7 +452,7 @@ func (c *GatewayConfig) Validate() error {
 // would send an incompatible payload).
 func (c *GatewayConfig) validateFallbackChain(owner string, p ProviderConfig) error {
 	seen := map[string]bool{owner: true}
-	family := providerAPIFamily(owner)
+	family := c.providerAPIFamily(owner)
 	for i, target := range p.Fallback {
 		tname := strings.ToLower(strings.TrimSpace(target.Provider))
 		if tname == "" {
@@ -449,7 +466,7 @@ func (c *GatewayConfig) validateFallbackChain(owner string, p ProviderConfig) er
 		if !ok || !tp.Enabled {
 			return fmt.Errorf("gateway provider %q: fallback[%d]: target %q is not an enabled gateway provider", owner, i, tname)
 		}
-		if tf := providerAPIFamily(tname); tf != family {
+		if tf := c.providerAPIFamily(tname); tf != family {
 			return fmt.Errorf("gateway provider %q: fallback[%d]: target %q API family %q does not match %q — fallback forwards the request body as-is (only the model field is rewritten)", owner, i, tname, tf, family)
 		}
 	}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -74,6 +74,31 @@ type ProviderConfig struct {
 	BlockedModels    []string `yaml:"blocked_models,omitempty" json:"blocked_models,omitempty"`
 	ForbiddenTools   []string `yaml:"forbidden_tools,omitempty" json:"forbidden_tools,omitempty"`
 	ToolPolicyAction string   `yaml:"tool_policy_action,omitempty" json:"tool_policy_action,omitempty"` // filter | block
+	// Fallback is the ordered error-driven fallback chain for this provider:
+	// on a transient upstream failure (timeout / connection error / 429 / 5xx)
+	// the gateway retries the request against each target in order, subject to
+	// the candidate filter pipeline (sovereignty under eu_strict). All chain
+	// members must share the provider's API family (the request body is
+	// forwarded as-is except for an optional model rewrite).
+	Fallback []FallbackTarget `yaml:"fallback,omitempty" json:"fallback,omitempty"`
+}
+
+// FallbackTarget is one candidate in a provider's error-driven fallback chain.
+type FallbackTarget struct {
+	Provider string `yaml:"provider" json:"provider"`
+	// Model, when set, replaces the "model" field of the forwarded JSON body
+	// (the only rewrite performed; the wire format must already match).
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+}
+
+// providerAPIFamily groups providers by wire format for fallback chain
+// validation. Anthropic uses its own Messages API; every other gateway
+// provider is treated as OpenAI-compatible (matching WriteProviderError).
+func providerAPIFamily(name string) string {
+	if name == "anthropic" {
+		return "anthropic"
+	}
+	return "openai"
 }
 
 // CallerConfig identifies an application or team that uses the gateway.
@@ -296,8 +321,11 @@ func normalizeProviderRegions(providers map[string]ProviderConfig) {
 		p := providers[name]
 		if p.Region != "" {
 			p.Region = normalizeEgressRegion(p.Region)
-			providers[name] = p
 		}
+		for i := range p.Fallback {
+			p.Fallback[i].Provider = strings.ToLower(strings.TrimSpace(p.Fallback[i].Provider))
+		}
+		providers[name] = p
 	}
 }
 
@@ -352,6 +380,15 @@ func (c *GatewayConfig) Validate() error {
 		}
 		c.Providers[name] = p
 	}
+	for name := range c.Providers {
+		p := c.Providers[name]
+		if !p.Enabled {
+			continue
+		}
+		if err := c.validateFallbackChain(name, p); err != nil {
+			return err
+		}
+	}
 	if p := c.ServerDefaults.AttachmentPolicy; p != nil {
 		switch p.Action {
 		case "block", "strip", "warn", "allow":
@@ -386,6 +423,34 @@ func (c *GatewayConfig) Validate() error {
 			}
 		} else if caller.TenantKey == "" && c.ServerDefaults.CallerIDRequired() {
 			return fmt.Errorf("gateway caller %q: tenant_key or identify_by=source_ip with source_ip_ranges is required", caller.Name)
+		}
+	}
+	return nil
+}
+
+// validateFallbackChain checks a provider's error-driven fallback chain at
+// load time: every target must exist, be enabled, differ from the owner,
+// appear at most once, and share the owner's API family (the body is
+// forwarded verbatim apart from a model rewrite, so cross-family fallback
+// would send an incompatible payload).
+func (c *GatewayConfig) validateFallbackChain(owner string, p ProviderConfig) error {
+	seen := map[string]bool{owner: true}
+	family := providerAPIFamily(owner)
+	for i, target := range p.Fallback {
+		tname := strings.ToLower(strings.TrimSpace(target.Provider))
+		if tname == "" {
+			return fmt.Errorf("gateway provider %q: fallback[%d]: provider is required", owner, i)
+		}
+		if seen[tname] {
+			return fmt.Errorf("gateway provider %q: fallback[%d]: duplicate or self-referencing target %q", owner, i, tname)
+		}
+		seen[tname] = true
+		tp, ok := c.Providers[tname]
+		if !ok || !tp.Enabled {
+			return fmt.Errorf("gateway provider %q: fallback[%d]: target %q is not an enabled gateway provider", owner, i, tname)
+		}
+		if tf := providerAPIFamily(tname); tf != family {
+			return fmt.Errorf("gateway provider %q: fallback[%d]: target %q API family %q does not match %q — fallback forwards the request body as-is (only the model field is rewritten)", owner, i, tname, tf, family)
 		}
 	}
 	return nil

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -389,6 +389,9 @@ func (c *GatewayConfig) Validate() error {
 		default:
 			return fmt.Errorf("gateway provider %q: api_family must be openai or anthropic", name)
 		}
+		if p.UpstreamAuthMode == "client_bearer" && (p.APIFamily == "anthropic" || name == "anthropic") {
+			return fmt.Errorf("gateway provider %q: upstream_auth_mode client_bearer is not supported for the anthropic API family (Anthropic uses x-api-key, not bearer tokens)", name)
+		}
 		if p.BaseURL == "" && (name == "openai" || name == "anthropic" || name == "ollama") {
 			return fmt.Errorf("gateway provider %q: base_url is required", name)
 		}

--- a/internal/gateway/config_schema_test.go
+++ b/internal/gateway/config_schema_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
+)
+
+// validateAgainstConfigSchema validates a YAML document against the repo's
+// talon.config.schema.json (editor support / docs contract for the gateway
+// config surface).
+func validateAgainstConfigSchema(t *testing.T, yamlDoc string) *gojsonschema.Result {
+	t.Helper()
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "..", "schemas", "talon.config.schema.json"))
+	require.NoError(t, err, "schemas/talon.config.schema.json must exist")
+
+	var raw map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(yamlDoc), &raw))
+	jsonBytes, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	result, err := gojsonschema.Validate(
+		gojsonschema.NewBytesLoader(schemaBytes),
+		gojsonschema.NewBytesLoader(jsonBytes),
+	)
+	require.NoError(t, err)
+	return result
+}
+
+// TestConfigSchema_FallbackFields guards that the published config schema
+// accepts the failover fields (fallback chains, api_family) so configs using
+// them validate and editors autocomplete them.
+func TestConfigSchema_FallbackFields(t *testing.T) {
+	t.Run("fallback chain and api_family accepted", func(t *testing.T) {
+		result := validateAgainstConfigSchema(t, `
+gateway:
+  enabled: true
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      secret_name: "openai-api-key"
+      region: "EU"
+      fallback:
+        - provider: "mistral-eu"
+          model: "mistral-large-latest"
+    mistral-eu:
+      enabled: true
+      base_url: "https://api.mistral.ai"
+      secret_name: "mistral-api-key"
+      region: "EU"
+    anthropic-eu:
+      enabled: true
+      base_url: "https://eu.anthropic.example.com"
+      secret_name: "anthropic-eu-key"
+      api_family: "anthropic"
+`)
+		assert.True(t, result.Valid(), "errors: %v", result.Errors())
+	})
+
+	t.Run("invalid api_family rejected", func(t *testing.T) {
+		result := validateAgainstConfigSchema(t, `
+gateway:
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      api_family: "grpc"
+`)
+		assert.False(t, result.Valid(), "api_family outside the enum must be rejected")
+	})
+
+	t.Run("fallback target without provider rejected", func(t *testing.T) {
+		result := validateAgainstConfigSchema(t, `
+gateway:
+  providers:
+    openai:
+      enabled: true
+      base_url: "https://api.openai.com"
+      fallback:
+        - model: "gpt-4o-mini"
+`)
+		assert.False(t, result.Valid(), "fallback targets require a provider")
+	})
+}

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -62,6 +62,15 @@ type RecordGatewayEvidenceParams struct {
 	// EgressDecision records the egress allow/deny outcome (tier x destination).
 	// Nil when egress is not configured or was not evaluated for this request.
 	EgressDecision *evidence.EgressDecision
+	// InvocationType overrides the default "gateway" (e.g.
+	// "gateway_failover_attempt" for failed provider attempt records).
+	InvocationType string
+	// Status/FailureReason classify failed outcomes (evidence-by-default).
+	Status        string
+	FailureReason string
+	// Failover carries fallback-chain context (failed attempt, fallback
+	// decision, or fail-closed outcome).
+	Failover *evidence.FailoverContext
 }
 
 // RecordGatewayEvidence creates and stores a signed evidence record for a gateway request.
@@ -76,6 +85,10 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		}
 	}
 
+	invocationType := params.InvocationType
+	if invocationType == "" {
+		invocationType = "gateway"
+	}
 	ev := &evidence.Evidence{
 		ID:              "gw_" + uuid.New().String()[:12],
 		CorrelationID:   params.CorrelationID,
@@ -86,7 +99,7 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		TenantID:        params.TenantID,
 		AgentID:         params.CallerName,
 		Team:            params.Team,
-		InvocationType:  "gateway",
+		InvocationType:  invocationType,
 		RequestSourceID: params.CallerName,
 		PolicyDecision: evidence.PolicyDecision{
 			Allowed:       params.PolicyAllowed,
@@ -135,6 +148,9 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		},
 		DataFlow:       params.DataFlow,
 		EgressDecision: params.EgressDecision,
+		Status:         params.Status,
+		FailureReason:  params.FailureReason,
+		Failover:       params.Failover,
 	}
 	if !params.PolicyAllowed {
 		ev.PolicyDecision.Action = "deny"

--- a/internal/gateway/extract.go
+++ b/internal/gateway/extract.go
@@ -343,6 +343,11 @@ func redactAnthropicContent(ctx context.Context, c interface{}, scanner *classif
 	if c == nil {
 		return nil
 	}
+	// The Anthropic Messages API accepts plain-string content as well as
+	// content-block arrays; both forms must be redacted.
+	if s, ok := c.(string); ok {
+		return scanner.Redact(ctx, s)
+	}
 	if arr, ok := c.([]interface{}); ok {
 		out := make([]interface{}, len(arr))
 		for i, part := range arr {

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -195,18 +195,32 @@ func (g *Gateway) fallbackAuthHeaders(ctx context.Context, caller *CallerConfig,
 		headers["Authorization"] = "Bearer " + clientKey
 		return headers, nil
 	}
+	anthropicFamily := g.config.providerAPIFamily(providerName) == "anthropic"
 	if prov.SecretName != "" {
 		secret, err := g.secretsStore.Get(ctx, prov.SecretName, caller.TenantID, caller.Name)
 		if err != nil {
 			return nil, fmt.Errorf("fallback provider %s: secret retrieval: %w", providerName, err)
 		}
-		if providerName == "anthropic" {
+		if anthropicFamily {
 			headers["x-api-key"] = string(secret.Value)
 		} else {
 			headers["Authorization"] = "Bearer " + string(secret.Value)
 		}
 	}
+	if anthropicFamily && !headerPresent(headers, "anthropic-version") {
+		headers["anthropic-version"] = "2023-06-01"
+	}
 	return headers, nil
+}
+
+// headerPresent reports whether a header key exists in the map, ignoring case.
+func headerPresent(headers map[string]string, key string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, key) {
+			return true
+		}
+	}
+	return false
 }
 
 // modelAllowedForProvider checks a fallback target's model against the target
@@ -360,9 +374,15 @@ func (g *Gateway) forwardWithFailover(
 		err = Forward(fw, ap)
 		class = classifyAttempt(err, fw.status)
 
-		if !class.Transient || fw.committed {
-			// Success (or permanent upstream response, or mid-stream failure):
-			// this candidate is the provider actually used.
+		success := err == nil && class.Class == failover.ClassNone
+		if success || fw.committed {
+			// Success — or a mid-stream failure after bytes already reached
+			// the client, which makes this candidate the provider actually
+			// used whether we like it or not. Only these outcomes may become
+			// the fallback decision: once failover is engaged, a fallback
+			// candidate that fails for ANY reason (transient or permanent,
+			// e.g. a misconfigured secret returning 401) is a failed attempt,
+			// never "the provider actually used".
 			out.SelectedProvider = target.Provider
 			out.SelectedModel = model
 			out.ChainPosition = i + 1
@@ -419,6 +439,10 @@ func (g *Gateway) recordFailoverAttemptEvidence(ctx context.Context, correlation
 	if errMsg == "" && rec.UpstreamStatus != 0 {
 		errMsg = fmt.Sprintf("upstream status %d", rec.UpstreamStatus)
 	}
+	failureReason := evidence.FailureReasonProviderTransient
+	if !rec.Class.Transient {
+		failureReason = evidence.FailureReasonProviderPermanent
+	}
 	ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, RecordGatewayEvidenceParams{
 		CorrelationID:  correlationID,
 		SessionID:      sessionIDFromContext(ctx),
@@ -433,7 +457,7 @@ func (g *Gateway) recordFailoverAttemptEvidence(ctx context.Context, correlation
 		Error:          errMsg,
 		InvocationType: "gateway_failover_attempt",
 		Status:         "failed",
-		FailureReason:  evidence.FailureReasonProviderTransient,
+		FailureReason:  failureReason,
 		DataFlow:       dataFlow,
 		Failover: &evidence.FailoverContext{
 			Role:            evidence.FailoverRoleFailedAttempt,

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -19,10 +19,12 @@ import (
 
 // failoverWriter defers committing the response to the destination writer
 // until the upstream outcome is known. Headers and status are buffered; a
-// success status (<400) commits immediately so SSE streams pass through
-// unbuffered, while error responses stay buffered so the gateway can retry
-// the request against a fallback candidate and only flush the buffered
-// upstream error when no candidate remains. Once committed (first byte on a
+// success status (<400) commits on the FIRST BODY WRITE — not on the header
+// write — so an upstream that returns 200 headers and then dies before any
+// body byte is read can still fail over. SSE streams pass through unbuffered
+// from their first event; error responses stay fully buffered so the gateway
+// can retry against a fallback candidate and only flush the buffered upstream
+// error when no candidate remains. Once committed (first body byte of a
 // success response), failover is no longer possible for this request.
 type failoverWriter struct {
 	dst       http.ResponseWriter
@@ -48,12 +50,12 @@ func (f *failoverWriter) WriteHeader(code int) {
 		return
 	}
 	f.status = code
-	if code < 400 {
-		f.commit()
-	}
 }
 
 func (f *failoverWriter) Write(b []byte) (int, error) {
+	if !f.committed && f.status != 0 && f.status < 400 {
+		f.commit()
+	}
 	if f.committed {
 		return f.dst.Write(b)
 	}
@@ -144,6 +146,13 @@ func (o *failoverOutcome) failedAttemptIDs() []string {
 // returns its evidence ID ("" when persistence failed; the request continues
 // — evidence write failures are logged, never silently drop traffic).
 type recordAttemptFn func(ctx context.Context, rec failoverAttemptRecord) string
+
+// checkCandidateFn re-runs caller/provider authorization and gateway policy
+// for a fallback candidate (provider, model). Failover dispatch is a
+// Talon-initiated action: it must pass the same gates the caller's own
+// request passed for the primary (allowed_providers, caller model lists,
+// egress rules, budgets) or the chain becomes a policy bypass.
+type checkCandidateFn func(ctx context.Context, provider, model string) failover.FilterResult
 
 // classifyAttempt classifies a Forward outcome from its transport error
 // and/or buffered upstream status.
@@ -264,6 +273,7 @@ func (g *Gateway) forwardWithFailover(
 	clientModel string,
 	originalAuthorization string,
 	recordAttempt recordAttemptFn,
+	checkCandidate checkCandidateFn,
 ) (*failoverOutcome, error) {
 	out := &failoverOutcome{SelectedProvider: route.Provider, SelectedModel: clientModel}
 
@@ -271,6 +281,7 @@ func (g *Gateway) forwardWithFailover(
 	chain := prov.Fallback
 
 	fw := newFailoverWriter(dst)
+	primaryStart := time.Now()
 	err := Forward(fw, p)
 	class := classifyAttempt(err, fw.status)
 
@@ -290,7 +301,7 @@ func (g *Gateway) forwardWithFailover(
 		UpstreamStatus: fw.status,
 		ChainPosition:  0,
 		RuleID:         fmt.Sprintf("gateway.providers.%s", route.Provider),
-		DurationMS:     0,
+		DurationMS:     time.Since(primaryStart).Milliseconds(),
 	}
 	if err != nil {
 		primaryRec.ErrMsg = err.Error()
@@ -343,6 +354,16 @@ func (g *Gateway) forwardWithFailover(
 				Filter: "model_allowlist", Reason: fmt.Sprintf("model %q not allowed for provider %s", model, target.Provider),
 			})
 			continue
+		}
+		if checkCandidate != nil {
+			if res := checkCandidate(ctx, target.Provider, model); !res.Allowed {
+				out.Skipped = append(out.Skipped, evidence.SkippedCandidate{
+					Provider: target.Provider, Model: model, ChainPosition: i + 1,
+					Filter: res.Filter, Reason: res.Reason,
+				})
+				log.Warn().Str("provider", target.Provider).Str("filter", res.Filter).Str("reason", res.Reason).Msg("gateway_failover_candidate_skipped")
+				continue
+			}
 		}
 
 		headers, hdrErr := g.fallbackAuthHeaders(ctx, caller, target.Provider, tprov, originalAuthorization, p.Headers)

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"github.com/dativo-io/talon/internal/config"
@@ -104,6 +105,7 @@ type failoverAttemptRecord struct {
 	ErrMsg         string
 	ChainPosition  int
 	RuleID         string
+	GroupID        string
 	DurationMS     int64
 	EvidenceID     string
 }
@@ -115,8 +117,11 @@ type failoverOutcome struct {
 	SelectedModel    string
 	ChainPosition    int
 	RuleID           string
-	FailedAttempts   []failoverAttemptRecord
-	Skipped          []evidence.SkippedCandidate
+	// GroupID identifies this failover engagement in evidence (one gateway
+	// request = one group).
+	GroupID        string
+	FailedAttempts []failoverAttemptRecord
+	Skipped        []evidence.SkippedCandidate
 	// FailClosed is true when the failover machinery was engaged and the
 	// caller received an error: either no policy-valid candidate existed
 	// (no fallback dispatch at all) or every valid candidate failed. Under
@@ -294,6 +299,7 @@ func (g *Gateway) forwardWithFailover(
 	}
 
 	out.Engaged = true
+	out.GroupID = newFailoverGroupID()
 	primaryRec := failoverAttemptRecord{
 		Provider:       route.Provider,
 		Model:          clientModel,
@@ -301,6 +307,7 @@ func (g *Gateway) forwardWithFailover(
 		UpstreamStatus: fw.status,
 		ChainPosition:  0,
 		RuleID:         fmt.Sprintf("gateway.providers.%s", route.Provider),
+		GroupID:        out.GroupID,
 		DurationMS:     time.Since(primaryStart).Milliseconds(),
 	}
 	if err != nil {
@@ -419,6 +426,7 @@ func (g *Gateway) forwardWithFailover(
 			UpstreamStatus: fw.status,
 			ChainPosition:  i + 1,
 			RuleID:         ruleID,
+			GroupID:        out.GroupID,
 			DurationMS:     time.Since(attemptStart).Milliseconds(),
 		}
 		if err != nil {
@@ -438,7 +446,7 @@ func (g *Gateway) forwardWithFailover(
 	if lastBuffered.status != 0 || lastBuffered.buf.Len() > 0 {
 		lastBuffered.flushTo()
 	} else {
-		WriteProviderError(dst, route.Provider, http.StatusBadGateway,
+		WriteProviderError(dst, g.config.providerAPIFamily(route.Provider), http.StatusBadGateway,
 			"upstream provider failed and no policy-valid fallback candidate exists (fail-closed)")
 	}
 	if err == nil {
@@ -450,6 +458,12 @@ func (g *Gateway) forwardWithFailover(
 // ErrNoFallbackCandidate is returned when a transient upstream failure could
 // not be recovered because no policy-valid fallback candidate succeeded.
 var ErrNoFallbackCandidate = errors.New("no policy-valid fallback candidate available")
+
+// newFailoverGroupID mints the identifier tying one failover engagement's
+// evidence records together.
+func newFailoverGroupID() string {
+	return "fog_" + uuid.New().String()[:12]
+}
 
 // recordFailoverAttemptEvidence persists a signed evidence record for one
 // failed provider attempt (evidence-by-default: the failed attempt is a fact
@@ -482,6 +496,7 @@ func (g *Gateway) recordFailoverAttemptEvidence(ctx context.Context, correlation
 		DataFlow:       dataFlow,
 		Failover: &evidence.FailoverContext{
 			Role:            evidence.FailoverRoleFailedAttempt,
+			FailoverGroupID: rec.GroupID,
 			Provider:        rec.Provider,
 			Region:          g.providerRegion(rec.Provider),
 			Model:           rec.Model,
@@ -507,6 +522,7 @@ func (g *Gateway) buildFailoverDecisionContext(out *failoverOutcome, mode string
 	}
 	fc := &evidence.FailoverContext{
 		Role:              evidence.FailoverRoleFallbackDecision,
+		FailoverGroupID:   out.GroupID,
 		Provider:          out.SelectedProvider,
 		Model:             out.SelectedModel,
 		ChainPosition:     out.ChainPosition,

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -1,0 +1,487 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/failover"
+)
+
+// failoverWriter defers committing the response to the destination writer
+// until the upstream outcome is known. Headers and status are buffered; a
+// success status (<400) commits immediately so SSE streams pass through
+// unbuffered, while error responses stay buffered so the gateway can retry
+// the request against a fallback candidate and only flush the buffered
+// upstream error when no candidate remains. Once committed (first byte on a
+// success response), failover is no longer possible for this request.
+type failoverWriter struct {
+	dst       http.ResponseWriter
+	header    http.Header
+	status    int
+	committed bool
+	buf       bytes.Buffer
+}
+
+func newFailoverWriter(dst http.ResponseWriter) *failoverWriter {
+	return &failoverWriter{dst: dst, header: make(http.Header)}
+}
+
+func (f *failoverWriter) Header() http.Header {
+	if f.committed {
+		return f.dst.Header()
+	}
+	return f.header
+}
+
+func (f *failoverWriter) WriteHeader(code int) {
+	if f.committed {
+		return
+	}
+	f.status = code
+	if code < 400 {
+		f.commit()
+	}
+}
+
+func (f *failoverWriter) Write(b []byte) (int, error) {
+	if f.committed {
+		return f.dst.Write(b)
+	}
+	return f.buf.Write(b)
+}
+
+func (f *failoverWriter) Flush() {
+	if !f.committed {
+		return
+	}
+	if fl, ok := f.dst.(http.Flusher); ok {
+		fl.Flush()
+	}
+}
+
+func (f *failoverWriter) commit() {
+	for k, vs := range f.header {
+		for _, v := range vs {
+			f.dst.Header().Set(k, v)
+		}
+	}
+	if f.status != 0 {
+		f.dst.WriteHeader(f.status)
+	}
+	f.committed = true
+}
+
+// flushTo commits the buffered response (headers, status, body) to the
+// destination. No-op for the already-committed portion.
+func (f *failoverWriter) flushTo() {
+	if !f.committed {
+		f.commit()
+	}
+	if f.buf.Len() > 0 {
+		//nolint:gosec // G705: buffered upstream API response (JSON), gateway passthrough
+		_, _ = f.dst.Write(f.buf.Bytes())
+	}
+}
+
+// failoverAttemptRecord describes one failed runtime attempt against a provider.
+type failoverAttemptRecord struct {
+	Provider       string
+	Model          string
+	Class          failover.Classification
+	UpstreamStatus int
+	ErrMsg         string
+	ChainPosition  int
+	RuleID         string
+	DurationMS     int64
+	EvidenceID     string
+}
+
+// failoverOutcome summarizes the fallback chain execution for evidence,
+// metrics, and OTel span attributes.
+type failoverOutcome struct {
+	SelectedProvider string
+	SelectedModel    string
+	ChainPosition    int
+	RuleID           string
+	FailedAttempts   []failoverAttemptRecord
+	Skipped          []evidence.SkippedCandidate
+	// FailClosed is true when the failover machinery was engaged and the
+	// caller received an error: either no policy-valid candidate existed
+	// (no fallback dispatch at all) or every valid candidate failed. Under
+	// eu_strict, refusing to route outside EU/LOCAL is a successful
+	// governance outcome even though the request failed.
+	FailClosed bool
+	// Engaged is true when the primary attempt failed transiently and a
+	// fallback chain was configured (i.e. failover logic actually ran).
+	Engaged bool
+}
+
+// failedAttemptIDs returns the evidence IDs of all recorded failed attempts.
+func (o *failoverOutcome) failedAttemptIDs() []string {
+	if len(o.FailedAttempts) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(o.FailedAttempts))
+	for i := range o.FailedAttempts {
+		if id := o.FailedAttempts[i].EvidenceID; id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// recordAttemptFn persists a signed failed-attempt evidence record and
+// returns its evidence ID ("" when persistence failed; the request continues
+// — evidence write failures are logged, never silently drop traffic).
+type recordAttemptFn func(ctx context.Context, rec failoverAttemptRecord) string
+
+// classifyAttempt classifies a Forward outcome from its transport error
+// and/or buffered upstream status.
+func classifyAttempt(err error, status int) failover.Classification {
+	if err != nil {
+		return failover.ClassifyHTTP(err, 0)
+	}
+	return failover.ClassifyHTTP(nil, status)
+}
+
+// rewriteModelInBody replaces the top-level "model" field of a JSON request
+// body. On any parse error the original body is returned unchanged (the
+// upstream will reject it with a provider-native error).
+func rewriteModelInBody(body []byte, model string) []byte {
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	m["model"] = model
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// fallbackAuthHeaders clones the primary attempt's upstream headers and
+// replaces credentials with the fallback target's own. Secret-mode targets
+// read from the tenant-scoped secret store; client_bearer targets keep the
+// caller's bearer token.
+func (g *Gateway) fallbackAuthHeaders(ctx context.Context, caller *CallerConfig, providerName string, prov ProviderConfig, originalAuthorization string, base map[string]string) (map[string]string, error) {
+	headers := make(map[string]string, len(base))
+	for k, v := range base {
+		switch strings.ToLower(k) {
+		case "authorization", "x-api-key":
+			continue
+		}
+		headers[k] = v
+	}
+	authMode := strings.TrimSpace(prov.UpstreamAuthMode)
+	if authMode == "" {
+		authMode = DefaultUpstreamAuthMode
+	}
+	if authMode == "client_bearer" {
+		clientKey := strings.TrimSpace(strings.TrimPrefix(originalAuthorization, "Bearer "))
+		if clientKey == "" {
+			return nil, fmt.Errorf("fallback provider %s: no client bearer credential", providerName)
+		}
+		headers["Authorization"] = "Bearer " + clientKey
+		return headers, nil
+	}
+	if prov.SecretName != "" {
+		secret, err := g.secretsStore.Get(ctx, prov.SecretName, caller.TenantID, caller.Name)
+		if err != nil {
+			return nil, fmt.Errorf("fallback provider %s: secret retrieval: %w", providerName, err)
+		}
+		if providerName == "anthropic" {
+			headers["x-api-key"] = string(secret.Value)
+		} else {
+			headers["Authorization"] = "Bearer " + string(secret.Value)
+		}
+	}
+	return headers, nil
+}
+
+// modelAllowedForProvider checks a fallback target's model against the target
+// provider's allow/block lists (prevents a fallback rewrite from bypassing a
+// per-provider model policy).
+func modelAllowedForProvider(prov ProviderConfig, model string) bool {
+	for _, m := range prov.BlockedModels {
+		if m == model {
+			return false
+		}
+	}
+	if len(prov.AllowedModels) == 0 {
+		return true
+	}
+	for _, m := range prov.AllowedModels {
+		if m == model {
+			return true
+		}
+	}
+	return false
+}
+
+// forwardWithFailover forwards the request to the routed provider and, on a
+// transient upstream failure (timeout / connection error / 429 / 5xx), walks
+// the provider's ordered fallback chain. Every candidate passes the filter
+// pipeline first (sovereignty under eu_strict; issue #189 model policy facts
+// plug in here) — refused candidates are recorded as skipped, never
+// dispatched. Failed runtime attempts are persisted as separate signed
+// evidence records via recordAttempt. When no candidate succeeds the request
+// fails closed: the buffered upstream error (or a gateway 502 when nothing
+// was dispatched) is returned to the caller and the outcome marks the
+// governance result for the final evidence record.
+//
+//nolint:gocyclo // sequential chain walk with per-candidate filtering and error classification
+func (g *Gateway) forwardWithFailover(
+	ctx context.Context,
+	dst http.ResponseWriter,
+	p ForwardParams,
+	route RouteResult,
+	caller *CallerConfig,
+	clientModel string,
+	originalAuthorization string,
+	recordAttempt recordAttemptFn,
+) (*failoverOutcome, error) {
+	out := &failoverOutcome{SelectedProvider: route.Provider, SelectedModel: clientModel}
+
+	prov, _ := g.config.Provider(route.Provider)
+	chain := prov.Fallback
+
+	fw := newFailoverWriter(dst)
+	err := Forward(fw, p)
+	class := classifyAttempt(err, fw.status)
+
+	if !class.Transient || fw.committed || len(chain) == 0 {
+		// Success, permanent upstream error, mid-stream failure after first
+		// byte, or no chain configured: identical behavior to a chainless
+		// gateway.
+		fw.flushTo()
+		return out, err
+	}
+
+	out.Engaged = true
+	primaryRec := failoverAttemptRecord{
+		Provider:       route.Provider,
+		Model:          clientModel,
+		Class:          class,
+		UpstreamStatus: fw.status,
+		ChainPosition:  0,
+		RuleID:         fmt.Sprintf("gateway.providers.%s", route.Provider),
+		DurationMS:     0,
+	}
+	if err != nil {
+		primaryRec.ErrMsg = err.Error()
+	}
+	primaryRec.EvidenceID = recordAttempt(ctx, primaryRec)
+	out.FailedAttempts = append(out.FailedAttempts, primaryRec)
+
+	mode := g.config.EffectiveSovereigntyMode
+	filters := failover.Pipeline{failover.NewSovereigntyFilter(mode)}
+	lastBuffered := fw
+
+	for i, target := range chain {
+		if ctx.Err() != nil {
+			break
+		}
+		ruleID := fmt.Sprintf("gateway.providers.%s.fallback[%d]", route.Provider, i)
+		model := target.Model
+		if model == "" {
+			model = clientModel
+		}
+		cand := failover.Candidate{
+			Provider:      target.Provider,
+			Model:         model,
+			Region:        g.providerRegion(target.Provider),
+			ChainPosition: i + 1,
+			RuleID:        ruleID,
+		}
+		if res := filters.Evaluate(ctx, cand); !res.Allowed {
+			out.Skipped = append(out.Skipped, evidence.SkippedCandidate{
+				Provider: target.Provider, Model: model, ChainPosition: i + 1,
+				Filter: res.Filter, Reason: res.Reason,
+			})
+			if res.Filter == "sovereignty" {
+				RecordSovereigntyProviderDenied(ctx, target.Provider)
+			}
+			log.Warn().Str("provider", target.Provider).Str("filter", res.Filter).Str("reason", res.Reason).Msg("gateway_failover_candidate_skipped")
+			continue
+		}
+		tprov, ok := g.config.Provider(target.Provider)
+		if !ok || !tprov.Enabled {
+			out.Skipped = append(out.Skipped, evidence.SkippedCandidate{
+				Provider: target.Provider, Model: model, ChainPosition: i + 1,
+				Filter: "config", Reason: "provider not enabled",
+			})
+			continue
+		}
+		if !modelAllowedForProvider(tprov, model) {
+			out.Skipped = append(out.Skipped, evidence.SkippedCandidate{
+				Provider: target.Provider, Model: model, ChainPosition: i + 1,
+				Filter: "model_allowlist", Reason: fmt.Sprintf("model %q not allowed for provider %s", model, target.Provider),
+			})
+			continue
+		}
+
+		headers, hdrErr := g.fallbackAuthHeaders(ctx, caller, target.Provider, tprov, originalAuthorization, p.Headers)
+		if hdrErr != nil {
+			out.Skipped = append(out.Skipped, evidence.SkippedCandidate{
+				Provider: target.Provider, Model: model, ChainPosition: i + 1,
+				Filter: "credentials", Reason: "upstream credential unavailable",
+			})
+			log.Warn().Err(hdrErr).Str("provider", target.Provider).Msg("gateway_failover_credentials_unavailable")
+			continue
+		}
+
+		ap := p
+		ap.UpstreamURL = strings.TrimSuffix(tprov.BaseURL, "/") + route.Path
+		ap.Headers = headers
+		if target.Model != "" {
+			ap.Body = rewriteModelInBody(p.Body, target.Model)
+		}
+
+		log.Info().
+			Str("from_provider", route.Provider).
+			Str("to_provider", target.Provider).
+			Str("error_class", class.Class).
+			Int("chain_position", i+1).
+			Msg("gateway_failover_attempt")
+
+		fw = newFailoverWriter(dst)
+		attemptStart := time.Now()
+		err = Forward(fw, ap)
+		class = classifyAttempt(err, fw.status)
+
+		if !class.Transient || fw.committed {
+			// Success (or permanent upstream response, or mid-stream failure):
+			// this candidate is the provider actually used.
+			out.SelectedProvider = target.Provider
+			out.SelectedModel = model
+			out.ChainPosition = i + 1
+			out.RuleID = ruleID
+			fw.flushTo()
+			return out, err
+		}
+
+		rec := failoverAttemptRecord{
+			Provider:       target.Provider,
+			Model:          model,
+			Class:          class,
+			UpstreamStatus: fw.status,
+			ChainPosition:  i + 1,
+			RuleID:         ruleID,
+			DurationMS:     time.Since(attemptStart).Milliseconds(),
+		}
+		if err != nil {
+			rec.ErrMsg = err.Error()
+		}
+		rec.EvidenceID = recordAttempt(ctx, rec)
+		out.FailedAttempts = append(out.FailedAttempts, rec)
+		lastBuffered = fw
+	}
+
+	// Chain exhausted: fail closed. Return the last buffered upstream error
+	// when a dispatch happened; otherwise (every candidate refused before
+	// dispatch) a gateway error naming the governance outcome.
+	out.FailClosed = true
+	out.SelectedProvider = ""
+	out.SelectedModel = ""
+	if lastBuffered.status != 0 || lastBuffered.buf.Len() > 0 {
+		lastBuffered.flushTo()
+	} else {
+		WriteProviderError(dst, route.Provider, http.StatusBadGateway,
+			"upstream provider failed and no policy-valid fallback candidate exists (fail-closed)")
+	}
+	if err == nil {
+		err = fmt.Errorf("provider %s failed (%s) and no fallback candidate succeeded: %w", route.Provider, primaryRec.Class.Class, ErrNoFallbackCandidate)
+	}
+	return out, err
+}
+
+// ErrNoFallbackCandidate is returned when a transient upstream failure could
+// not be recovered because no policy-valid fallback candidate succeeded.
+var ErrNoFallbackCandidate = errors.New("no policy-valid fallback candidate available")
+
+// recordFailoverAttemptEvidence persists a signed evidence record for one
+// failed provider attempt (evidence-by-default: the failed attempt is a fact
+// of its own, linked to the request by correlation ID). Returns the evidence
+// ID, or "" when the write failed.
+func (g *Gateway) recordFailoverAttemptEvidence(ctx context.Context, correlationID string, caller *CallerConfig, mode string, tier int, rec failoverAttemptRecord, dataFlow *evidence.DataFlow) string {
+	errMsg := rec.ErrMsg
+	if errMsg == "" && rec.UpstreamStatus != 0 {
+		errMsg = fmt.Sprintf("upstream status %d", rec.UpstreamStatus)
+	}
+	ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, RecordGatewayEvidenceParams{
+		CorrelationID:  correlationID,
+		SessionID:      sessionIDFromContext(ctx),
+		TenantID:       caller.TenantID,
+		CallerName:     caller.Name,
+		Team:           caller.Team,
+		Provider:       rec.Provider,
+		Model:          rec.Model,
+		PolicyAllowed:  true,
+		InputTier:      tier,
+		DurationMS:     rec.DurationMS,
+		Error:          errMsg,
+		InvocationType: "gateway_failover_attempt",
+		Status:         "failed",
+		FailureReason:  evidence.FailureReasonProviderTransient,
+		DataFlow:       dataFlow,
+		Failover: &evidence.FailoverContext{
+			Role:            evidence.FailoverRoleFailedAttempt,
+			Provider:        rec.Provider,
+			Region:          g.providerRegion(rec.Provider),
+			Model:           rec.Model,
+			ErrorClass:      rec.Class.Class,
+			UpstreamStatus:  rec.UpstreamStatus,
+			ChainPosition:   rec.ChainPosition,
+			FallbackRuleID:  rec.RuleID,
+			SovereigntyMode: mode,
+		},
+	})
+	if err != nil {
+		g.handleEvidenceWriteFailure(ctx, err)
+		return ""
+	}
+	return ev.ID
+}
+
+// buildFailoverDecisionContext assembles the FailoverContext for the
+// request's final evidence record after the failover machinery was engaged.
+func (g *Gateway) buildFailoverDecisionContext(out *failoverOutcome, mode string) *evidence.FailoverContext {
+	if out == nil || !out.Engaged {
+		return nil
+	}
+	fc := &evidence.FailoverContext{
+		Role:              evidence.FailoverRoleFallbackDecision,
+		Provider:          out.SelectedProvider,
+		Model:             out.SelectedModel,
+		ChainPosition:     out.ChainPosition,
+		FallbackRuleID:    out.RuleID,
+		SovereigntyMode:   mode,
+		FailedAttemptIDs:  out.failedAttemptIDs(),
+		SkippedCandidates: out.Skipped,
+	}
+	if out.FailClosed {
+		fc.Role = evidence.FailoverRoleFailClosed
+		if n := len(out.FailedAttempts); n > 0 {
+			fc.ErrorClass = out.FailedAttempts[n-1].Class.Class
+		}
+		return fc
+	}
+	fc.Region = g.providerRegion(out.SelectedProvider)
+	if mode == config.DataSovereigntyEUStrict {
+		fc.SovereigntyCheck = "allowed"
+	} else {
+		fc.SovereigntyCheck = "not_evaluated"
+	}
+	return fc
+}

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -72,23 +72,38 @@ func newFailoverUpstream(t *testing.T, status int) *failoverUpstream {
 	return u
 }
 
+// extraBackup adds another provider to the fallback chain after "backup".
+type extraBackup struct {
+	name   string
+	region string
+	up     *failoverUpstream
+}
+
 // setupFailoverGateway wires a gateway with a primary provider ("openai") and
 // a fallback provider ("backup") whose regions and chain are configurable.
-func setupFailoverGateway(t *testing.T, sovereigntyMode, primaryRegion, backupRegion string, primary, backup *failoverUpstream, fallbackModel string) (*Gateway, *evidence.Store) {
+// Additional chain targets can be appended via extras.
+func setupFailoverGateway(t *testing.T, sovereigntyMode, primaryRegion, backupRegion string, primary, backup *failoverUpstream, fallbackModel string, extras ...extraBackup) (*Gateway, *evidence.Store) {
 	t.Helper()
 	dir := t.TempDir()
+
+	chain := []FallbackTarget{{Provider: "backup", Model: fallbackModel}}
+	providers := map[string]ProviderConfig{
+		"backup": {Enabled: true, BaseURL: backup.server.URL, SecretName: "backup-api-key", Region: backupRegion},
+	}
+	for _, e := range extras {
+		providers[e.name] = ProviderConfig{Enabled: true, BaseURL: e.up.server.URL, SecretName: "backup-api-key", Region: e.region}
+		chain = append(chain, FallbackTarget{Provider: e.name})
+	}
+	providers["openai"] = ProviderConfig{
+		Enabled: true, BaseURL: primary.server.URL, SecretName: "openai-api-key", Region: primaryRegion,
+		Fallback: chain,
+	}
 
 	cfg := &GatewayConfig{
 		Enabled:      true,
 		ListenPrefix: "/v1/proxy",
 		Mode:         ModeEnforce,
-		Providers: map[string]ProviderConfig{
-			"openai": {
-				Enabled: true, BaseURL: primary.server.URL, SecretName: "openai-api-key", Region: primaryRegion,
-				Fallback: []FallbackTarget{{Provider: "backup", Model: fallbackModel}},
-			},
-			"backup": {Enabled: true, BaseURL: backup.server.URL, SecretName: "backup-api-key", Region: backupRegion},
-		},
+		Providers:    providers,
 		Callers: []CallerConfig{
 			{
 				Name: "failover-bot", TenantKey: failoverTestTenantKey, TenantID: "test-tenant",
@@ -306,6 +321,107 @@ func TestGatewayFailover_BothProvidersFail_FailClosedWithAttempts(t *testing.T) 
 	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
 }
 
+// A fallback candidate failing with a PERMANENT error (misconfigured secret,
+// missing model) must never be recorded as the provider actually used: it is
+// a failed attempt and the outcome is fail-closed, not a fallback decision.
+func TestGatewayFailover_FallbackPermanentError_FailsClosed(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		wantClass  string
+		statusBody string
+	}{
+		{name: "fallback 401", status: http.StatusUnauthorized, wantClass: "auth_error", statusBody: `{"error":{"message":"bad key","type":"invalid_request_error"}}`},
+		{name: "fallback 404", status: http.StatusNotFound, wantClass: "client_error", statusBody: `{"error":{"message":"model not found","type":"invalid_request_error"}}`},
+		{name: "fallback 422", status: http.StatusUnprocessableEntity, wantClass: "client_error", statusBody: `{"error":{"message":"unprocessable","type":"invalid_request_error"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+			backup := newFailoverUpstream(t, tc.status)
+			backup.statusBody = tc.statusBody
+			gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+			w := makeFailoverRequest(gw, failoverTestBody)
+
+			assert.Equal(t, tc.status, w.Code, "caller sees the fallback's upstream error")
+			assert.Equal(t, int64(1), backup.calls.Load())
+
+			correlationID := correlationIDFromResponse(t, w)
+			attempts, final := failoverRecords(t, store, correlationID)
+			require.Len(t, attempts, 2, "the permanent fallback failure must be a failed attempt too")
+			assert.Equal(t, "upstream_5xx", attempts[0].Failover.ErrorClass)
+			assert.Equal(t, evidence.FailureReasonProviderTransient, attempts[0].FailureReason)
+			assert.Equal(t, tc.wantClass, attempts[1].Failover.ErrorClass)
+			assert.Equal(t, evidence.FailureReasonProviderPermanent, attempts[1].FailureReason,
+				"failure_reason must match the error class, not claim transient")
+
+			require.NotNil(t, final)
+			require.NotNil(t, final.Failover)
+			assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role,
+				"a failed fallback must never become the fallback decision")
+			assert.Equal(t, "failed", final.Status)
+			assert.Len(t, final.Failover.FailedAttemptIDs, 2)
+
+			finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
+			require.NoError(t, err)
+			assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
+		})
+	}
+}
+
+// Once failover is engaged, only success ends the chain: a permanently
+// failing fallback candidate is skipped over and the next candidate is tried.
+func TestGatewayFailover_ChainContinuesPastPermanentFallback(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	badBackup := newFailoverUpstream(t, http.StatusUnauthorized)
+	goodBackup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, badBackup, "",
+		extraBackup{name: "backup2", region: "EU", up: goodBackup})
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback says hi")
+	assert.Equal(t, int64(1), badBackup.calls.Load())
+	assert.Equal(t, int64(1), goodBackup.calls.Load())
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 2)
+	assert.Equal(t, "auth_error", attempts[1].Failover.ErrorClass)
+
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, final.Failover.Role)
+	assert.Equal(t, "backup2", final.Failover.Provider)
+	assert.Equal(t, 2, final.Failover.ChainPosition)
+	assert.Len(t, final.Failover.FailedAttemptIDs, 2)
+
+	finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
+	require.NoError(t, err)
+	assert.Equal(t, evidence.FailoverVerdictValidFallback, finding.Verdict, "details: %v", finding.Details)
+}
+
+// api_family lets aliased Anthropic-compatible endpoints join chains and get
+// Anthropic auth conventions (x-api-key + anthropic-version).
+func TestGatewayFailover_APIFamilyAliases(t *testing.T) {
+	t.Run("fallbackAuthHeaders uses x-api-key for anthropic-family alias", func(t *testing.T) {
+		primary := newFailoverUpstream(t, http.StatusOK)
+		backup := newFailoverUpstream(t, http.StatusOK)
+		gw, _ := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+		prov := ProviderConfig{Enabled: true, BaseURL: backup.server.URL, SecretName: "backup-api-key", APIFamily: "anthropic"}
+		gw.config.Providers["anthropic-eu"] = prov
+		headers, err := gw.fallbackAuthHeaders(context.Background(),
+			gw.config.CallerByName("failover-bot"), "anthropic-eu", prov,
+			"Bearer client-token", map[string]string{"Authorization": "Bearer old", "Content-Type": "application/json"})
+		require.NoError(t, err)
+		assert.Equal(t, "sk-backup-key-1234567890", headers["x-api-key"])
+		assert.Equal(t, "2023-06-01", headers["anthropic-version"])
+		assert.Empty(t, headers["Authorization"], "bearer auth of the failed provider must not leak to an anthropic-family target")
+	})
+}
+
 func TestGatewayConfig_ValidateFallbackChain(t *testing.T) {
 	base := func() *GatewayConfig {
 		return &GatewayConfig{
@@ -388,14 +504,32 @@ func TestGatewayConfig_ValidateFallbackChain(t *testing.T) {
 			wantErr: "provider is required",
 		},
 		{
-			name: "anthropic to anthropic-family is fine",
+			name: "anthropic alias without api_family is rejected",
 			mutate: func(c *GatewayConfig) {
 				c.Providers["anthropic-eu"] = ProviderConfig{Enabled: true, BaseURL: "https://eu.anthropic.example.com", SecretName: "k4"}
 				p := c.Providers["anthropic"]
 				p.Fallback = []FallbackTarget{{Provider: "anthropic-eu"}}
 				c.Providers["anthropic"] = p
 			},
-			wantErr: "API family", // anthropic-eu resolves to openai family by name; must be rejected
+			wantErr: "API family", // without api_family, anthropic-eu resolves to openai by name
+		},
+		{
+			name: "anthropic alias with api_family anthropic is accepted",
+			mutate: func(c *GatewayConfig) {
+				c.Providers["anthropic-eu"] = ProviderConfig{Enabled: true, BaseURL: "https://eu.anthropic.example.com", SecretName: "k4", APIFamily: "anthropic"}
+				p := c.Providers["anthropic"]
+				p.Fallback = []FallbackTarget{{Provider: "anthropic-eu"}}
+				c.Providers["anthropic"] = p
+			},
+		},
+		{
+			name: "invalid api_family value is rejected",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.APIFamily = "grpc"
+				c.Providers["openai"] = p
+			},
+			wantErr: "api_family must be openai or anthropic",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dativo-io/talon/internal/cache"
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
@@ -35,9 +37,11 @@ type failoverUpstream struct {
 	// status controls the response code (200 = success). 0 = kill connection.
 	status atomic.Int64
 	// lastModel records the "model" field of the last request body.
-	lastModel  atomic.Value
-	lastAuth   atomic.Value
-	statusBody string
+	lastModel   atomic.Value
+	lastAuth    atomic.Value
+	lastBody    atomic.Value // full raw request body
+	lastHeaders atomic.Value // http.Header of the last request
+	statusBody  string
 }
 
 func newFailoverUpstream(t *testing.T, status int) *failoverUpstream {
@@ -46,10 +50,13 @@ func newFailoverUpstream(t *testing.T, status int) *failoverUpstream {
 	u.status.Store(int64(status))
 	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u.calls.Add(1)
+		raw, _ := io.ReadAll(r.Body)
+		u.lastBody.Store(string(raw))
+		u.lastHeaders.Store(r.Header.Clone())
 		var body struct {
 			Model string `json:"model"`
 		}
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.Unmarshal(raw, &body)
 		u.lastModel.Store(body.Model)
 		u.lastAuth.Store(r.Header.Get("Authorization"))
 		st := int(u.status.Load())
@@ -217,6 +224,9 @@ func TestGatewayFailover_Upstream5xx_FailsOverToSecondary(t *testing.T) {
 	assert.Equal(t, "allowed", final.Failover.SovereigntyCheck)
 	assert.Equal(t, []string{att.ID}, final.Failover.FailedAttemptIDs)
 	assert.Equal(t, "backup", final.RoutingDecision.SelectedProvider, "evidence must record the provider actually used")
+	assert.NotEmpty(t, final.Failover.FailoverGroupID)
+	assert.Equal(t, att.Failover.FailoverGroupID, final.Failover.FailoverGroupID,
+		"attempt and terminal record must share one failover group")
 	assert.True(t, store.VerifyRecord(final))
 
 	finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
@@ -262,7 +272,7 @@ func TestGatewayFailover_EUStrict_USSecondary_FailsClosed(t *testing.T) {
 	require.NotNil(t, final.Failover)
 	assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role)
 	assert.Equal(t, "failed", final.Status)
-	assert.Equal(t, evidence.FailureReasonNoSovereignFallback, final.FailureReason)
+	assert.Equal(t, evidence.FailureReasonNoValidFallbackCandidate, final.FailureReason)
 	require.Len(t, final.Failover.SkippedCandidates, 1)
 	assert.Equal(t, "backup", final.Failover.SkippedCandidates[0].Provider)
 	assert.Equal(t, "sovereignty", final.Failover.SkippedCandidates[0].Filter)
@@ -487,6 +497,165 @@ func TestGatewayFailover_CallerModelPolicy_SkipsCandidate(t *testing.T) {
 	assert.Equal(t, "gateway_policy", final.Failover.SkippedCandidates[0].Filter)
 }
 
+// An Anthropic-compatible ALIAS must get Anthropic governance end to end:
+// extraction, PII redaction, auth conventions, and error shape must follow
+// api_family, never the provider map key. Anything less lets an alias bypass
+// PII scanning by being parsed as OpenAI.
+func TestGatewayAlias_AnthropicFamilyGovernance(t *testing.T) {
+	upstream := newFailoverUpstream(t, http.StatusOK)
+	dir := t.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"anthropic-eu": {Enabled: true, BaseURL: upstream.server.URL, SecretName: "anthropic-eu-key", Region: "EU", APIFamily: "anthropic"},
+		},
+		Callers: []CallerConfig{{
+			Name: "alias-bot", TenantKey: failoverTestTenantKey, TenantID: "test-tenant",
+			PolicyOverrides: &CallerPolicyOverrides{PIIAction: "redact", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+		}},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "redact", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+		Timeouts:       TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+	require.NoError(t, cfg.Validate())
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "anthropic-eu-key", []byte("sk-ant-alias-key-123456"),
+		secrets.ACL{Tenants: []string{"test-tenant"}, Agents: []string{"*"}}))
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+
+	anthropicBody := `{"model":"claude-sonnet-4-20250514","max_tokens":100,"messages":[{"role":"user","content":"Contact jan.kowalski@example.com about the invoice"}]}`
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) { r.Handle("/*", gw) })
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://test/v1/proxy/anthropic-eu/v1/messages", bytes.NewReader([]byte(anthropicBody)))
+	req.Header.Set("Authorization", "Bearer "+failoverTestTenantKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// Extraction followed the Anthropic wire format: the model was found.
+	assert.Equal(t, "claude-sonnet-4-20250514", upstream.lastModel.Load())
+
+	// PII redaction followed the Anthropic wire format: the email never
+	// reached the upstream.
+	sentBody, _ := upstream.lastBody.Load().(string)
+	assert.NotContains(t, sentBody, "jan.kowalski@example.com",
+		"alias request must be redacted via the Anthropic extractor, not the OpenAI default")
+
+	// Auth followed the Anthropic conventions for the alias.
+	hdrs, _ := upstream.lastHeaders.Load().(http.Header)
+	require.NotNil(t, hdrs)
+	assert.Equal(t, "sk-ant-alias-key-123456", hdrs.Get("x-api-key"))
+	assert.NotEmpty(t, hdrs.Get("anthropic-version"))
+	assert.Empty(t, hdrs.Get("Authorization"))
+
+	// Evidence recorded the extracted model (proves extraction worked).
+	correlationID := correlationIDFromResponse(t, w)
+	records, err := evStore.ListByCorrelationID(context.Background(), correlationID)
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	assert.Equal(t, "claude-sonnet-4-20250514", records[len(records)-1].Execution.ModelUsed)
+}
+
+// Shadow mode must never change runtime behavior: a candidate the gateway
+// policy would deny is still dispatched in shadow mode, with the would-be
+// denial recorded as a shadow violation on the final evidence record.
+func TestGatewayFailover_ShadowMode_CandidatePolicyDoesNotBlock(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "gpt-4o")
+	gw.config.Mode = ModeShadow
+	// Caller model policy denies everything except the primary's model —
+	// in enforce mode the gpt-4o fallback rewrite would be skipped.
+	gw.config.Callers[0].PolicyOverrides.AllowedModels = []string{"gpt-4o-mini"}
+	policyEngine, err := policy.NewGatewayEngine(context.Background())
+	require.NoError(t, err)
+	gw.policy = policyEngine
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code, "shadow mode must not fail closed on a policy-denied candidate")
+	assert.Equal(t, int64(1), backup.calls.Load(), "candidate must be dispatched in shadow mode")
+
+	correlationID := correlationIDFromResponse(t, w)
+	_, final := failoverRecords(t, store, correlationID)
+	require.NotNil(t, final)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, final.Failover.Role)
+	found := false
+	for _, sv := range final.ShadowViolations {
+		if sv.Type == "policy_deny" && strings.Contains(sv.Detail, "failover candidate") {
+			found = true
+		}
+	}
+	assert.True(t, found, "the would-be candidate denial must be recorded as a shadow violation: %+v", final.ShadowViolations)
+}
+
+// The primary request and fallback candidates must be evaluated against the
+// exact same policy input surface — guard against the two constructions
+// drifting apart.
+func TestPolicyInputParity_PrimaryVsCandidate(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusOK)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, _ := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+	caller := &gw.config.Callers[0]
+
+	primaryInput := gw.buildPolicyInputForRequest(context.Background(), caller, "openai", "gpt-4o-mini", 1, 0.01, 1, 2, "")
+	candidateInput := gw.buildPolicyInputForRequest(context.Background(), caller, "backup", "gpt-4o", 1, 0.02, 1, 2, "")
+
+	primaryKeys := make([]string, 0, len(primaryInput))
+	for k := range primaryInput {
+		primaryKeys = append(primaryKeys, k)
+	}
+	candidateKeys := make([]string, 0, len(candidateInput))
+	for k := range candidateInput {
+		candidateKeys = append(candidateKeys, k)
+	}
+	assert.ElementsMatch(t, primaryKeys, candidateKeys,
+		"primary and candidate policy inputs must expose the same fields")
+	assert.Equal(t, "gpt-4o", candidateInput["model"])
+	assert.Equal(t, "backup", candidateInput["provider"])
+	assert.Equal(t, 0.02, candidateInput["estimated_cost"], "candidate cost must be recomputed for the candidate model")
+}
+
+// A failover model rewrite makes the fallback-selected model the truth: the
+// semantic cache must store the response under that model, not the one the
+// client asked for.
+func TestGatewayFailover_CacheStoresSelectedModel(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, _ := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "gpt-4o-mini-eu")
+
+	dir := t.TempDir()
+	cacheStore, err := cache.NewStore(filepath.Join(dir, "c.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cacheStore.Close() })
+	embedder := cache.NewBM25()
+	cachePolicy, err := cache.NewEvaluator(context.Background())
+	require.NoError(t, err)
+	gw.SetCache(cacheStore, embedder, nil, cachePolicy, true, 3600, nil, 0.9, 100)
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	queryBlob, err := embedder.Embed("Summarize our public roadmap")
+	require.NoError(t, err)
+	hit, err := cacheStore.Lookup(context.Background(), "test-tenant", queryBlob, 0.9, 100, embedder.SimilarityFunc())
+	require.NoError(t, err)
+	require.NotNil(t, hit, "response must have been cached")
+	assert.Equal(t, "gpt-4o-mini-eu", hit.Entry.Model,
+		"cache entry must carry the fallback-selected model, not the requested one")
+}
+
 // api_family lets aliased Anthropic-compatible endpoints join chains and get
 // Anthropic auth conventions (x-api-key + anthropic-version).
 func TestGatewayFailover_APIFamilyAliases(t *testing.T) {
@@ -615,6 +784,13 @@ func TestGatewayConfig_ValidateFallbackChain(t *testing.T) {
 				c.Providers["openai"] = p
 			},
 			wantErr: "api_family must be openai or anthropic",
+		},
+		{
+			name: "client_bearer with anthropic api_family is rejected",
+			mutate: func(c *GatewayConfig) {
+				c.Providers["anthropic-eu"] = ProviderConfig{Enabled: true, BaseURL: "https://eu.anthropic.example.com", APIFamily: "anthropic", UpstreamAuthMode: "client_bearer"}
+			},
+			wantErr: "client_bearer is not supported for the anthropic API family",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
 	"github.com/dativo-io/talon/internal/secrets"
 	"github.com/dativo-io/talon/internal/testutil"
 )
@@ -57,6 +58,17 @@ func newFailoverUpstream(t *testing.T, status int) *failoverUpstream {
 			hj, ok := w.(http.Hijacker)
 			require.True(t, ok)
 			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+			return
+		}
+		if st == -1 {
+			// 200 headers, then die before delivering the promised body:
+			// the client's body read fails with unexpected EOF.
+			hj, ok := w.(http.Hijacker)
+			require.True(t, ok)
+			conn, buf, _ := hj.Hijack()
+			_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1000\r\n\r\n{\"partial\":")
+			_ = buf.Flush()
 			_ = conn.Close()
 			return
 		}
@@ -402,6 +414,79 @@ func TestGatewayFailover_ChainContinuesPastPermanentFallback(t *testing.T) {
 	assert.Equal(t, evidence.FailoverVerdictValidFallback, finding.Verdict, "details: %v", finding.Details)
 }
 
+// A 200-with-headers upstream that dies before the body is delivered must
+// still be able to fail over: the failoverWriter commits on the first body
+// write, not on the header write.
+func TestGatewayFailover_200HeadersThenBodyEOF_FailsOver(t *testing.T) {
+	primary := newFailoverUpstream(t, -1) // 200 headers, then connection dies
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback says hi")
+	assert.Equal(t, int64(1), backup.calls.Load())
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 1)
+	assert.Equal(t, "connection_error", attempts[0].Failover.ErrorClass)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, final.Failover.Role)
+}
+
+// Fallback candidates must pass the caller's allowed_providers gate — the
+// same authorization the primary route passed. A candidate outside the
+// caller's allowlist is skipped, never dispatched.
+func TestGatewayFailover_CallerAllowedProviders_SkipsCandidate(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+	// Restrict the caller to the primary provider only.
+	gw.config.Callers[0].AllowedProviders = []string{"openai"}
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, int64(0), backup.calls.Load(), "candidate outside caller allowed_providers must never be dispatched")
+
+	correlationID := correlationIDFromResponse(t, w)
+	_, final := failoverRecords(t, store, correlationID)
+	require.NotNil(t, final)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role)
+	require.Len(t, final.Failover.SkippedCandidates, 1)
+	assert.Equal(t, "caller_allowlist", final.Failover.SkippedCandidates[0].Filter)
+}
+
+// Fallback candidates re-run the full gateway policy with their own provider
+// and model, so a caller-level model restriction cannot be bypassed by a
+// fallback model rewrite.
+func TestGatewayFailover_CallerModelPolicy_SkipsCandidate(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "gpt-4o")
+	gw.config.Callers[0].PolicyOverrides.AllowedModels = []string{"gpt-4o-mini"}
+	// Wire the real gateway policy engine so caller model lists are enforced.
+	policyEngine, err := policy.NewGatewayEngine(context.Background())
+	require.NoError(t, err)
+	gw.policy = policyEngine
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, int64(0), backup.calls.Load(), "fallback model outside caller allowed_models must never be dispatched")
+
+	correlationID := correlationIDFromResponse(t, w)
+	_, final := failoverRecords(t, store, correlationID)
+	require.NotNil(t, final)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role)
+	require.Len(t, final.Failover.SkippedCandidates, 1)
+	assert.Equal(t, "gateway_policy", final.Failover.SkippedCandidates[0].Filter)
+}
+
 // api_family lets aliased Anthropic-compatible endpoints join chains and get
 // Anthropic auth conventions (x-api-key + anthropic-version).
 func TestGatewayFailover_APIFamilyAliases(t *testing.T) {
@@ -548,16 +633,27 @@ func TestGatewayConfig_ValidateFallbackChain(t *testing.T) {
 }
 
 func TestFailoverWriter(t *testing.T) {
-	t.Run("success status commits immediately", func(t *testing.T) {
+	t.Run("success status commits on first body write, not on headers", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		fw := newFailoverWriter(rec)
 		fw.Header().Set("Content-Type", "application/json")
 		fw.WriteHeader(http.StatusOK)
-		assert.True(t, fw.committed)
+		assert.False(t, fw.committed, "200 headers alone must not commit — a body-read failure can still fail over")
 		_, _ = fw.Write([]byte("hello"))
+		assert.True(t, fw.committed)
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, "hello", rec.Body.String())
 		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	})
+
+	t.Run("success status with empty body commits on flushTo", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		fw := newFailoverWriter(rec)
+		fw.WriteHeader(http.StatusNoContent)
+		assert.False(t, fw.committed)
+		fw.flushTo()
+		assert.True(t, fw.committed)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
 	})
 
 	t.Run("error status stays buffered until flushTo", func(t *testing.T) {

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -1,0 +1,443 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+const (
+	failoverTestTenantKey = "talon-gw-failover-001"
+	failoverTestBody      = `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Summarize our public roadmap"}]}`
+)
+
+// failoverUpstream is a controllable fake provider endpoint.
+type failoverUpstream struct {
+	server *httptest.Server
+	calls  atomic.Int64
+	// status controls the response code (200 = success). 0 = kill connection.
+	status atomic.Int64
+	// lastModel records the "model" field of the last request body.
+	lastModel  atomic.Value
+	lastAuth   atomic.Value
+	statusBody string
+}
+
+func newFailoverUpstream(t *testing.T, status int) *failoverUpstream {
+	t.Helper()
+	u := &failoverUpstream{statusBody: `{"error":{"message":"upstream unavailable","type":"server_error"}}`}
+	u.status.Store(int64(status))
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.calls.Add(1)
+		var body struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		u.lastModel.Store(body.Model)
+		u.lastAuth.Store(r.Header.Get("Authorization"))
+		st := int(u.status.Load())
+		if st == 0 {
+			// Kill the connection mid-request (simulates provider death).
+			hj, ok := w.(http.Hijacker)
+			require.True(t, ok)
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(st)
+		if st == http.StatusOK {
+			_, _ = w.Write([]byte(`{"id":"1","choices":[{"message":{"content":"fallback says hi"}}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`))
+			return
+		}
+		_, _ = w.Write([]byte(u.statusBody))
+	}))
+	t.Cleanup(u.server.Close)
+	return u
+}
+
+// setupFailoverGateway wires a gateway with a primary provider ("openai") and
+// a fallback provider ("backup") whose regions and chain are configurable.
+func setupFailoverGateway(t *testing.T, sovereigntyMode, primaryRegion, backupRegion string, primary, backup *failoverUpstream, fallbackModel string) (*Gateway, *evidence.Store) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"openai": {
+				Enabled: true, BaseURL: primary.server.URL, SecretName: "openai-api-key", Region: primaryRegion,
+				Fallback: []FallbackTarget{{Provider: "backup", Model: fallbackModel}},
+			},
+			"backup": {Enabled: true, BaseURL: backup.server.URL, SecretName: "backup-api-key", Region: backupRegion},
+		},
+		Callers: []CallerConfig{
+			{
+				Name: "failover-bot", TenantKey: failoverTestTenantKey, TenantID: "test-tenant",
+				PolicyOverrides: &CallerPolicyOverrides{PIIAction: "warn", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+		Timeouts:       TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+	cfg.EffectiveSovereigntyMode = sovereigntyMode
+	require.NoError(t, cfg.Validate())
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	acl := secrets.ACL{Tenants: []string{"test-tenant"}, Agents: []string{"*"}}
+	require.NoError(t, secStore.Set(context.Background(), "openai-api-key", []byte("sk-primary-key-1234567890"), acl))
+	require.NoError(t, secStore.Set(context.Background(), "backup-api-key", []byte("sk-backup-key-1234567890"), acl))
+
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+	return gw, evStore
+}
+
+func makeFailoverRequest(gw *Gateway, body string) *httptest.ResponseRecorder {
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) {
+		r.Handle("/*", gw)
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://test/v1/proxy/openai/v1/chat/completions", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+failoverTestTenantKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// correlationIDFromResponse recovers the correlation ID from the session
+// header the gateway sets ("sess_" + correlation ID when none was supplied).
+func correlationIDFromResponse(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	sid := w.Header().Get("X-Talon-Session-ID")
+	require.True(t, strings.HasPrefix(sid, "sess_"), "session header %q", sid)
+	return strings.TrimPrefix(sid, "sess_")
+}
+
+func failoverRecords(t *testing.T, store *evidence.Store, correlationID string) (attempts []*evidence.Evidence, final *evidence.Evidence) {
+	t.Helper()
+	records, err := store.ListByCorrelationID(context.Background(), correlationID)
+	require.NoError(t, err)
+	for _, ev := range records {
+		if ev.InvocationType == "gateway_failover_attempt" {
+			attempts = append(attempts, ev)
+			continue
+		}
+		if ev.InvocationType == "gateway" {
+			final = ev
+		}
+	}
+	return attempts, final
+}
+
+func TestGatewayFailover_Upstream5xx_FailsOverToSecondary(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, config.DataSovereigntyEUStrict, "EU", "EU", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback says hi")
+	assert.Equal(t, int64(1), primary.calls.Load())
+	assert.Equal(t, int64(1), backup.calls.Load())
+	// Fallback attempt must use the backup provider's own credentials.
+	assert.Equal(t, "Bearer sk-backup-key-1234567890", backup.lastAuth.Load())
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+
+	require.Len(t, attempts, 1, "failed primary attempt must be a separate signed evidence record")
+	att := attempts[0]
+	assert.Equal(t, evidence.FailoverRoleFailedAttempt, att.Failover.Role)
+	assert.Equal(t, "openai", att.Failover.Provider)
+	assert.Equal(t, "upstream_5xx", att.Failover.ErrorClass)
+	assert.Equal(t, http.StatusServiceUnavailable, att.Failover.UpstreamStatus)
+	assert.Equal(t, evidence.FailureReasonProviderTransient, att.FailureReason)
+	assert.True(t, store.VerifyRecord(att), "failed-attempt record must be signed")
+
+	require.NotNil(t, final, "final gateway record must exist")
+	require.NotNil(t, final.Failover, "final record must carry the fallback decision")
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, final.Failover.Role)
+	assert.Equal(t, "backup", final.Failover.Provider)
+	assert.Equal(t, "EU", final.Failover.Region)
+	assert.Equal(t, "allowed", final.Failover.SovereigntyCheck)
+	assert.Equal(t, []string{att.ID}, final.Failover.FailedAttemptIDs)
+	assert.Equal(t, "backup", final.RoutingDecision.SelectedProvider, "evidence must record the provider actually used")
+	assert.True(t, store.VerifyRecord(final))
+
+	finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
+	require.NoError(t, err)
+	require.NotNil(t, finding)
+	assert.Equal(t, evidence.FailoverVerdictValidFallback, finding.Verdict, "details: %v", finding.Details)
+}
+
+func TestGatewayFailover_KilledPrimaryConnection_FailsOver(t *testing.T) {
+	primary := newFailoverUpstream(t, 0) // kill connection mid-request
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback says hi")
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 1)
+	assert.Equal(t, "connection_error", attempts[0].Failover.ErrorClass)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFallbackDecision, final.Failover.Role)
+}
+
+func TestGatewayFailover_EUStrict_USSecondary_FailsClosed(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, config.DataSovereigntyEUStrict, "EU", "US", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	// The caller sees the primary's upstream error; the US secondary is never dispatched.
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, int64(1), primary.calls.Load())
+	assert.Equal(t, int64(0), backup.calls.Load(), "sovereignty-rejected candidate must never be dispatched")
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 1)
+	require.NotNil(t, final)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role)
+	assert.Equal(t, "failed", final.Status)
+	assert.Equal(t, evidence.FailureReasonNoSovereignFallback, final.FailureReason)
+	require.Len(t, final.Failover.SkippedCandidates, 1)
+	assert.Equal(t, "backup", final.Failover.SkippedCandidates[0].Provider)
+	assert.Equal(t, "sovereignty", final.Failover.SkippedCandidates[0].Filter)
+	assert.True(t, store.VerifyRecord(final), "fail-closed governance outcome must be signed")
+
+	finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
+	require.NoError(t, err)
+	require.NotNil(t, finding)
+	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
+}
+
+func TestGatewayFailover_PermanentError_NoFailover(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusUnauthorized)
+	primary.statusBody = `{"error":{"message":"bad key","type":"invalid_request_error"}}`
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "permanent auth errors pass through unchanged")
+	assert.Equal(t, int64(0), backup.calls.Load(), "permanent errors must not trigger failover")
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	assert.Empty(t, attempts)
+	require.NotNil(t, final)
+	assert.Nil(t, final.Failover, "no failover context when failover was not engaged")
+}
+
+func TestGatewayFailover_RateLimited_ModelRewrite(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusTooManyRequests)
+	backup := newFailoverUpstream(t, http.StatusOK)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "gpt-4o-mini-eu")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "gpt-4o-mini", primary.lastModel.Load(), "primary receives the client's model")
+	assert.Equal(t, "gpt-4o-mini-eu", backup.lastModel.Load(), "fallback body model must be rewritten")
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 1)
+	assert.Equal(t, "rate_limited", attempts[0].Failover.ErrorClass)
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, "gpt-4o-mini-eu", final.Failover.Model)
+	assert.Equal(t, "gpt-4o-mini-eu", final.RoutingDecision.SelectedModel)
+}
+
+func TestGatewayFailover_BothProvidersFail_FailClosedWithAttempts(t *testing.T) {
+	primary := newFailoverUpstream(t, http.StatusServiceUnavailable)
+	backup := newFailoverUpstream(t, http.StatusBadGateway)
+	gw, store := setupFailoverGateway(t, "", "EU", "EU", primary, backup, "")
+
+	w := makeFailoverRequest(gw, failoverTestBody)
+
+	assert.Equal(t, http.StatusBadGateway, w.Code, "caller sees the last upstream error")
+
+	correlationID := correlationIDFromResponse(t, w)
+	attempts, final := failoverRecords(t, store, correlationID)
+	require.Len(t, attempts, 2, "both failed attempts must be evidenced")
+	require.NotNil(t, final.Failover)
+	assert.Equal(t, evidence.FailoverRoleFailClosed, final.Failover.Role)
+	assert.Len(t, final.Failover.FailedAttemptIDs, 2)
+
+	finding, err := store.VerifyFailoverChain(context.Background(), correlationID)
+	require.NoError(t, err)
+	assert.Equal(t, evidence.FailoverVerdictValidFailClosed, finding.Verdict, "details: %v", finding.Details)
+}
+
+func TestGatewayConfig_ValidateFallbackChain(t *testing.T) {
+	base := func() *GatewayConfig {
+		return &GatewayConfig{
+			ListenPrefix: "/v1/proxy",
+			Mode:         ModeEnforce,
+			Providers: map[string]ProviderConfig{
+				"openai":    {Enabled: true, BaseURL: "https://api.openai.com", SecretName: "k"},
+				"backup":    {Enabled: true, BaseURL: "https://eu.example.com", SecretName: "k2"},
+				"anthropic": {Enabled: true, BaseURL: "https://api.anthropic.com", SecretName: "k3"},
+				"disabled":  {Enabled: false, BaseURL: "https://off.example.com"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*GatewayConfig)
+		wantErr string
+	}{
+		{
+			name: "valid chain",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "backup", Model: "m"}}
+				c.Providers["openai"] = p
+			},
+		},
+		{
+			name: "self-referencing target",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "openai"}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "duplicate or self-referencing",
+		},
+		{
+			name: "duplicate target",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "backup"}, {Provider: "backup"}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "duplicate or self-referencing",
+		},
+		{
+			name: "unknown target",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "missing"}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "not an enabled gateway provider",
+		},
+		{
+			name: "disabled target",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "disabled"}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "not an enabled gateway provider",
+		},
+		{
+			name: "cross-family target",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: "anthropic"}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "API family",
+		},
+		{
+			name: "empty provider name",
+			mutate: func(c *GatewayConfig) {
+				p := c.Providers["openai"]
+				p.Fallback = []FallbackTarget{{Provider: ""}}
+				c.Providers["openai"] = p
+			},
+			wantErr: "provider is required",
+		},
+		{
+			name: "anthropic to anthropic-family is fine",
+			mutate: func(c *GatewayConfig) {
+				c.Providers["anthropic-eu"] = ProviderConfig{Enabled: true, BaseURL: "https://eu.anthropic.example.com", SecretName: "k4"}
+				p := c.Providers["anthropic"]
+				p.Fallback = []FallbackTarget{{Provider: "anthropic-eu"}}
+				c.Providers["anthropic"] = p
+			},
+			wantErr: "API family", // anthropic-eu resolves to openai family by name; must be rejected
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestFailoverWriter(t *testing.T) {
+	t.Run("success status commits immediately", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		fw := newFailoverWriter(rec)
+		fw.Header().Set("Content-Type", "application/json")
+		fw.WriteHeader(http.StatusOK)
+		assert.True(t, fw.committed)
+		_, _ = fw.Write([]byte("hello"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "hello", rec.Body.String())
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	})
+
+	t.Run("error status stays buffered until flushTo", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		fw := newFailoverWriter(rec)
+		fw.Header().Set("Content-Type", "application/json")
+		fw.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fw.Write([]byte(`{"error":"down"}`))
+		assert.False(t, fw.committed)
+		assert.Equal(t, http.StatusOK, rec.Code, "nothing written to destination yet")
+		assert.Empty(t, rec.Body.String())
+
+		fw.flushTo()
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Equal(t, `{"error":"down"}`, rec.Body.String())
+	})
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -239,6 +239,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		WriteProviderError(w, "openai", http.StatusBadRequest, err.Error())
 		return
 	}
+	// Wire format (api_family) of the routed provider: drives request
+	// parsing, PII redaction, tool filtering, attachment extraction, and
+	// provider-native error shape. Governance parsing must never depend on
+	// the provider map key -- an aliased Anthropic-compatible endpoint gets
+	// Anthropic parsing, not the OpenAI default.
+	wire := g.config.providerAPIFamily(route.Provider)
 
 	// Step 2: Identify
 	var caller *CallerConfig
@@ -251,12 +257,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err == ErrCallerIDRequired || err == ErrCallerNotFound {
 				RecordGatewayError(ctx, "auth")
 				RecordGatewayRequest(ctx, "unknown", "", route.Provider, "error")
-				WriteProviderError(w, route.Provider, http.StatusUnauthorized, "Invalid or missing tenant key")
+				WriteProviderError(w, wire, http.StatusUnauthorized, "Invalid or missing tenant key")
 				return
 			}
 			RecordGatewayError(ctx, "auth")
 			RecordGatewayRequest(ctx, "unknown", "", route.Provider, "error")
-			WriteProviderError(w, route.Provider, http.StatusInternalServerError, err.Error())
+			WriteProviderError(w, wire, http.StatusInternalServerError, err.Error())
 			return
 		}
 	}
@@ -277,7 +283,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			log.Warn().Str("caller", caller.Name).Msg("gateway_rate_limited")
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, route.Provider, http.StatusTooManyRequests, "Rate limit exceeded")
+			WriteProviderError(w, wire, http.StatusTooManyRequests, "Rate limit exceeded")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, "", start, "", &classifier.Classification{}, nil, 0, durationMS, "", false, []string{"rate limit exceeded"}, false, nil, nil, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -292,7 +298,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		RecordGatewayRequest(ctx, caller.Name, "", route.Provider, "error")
 		RecordGatewayError(ctx, "invalid_method")
-		WriteProviderError(w, route.Provider, http.StatusMethodNotAllowed, "Method not allowed")
+		WriteProviderError(w, wire, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
@@ -300,17 +306,17 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		RecordGatewayRequest(ctx, caller.Name, "", route.Provider, "error")
 		RecordGatewayError(ctx, "read_body")
-		WriteProviderError(w, route.Provider, http.StatusBadRequest, "Failed to read request body")
+		WriteProviderError(w, wire, http.StatusBadRequest, "Failed to read request body")
 		return
 	}
 	_ = r.Body.Close()
 
 	// Step 3: Extract
-	extracted, err := ExtractForProvider(route.Provider, body)
+	extracted, err := ExtractForProvider(wire, body)
 	if err != nil {
 		RecordGatewayRequest(ctx, caller.Name, "", route.Provider, "error")
 		RecordGatewayError(ctx, "extract_request")
-		WriteProviderError(w, route.Provider, http.StatusBadRequest, "Invalid request body")
+		WriteProviderError(w, wire, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
@@ -318,7 +324,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	attPolicy := ResolveAttachmentPolicy(&g.config.ServerDefaults, caller.PolicyOverrides)
 	var attSummary *AttachmentsScanSummary
 	if attPolicy.Action != "allow" {
-		attSummary = ScanRequestAttachments(ctx, body, route.Provider,
+		attSummary = ScanRequestAttachments(ctx, body, wire,
 			g.attExtractor, g.classifier, g.attInjScanner, attPolicy)
 	}
 	if attSummary != nil && attSummary.BlockRequest {
@@ -329,7 +335,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Str("enforcement_mode", "shadow").Msg("shadow_attachment_block")
 		} else {
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, route.Provider, http.StatusBadRequest,
+			WriteProviderError(w, wire, http.StatusBadRequest,
 				"Request blocked: attachment violates policy")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
 				g.classifier.Scan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), extracted.Text), nil, 0, 0, "", false,
@@ -366,7 +372,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if !allowed {
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, route.Provider, http.StatusForbidden, "Caller not allowed for this provider")
+			WriteProviderError(w, wire, http.StatusForbidden, "Caller not allowed for this provider")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"provider not allowed"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -398,7 +404,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("caller", caller.Name).Str("enforcement_mode", "shadow").Strs("pii", piiTypes).Msg("shadow_pii_block")
 		} else {
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request contains PII that is not allowed")
+			WriteProviderError(w, wire, http.StatusBadRequest, "Request contains PII that is not allowed")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -426,20 +432,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		g.tryBudgetAlert(ctx, caller.TenantID, "monthly", pct, 95)
 	}
 	destinationRegion := g.providerRegion(route.Provider)
-	policyInput := buildGatewayPolicyInput(caller, g.config.ServerDefaults, route.Provider, extracted.Model, tier, estimatedCost, dailyCost, monthlyCost, destinationRegion)
-	if g.sessionStore != nil && sessionID != "" {
-		if sess, err := g.sessionStore.Get(ctx, sessionID); err == nil {
-			policyInput["session_cost_total"] = sess.TotalCost
-		}
-		if sc, err := g.sessionStore.GetStageCounts(ctx, sessionID); err == nil {
-			policyInput["session_stage_counts"] = map[string]int{
-				"generation": sc.Generation,
-				"judge":      sc.Judge,
-				"commit":     sc.Commit,
-			}
-		}
-		policyInput["session_stage"] = stageFromContext(ctx)
-	}
+	policyInput := g.buildPolicyInputForRequest(ctx, caller, route.Provider, extracted.Model, tier, estimatedCost, dailyCost, monthlyCost, sessionID)
 	if g.policy != nil && (g.config.Mode == ModeEnforce || isShadow) {
 		allowed, reasons, policyErr := g.policy.EvaluateGateway(ctx, policyInput)
 		if policyErr != nil {
@@ -450,7 +443,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				log.Warn().Err(policyErr).Str("caller", caller.Name).Str("enforcement_mode", "shadow").Msg("shadow_policy_error")
 			} else {
 				durationMS := time.Since(start).Milliseconds()
-				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Policy evaluation failed")
+				WriteProviderError(w, wire, http.StatusInternalServerError, "Policy evaluation failed")
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"policy evaluation error"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
@@ -484,7 +477,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						Str("reason", egressReason).
 						Msg("gateway_egress_denied")
 				}
-				WriteProviderError(w, route.Provider, http.StatusForbidden, preferredDenyReason(reasons))
+				WriteProviderError(w, wire, http.StatusForbidden, preferredDenyReason(reasons))
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
@@ -517,7 +510,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Str("caller", caller.Name).
 					Strs("forbidden", tr.Removed).
 					Msg("gateway_tool_blocked")
-				WriteProviderError(w, route.Provider, http.StatusForbidden,
+				WriteProviderError(w, wire, http.StatusForbidden,
 					fmt.Sprintf("Request contains forbidden tools: %v", tr.Removed))
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
 					classification, nil, 0, 0, "", false, []string{"tool governance block"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
@@ -528,14 +521,14 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			default:
-				filtered, filterErr := FilterRequestBodyTools(route.Provider, forwardBody, tr.Kept)
+				filtered, filterErr := FilterRequestBodyTools(wire, forwardBody, tr.Kept)
 				if filterErr != nil {
 					durationMS := time.Since(start).Milliseconds()
 					log.Error().Err(filterErr).
 						Str("caller", caller.Name).
 						Strs("forbidden", tr.Removed).
 						Msg("gateway_tool_filter_failed")
-					WriteProviderError(w, route.Provider, http.StatusInternalServerError,
+					WriteProviderError(w, wire, http.StatusInternalServerError,
 						"Failed to filter forbidden tools from request")
 					persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
 						classification, nil, 0, 0, "", false, []string{"tool filter error"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
@@ -559,7 +552,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	inputPIIRedacted := false
 	// Step 7: Redact (if policy says redact and PII found, skip in shadow mode)
 	if !isShadow && piiAction == "redact" && classification.HasPII {
-		redacted, redactErr := RedactRequestBody(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), route.Provider, forwardBody, g.classifier)
+		redacted, redactErr := RedactRequestBody(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), wire, forwardBody, g.classifier)
 		if redactErr == nil {
 			forwardBody = redacted
 			inputPIIRedacted = true
@@ -567,10 +560,10 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// Fail closed if redacted request text still contains recognized PII.
 	if !isShadow && inputPIIRedacted && g.classifier != nil {
-		redactedExtracted, extractErr := ExtractForProvider(route.Provider, forwardBody)
+		redactedExtracted, extractErr := ExtractForProvider(wire, forwardBody)
 		if extractErr != nil {
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, route.Provider, http.StatusBadRequest, "Request blocked: unable to verify redacted payload")
+			WriteProviderError(w, wire, http.StatusBadRequest, "Request blocked: unable to verify redacted payload")
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"request redaction verification failed"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -586,7 +579,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if types != "" {
 				msg += " (types: " + types + ")"
 			}
-			WriteProviderError(w, route.Provider, http.StatusBadRequest, msg)
+			WriteProviderError(w, wire, http.StatusBadRequest, msg)
 			persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"request residual pii after redaction"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -600,7 +593,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Step 7b: Ensure Responses API requests use store:true so multi-turn works through a proxy.
 	// Without this, OpenAI doesn't persist response items and follow-up messages that reference
 	// previous response IDs get 404 "Items are not persisted when store is set to false".
-	if route.Provider == "openai" && isResponsesAPIPath(route.Path) {
+	if wire == "openai" && isResponsesAPIPath(route.Path) {
 		forwardBody = ensureResponsesStore(forwardBody)
 	}
 
@@ -649,7 +642,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, false, false, piiAction, true, costSaved, 0, 0, persisted)
-					writeCachedCompletion(w, route.Provider, extracted.Model, hit.ResponseText)
+					writeCachedCompletion(w, wire, extracted.Model, hit.ResponseText)
 					return
 				}
 			}
@@ -704,7 +697,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if clientKey == "" {
 			RecordGatewayError(ctx, "missing_upstream_key")
 			RecordGatewayRequest(ctx, caller.Name, extracted.Model, route.Provider, "error")
-			WriteProviderError(w, route.Provider, http.StatusUnauthorized,
+			WriteProviderError(w, wire, http.StatusUnauthorized,
 				"no upstream credential: set OPENAI_API_KEY or send Authorization: Bearer ...")
 			return
 		}
@@ -718,7 +711,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				durationMS := time.Since(start).Milliseconds()
 				log.Warn().Err(err).Str("secret", prov.SecretName).Msg("gateway_secret_get_failed")
-				WriteProviderError(w, route.Provider, http.StatusInternalServerError, "Service configuration error")
+				WriteProviderError(w, wire, http.StatusInternalServerError, "Service configuration error")
 				persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"secret retrieval error"}, false, nil, attSummary, toolResult, shadowViolations, false, "", 0, 0, false, 0, 0, estimatedCost)
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
@@ -777,12 +770,14 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		return g.recordFailoverAttemptEvidence(aCtx, correlationID, caller, g.config.EffectiveSovereigntyMode, tier, rec, attemptFlow)
 	}
-	// Fallback candidates must pass the same gates the primary passed:
-	// the caller's provider allowlist and the full gateway policy (caller
-	// model lists, egress rules, budgets) with the candidate's provider,
-	// model, and destination region. Dispatching a fallback is a
-	// Talon-initiated action, so candidates are policy-gated even in shadow
-	// mode — failover must never become a policy bypass.
+	// Fallback candidates must pass the same gates the primary passed.
+	// Shadow mode must never change runtime behavior: policy and tool
+	// violations are recorded as shadow violations and the dispatch
+	// proceeds, exactly like the primary path. Two gates stay hard in every
+	// mode: the caller's provider allowlist (the primary route enforces it
+	// unconditionally too) and the sovereignty filter inside the failover
+	// pipeline (an explicit hard invariant — under eu_strict Talon never
+	// dispatches outside EU/LOCAL, shadow or not).
 	checkCandidate := func(cCtx context.Context, candProvider, candModel string) failover.FilterResult {
 		if len(caller.AllowedProviders) > 0 {
 			allowed := false
@@ -796,13 +791,47 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return failover.FilterResult{Filter: "caller_allowlist", Reason: fmt.Sprintf("caller %s not allowed for provider %s", caller.Name, candProvider)}
 			}
 		}
-		if g.policy != nil {
-			candInput := buildGatewayPolicyInput(caller, g.config.ServerDefaults, candProvider, candModel, tier, estimatedCost, dailyCost, monthlyCost, g.providerRegion(candProvider))
-			allowed, reasons, policyErr := g.policy.EvaluateGateway(cCtx, candInput)
-			if policyErr != nil {
-				return failover.FilterResult{Filter: "gateway_policy", Reason: "policy evaluation error: " + policyErr.Error()}
+		// Provider-level tool governance of the TARGET provider: a fallback
+		// must not deliver tools the target's policy forbids. The body was
+		// filtered against the primary's tool policy only.
+		if len(extracted.ToolNames) > 0 {
+			candProv, _ := g.config.Provider(candProvider)
+			candToolPolicy := ResolveToolPolicy(&g.config.ServerDefaults, candProv, caller.PolicyOverrides)
+			if len(candToolPolicy.AllowedTools) > 0 || len(candToolPolicy.ForbiddenTools) > 0 {
+				forwarded := extracted.ToolNames
+				if toolResult != nil {
+					forwarded = toolResult.Kept
+				}
+				if tr := EvaluateToolPolicy(forwarded, candToolPolicy.AllowedTools, candToolPolicy.ForbiddenTools); len(tr.Removed) > 0 {
+					if isShadow {
+						shadowViolations = append(shadowViolations, evidence.ShadowViolation{
+							Type: "tool_block", Detail: fmt.Sprintf("failover candidate %s: forbidden tools %v", candProvider, tr.Removed), Action: "block",
+						})
+					} else {
+						return failover.FilterResult{Filter: "tool_policy", Reason: fmt.Sprintf("target provider %s forbids tools %v", candProvider, tr.Removed)}
+					}
+				}
 			}
-			if !allowed {
+		}
+		// Full gateway policy with the CANDIDATE's provider, model,
+		// recomputed cost estimate, and destination region — built by the
+		// same function as the primary's input (session context included).
+		if g.policy != nil && (g.config.Mode == ModeEnforce || isShadow) {
+			candEstimate := g.costEstimate(candModel, estTokensIn, estTokensOut)
+			candInput := g.buildPolicyInputForRequest(cCtx, caller, candProvider, candModel, tier, candEstimate, dailyCost, monthlyCost, sessionID)
+			allowed, reasons, policyErr := g.policy.EvaluateGateway(cCtx, candInput)
+			switch {
+			case policyErr != nil && isShadow:
+				shadowViolations = append(shadowViolations, evidence.ShadowViolation{
+					Type: "policy_deny", Detail: fmt.Sprintf("failover candidate %s/%s: policy evaluation error: %v", candProvider, candModel, policyErr), Action: "block",
+				})
+			case policyErr != nil:
+				return failover.FilterResult{Filter: "gateway_policy", Reason: "policy evaluation error: " + policyErr.Error()}
+			case !allowed && isShadow:
+				shadowViolations = append(shadowViolations, evidence.ShadowViolation{
+					Type: "policy_deny", Detail: fmt.Sprintf("failover candidate %s/%s: %s", candProvider, candModel, preferredDenyReason(reasons)), Action: "block",
+				})
+			case !allowed:
 				return failover.FilterResult{Filter: "gateway_policy", Reason: preferredDenyReason(reasons)}
 			}
 		}
@@ -828,15 +857,23 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if content := extractContentFromOpenAIResponse(scannedBody); content != "" {
 					emb, err := g.cacheEmbedder.Embed(extracted.Text)
 					if err == nil {
+						// The response must be cached under the model that
+						// actually produced it: a failover model rewrite
+						// makes the fallback-selected model the truth, not
+						// the model the client asked for.
+						cachedModel := extracted.Model
+						if failoverOut != nil && failoverOut.SelectedProvider != "" && failoverOut.SelectedModel != "" {
+							cachedModel = failoverOut.SelectedModel
+						}
 						// Use canonical tenant ID from config-derived map so cache key is not tainted by request path (CodeQL go/weak-sensitive-data-hashing).
 						scopeTenantID := g.canonicalTenantIDForCache(caller.TenantID)
-						keyHash := cache.DeriveEntryKey(scopeTenantID, extracted.Model, extracted.Text)
+						keyHash := cache.DeriveEntryKey(scopeTenantID, cachedModel, extracted.Text)
 						tierLabel := cache.TierLabel(tier)
 						ttl := cache.TTLForTier(tierLabel, g.cacheConfig.TTLByTier, g.cacheConfig.DefaultTTL)
 						now := time.Now().UTC()
 						entry := &cache.Entry{
 							TenantID: caller.TenantID, CacheKey: keyHash, EmbeddingData: emb, ResponseText: content,
-							Model: extracted.Model, DataTier: tierLabel, PIIScrubbed: true,
+							Model: cachedModel, DataTier: tierLabel, PIIScrubbed: true,
 							CreatedAt: now, ExpiresAt: now.Add(ttl),
 						}
 						if insertErr := g.cacheStore.Insert(ctx, entry); insertErr == nil {
@@ -914,7 +951,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		p.Failover = failoverEvCtx
 		if failoverOut != nil && failoverOut.FailClosed {
 			p.Status = "failed"
-			p.FailureReason = evidence.FailureReasonNoSovereignFallback
+			p.FailureReason = evidence.FailureReasonNoValidFallbackCandidate
 		}
 	})
 	if recordErr != nil {
@@ -1229,6 +1266,29 @@ func (g *Gateway) trackSessionUsage(ctx context.Context, sessionID, tenantID, ca
 			log.Warn().Err(err).Str("session_id", sessionID).Str("stage", stage).Msg("stage count increment failed")
 		}
 	}
+}
+
+// buildPolicyInputForRequest builds the gateway policy input for a
+// (provider, model) pair with the full request context — destination region
+// and session budget/stage included. The primary request and every fallback
+// candidate MUST go through this same function so the two policy surfaces
+// cannot drift apart (see TestPolicyInputParity_PrimaryVsCandidate).
+func (g *Gateway) buildPolicyInputForRequest(ctx context.Context, caller *CallerConfig, provider, model string, tier int, estimatedCost, dailyCost, monthlyCost float64, sessionID string) map[string]interface{} {
+	input := buildGatewayPolicyInput(caller, g.config.ServerDefaults, provider, model, tier, estimatedCost, dailyCost, monthlyCost, g.providerRegion(provider))
+	if g.sessionStore != nil && sessionID != "" {
+		if sess, err := g.sessionStore.Get(ctx, sessionID); err == nil {
+			input["session_cost_total"] = sess.TotalCost
+		}
+		if sc, err := g.sessionStore.GetStageCounts(ctx, sessionID); err == nil {
+			input["session_stage_counts"] = map[string]int{
+				"generation": sc.Generation,
+				"judge":      sc.Judge,
+				"commit":     sc.Commit,
+			}
+		}
+		input["session_stage"] = stageFromContext(ctx)
+	}
+	return input
 }
 
 func buildGatewayPolicyInput(caller *CallerConfig, defaults ServerDefaults, provider, model string, dataTier int, estimatedCost, dailyCost, monthlyCost float64, destinationRegion string) map[string]interface{} {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -678,7 +678,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			headers[k] = v[0]
 		}
 	}
-	if route.Provider == "anthropic" {
+	if g.config.providerAPIFamily(route.Provider) == "anthropic" {
 		if v := r.Header.Get("anthropic-version"); v != "" {
 			headers["anthropic-version"] = v
 		} else {
@@ -726,7 +726,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations, nil, 0, durationMS, true, true, piiAction, false, 0, 0, 0, persisted)
 				return
 			}
-			if route.Provider == "anthropic" {
+			if g.config.providerAPIFamily(route.Provider) == "anthropic" {
 				headers["x-api-key"] = string(secret.Value)
 			} else {
 				headers["Authorization"] = "Bearer " + string(secret.Value)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dativo-io/talon/internal/explanation"
 	"github.com/dativo-io/talon/internal/llm"
 	"github.com/dativo-io/talon/internal/metrics"
+	"github.com/dativo-io/talon/internal/otel"
 	"github.com/dativo-io/talon/internal/secrets"
 	"github.com/dativo-io/talon/internal/session"
 )
@@ -757,11 +758,31 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		StreamingMetrics: &streamingMetrics,
 	}
 
+	// Error-driven provider failover (issue #138): the primary attempt plus
+	// the provider's ordered fallback chain, sovereignty-filtered. Failed
+	// attempts are recorded as separate signed evidence facts, each with its
+	// own data-flow section (the prompt did egress to the failed provider).
+	recordAttempt := func(aCtx context.Context, rec failoverAttemptRecord) string {
+		attemptFlow := g.buildDataFlow(dataFlowInputs{
+			CorrelationID:    correlationID,
+			TenantID:         caller.TenantID,
+			CallerName:       caller.Name,
+			Provider:         rec.Provider,
+			Model:            rec.Model,
+			Allowed:          true,
+			InputPIIRedacted: inputPIIRedacted,
+			InputText:        extracted.Text,
+			Classification:   classification,
+		})
+		return g.recordFailoverAttemptEvidence(aCtx, correlationID, caller, g.config.EffectiveSovereigntyMode, tier, rec, attemptFlow)
+	}
+	var failoverOut *failoverOutcome
+
 	switch {
 	case needsResponseScan && !isStreaming:
 		// Non-streaming: capture response, scan, then write
 		capture := &responseCapture{ResponseWriter: w}
-		forwardErr = Forward(capture, fwdParams)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
 		if forwardErr == nil {
 			scannedBody, scanResult := scanResponseForPII(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), capture.body.Bytes(), responsePIIAction, g.classifier)
 			responsePII = scanResult
@@ -801,7 +822,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// scan for PII. If clean, forward the original buffered events. If
 		// PII found, return the redacted content wrapped in SSE format.
 		capture := &responseCapture{ResponseWriter: w}
-		forwardErr = Forward(capture, fwdParams)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
 		if forwardErr == nil {
 			responsePII = handleStreamingPIIScan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), w, capture, responsePIIAction, g.classifier)
 		} else {
@@ -809,11 +830,35 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 	default:
-		forwardErr = Forward(w, fwdParams)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, w, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
 	}
 
 	durationMS := time.Since(start).Milliseconds()
-	cost := g.costEstimate(extracted.Model, tokenUsage.Input, tokenUsage.Output)
+
+	// Provider/model actually used (may differ from the route when failover
+	// dispatched a fallback candidate). Evidence must record the truth.
+	selectedProvider, selectedModel := route.Provider, extracted.Model
+	if failoverOut != nil && failoverOut.SelectedProvider != "" {
+		selectedProvider, selectedModel = failoverOut.SelectedProvider, failoverOut.SelectedModel
+	}
+	failoverEvCtx := g.buildFailoverDecisionContext(failoverOut, g.config.EffectiveSovereigntyMode)
+	if failoverEvCtx != nil {
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.SetAttributes(
+				otel.TalonProviderOriginal.String(route.Provider),
+				otel.TalonProviderSelected.String(selectedProvider),
+				otel.TalonProviderFallbackReason.String(failoverOut.FailedAttempts[0].Class.Class),
+				otel.TalonFallbackChainPosition.Int(failoverOut.ChainPosition),
+				otel.TalonFallbackFailedAttempts.Int(len(failoverOut.FailedAttempts)),
+				otel.TalonFallbackFailClosed.Bool(failoverOut.FailClosed),
+			)
+		}
+		if !failoverOut.FailClosed {
+			llm.RecordFailover(ctx, extracted.Model, selectedModel, failoverOut.FailedAttempts[0].Class.Class)
+		}
+	}
+
+	cost := g.costEstimate(selectedModel, tokenUsage.Input, tokenUsage.Output)
 	if tokenUsage.Input == 0 && tokenUsage.Output == 0 {
 		cost = estimatedCost
 	}
@@ -833,7 +878,13 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if forwardErr != nil {
 		forwardErrStr = forwardErr.Error()
 	}
-	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, responsePII, attSummary, toolResult, shadowViolations, false, "", 0, 0, cacheStored, ttftMS, tpotMS, estimatedCost)
+	persisted, recordErr := g.recordEvidence(ctx, correlationID, caller, selectedProvider, selectedModel, start, extracted.Text, classification, &tokenUsage, cost, durationMS, forwardErrStr, true, nil, inputPIIRedacted, responsePII, attSummary, toolResult, shadowViolations, false, "", 0, 0, cacheStored, ttftMS, tpotMS, estimatedCost, func(p *RecordGatewayEvidenceParams) {
+		p.Failover = failoverEvCtx
+		if failoverOut != nil && failoverOut.FailClosed {
+			p.Status = "failed"
+			p.FailureReason = evidence.FailureReasonNoSovereignFallback
+		}
+	})
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
@@ -841,7 +892,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.trackSessionUsage(ctx, sessionID, caller.TenantID, caller.Name, cost, tokenUsage.Input+tokenUsage.Output)
 
 	// Emit OTel + dashboard metrics
-	g.emitMetrics(ctx, caller, route.Provider, extracted.Model, classification, toolResult, shadowViolations,
+	g.emitMetrics(ctx, caller, selectedProvider, selectedModel, classification, toolResult, shadowViolations,
 		&tokenUsage, cost, durationMS, forwardErr != nil, false, piiAction, false, 0, ttftMS, tpotMS, persisted)
 	if forwardErr != nil {
 		log.Warn().Err(forwardErr).Msg("gateway_forward_error")
@@ -849,7 +900,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 //nolint:gocyclo // evidence assembly branches on optional subsystems (cache, egress, attachments, tools)
-func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, inputText string, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, responsePII *ResponsePIIScanResult, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, cacheStored bool, ttftMS int64, tpotMS float64, estimatedCost float64) (*evidence.Evidence, error) {
+func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, caller *CallerConfig, provider, model string, start time.Time, inputText string, classification *classifier.Classification, usage *TokenUsage, cost float64, durationMS int64, executionError string, allowed bool, reasons []string, inputPIIRedacted bool, responsePII *ResponsePIIScanResult, attSummary *AttachmentsScanSummary, toolResult *ToolGovernanceResult, shadowViolations []evidence.ShadowViolation, cacheHit bool, cacheEntryID string, cacheSimilarity float64, costSaved float64, cacheStored bool, ttftMS int64, tpotMS float64, estimatedCost float64, opts ...func(*RecordGatewayEvidenceParams)) (*evidence.Evidence, error) {
 	if classification == nil {
 		classification = &classifier.Classification{}
 	}
@@ -974,6 +1025,9 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 	params.GatewayAnnotations = gatewayAnnotationsForEvidence(g, caller)
 	params.TTFTMS = ttftMS
 	params.TPOTMS = tpotMS
+	for _, opt := range opts {
+		opt(&params)
+	}
 	ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, params)
 	if err != nil {
 		return nil, err

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/explanation"
+	"github.com/dativo-io/talon/internal/failover"
 	"github.com/dativo-io/talon/internal/llm"
 	"github.com/dativo-io/talon/internal/metrics"
 	"github.com/dativo-io/talon/internal/otel"
@@ -776,13 +777,44 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		})
 		return g.recordFailoverAttemptEvidence(aCtx, correlationID, caller, g.config.EffectiveSovereigntyMode, tier, rec, attemptFlow)
 	}
+	// Fallback candidates must pass the same gates the primary passed:
+	// the caller's provider allowlist and the full gateway policy (caller
+	// model lists, egress rules, budgets) with the candidate's provider,
+	// model, and destination region. Dispatching a fallback is a
+	// Talon-initiated action, so candidates are policy-gated even in shadow
+	// mode — failover must never become a policy bypass.
+	checkCandidate := func(cCtx context.Context, candProvider, candModel string) failover.FilterResult {
+		if len(caller.AllowedProviders) > 0 {
+			allowed := false
+			for _, p := range caller.AllowedProviders {
+				if p == candProvider {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				return failover.FilterResult{Filter: "caller_allowlist", Reason: fmt.Sprintf("caller %s not allowed for provider %s", caller.Name, candProvider)}
+			}
+		}
+		if g.policy != nil {
+			candInput := buildGatewayPolicyInput(caller, g.config.ServerDefaults, candProvider, candModel, tier, estimatedCost, dailyCost, monthlyCost, g.providerRegion(candProvider))
+			allowed, reasons, policyErr := g.policy.EvaluateGateway(cCtx, candInput)
+			if policyErr != nil {
+				return failover.FilterResult{Filter: "gateway_policy", Reason: "policy evaluation error: " + policyErr.Error()}
+			}
+			if !allowed {
+				return failover.FilterResult{Filter: "gateway_policy", Reason: preferredDenyReason(reasons)}
+			}
+		}
+		return failover.FilterResult{Allowed: true}
+	}
 	var failoverOut *failoverOutcome
 
 	switch {
 	case needsResponseScan && !isStreaming:
 		// Non-streaming: capture response, scan, then write
 		capture := &responseCapture{ResponseWriter: w}
-		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt, checkCandidate)
 		if forwardErr == nil {
 			scannedBody, scanResult := scanResponseForPII(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), capture.body.Bytes(), responsePIIAction, g.classifier)
 			responsePII = scanResult
@@ -822,7 +854,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// scan for PII. If clean, forward the original buffered events. If
 		// PII found, return the redacted content wrapped in SSE format.
 		capture := &responseCapture{ResponseWriter: w}
-		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt, checkCandidate)
 		if forwardErr == nil {
 			responsePII = handleStreamingPIIScan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), w, capture, responsePIIAction, g.classifier)
 		} else {
@@ -830,7 +862,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 	default:
-		failoverOut, forwardErr = g.forwardWithFailover(ctx, w, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt)
+		failoverOut, forwardErr = g.forwardWithFailover(ctx, w, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt, checkCandidate)
 	}
 
 	durationMS := time.Since(start).Milliseconds()

--- a/internal/gateway/sovereignty.go
+++ b/internal/gateway/sovereignty.go
@@ -54,7 +54,7 @@ func (g *Gateway) denySovereigntyExcluded(
 
 	durationMS := time.Since(start).Milliseconds()
 	msg := "provider blocked by sovereignty.mode=eu_strict (non-EU/LOCAL region)"
-	WriteProviderError(w, route.Provider, http.StatusForbidden, msg)
+	WriteProviderError(w, g.config.providerAPIFamily(route.Provider), http.StatusForbidden, msg)
 	RecordSovereigntyProviderDenied(ctx, route.Provider)
 	persisted, err := g.recordEvidence(ctx, correlationID, caller, route.Provider, extracted.Model, start, extracted.Text,
 		classification, nil, 0, durationMS, "", false, []string{sovereigntyDenyReason}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)

--- a/internal/llm/failover.go
+++ b/internal/llm/failover.go
@@ -1,0 +1,39 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/dativo-io/talon/internal/failover"
+)
+
+// ClassifyGenerateError classifies a Provider.Generate error for error-driven
+// failover. Typed ProviderErrors classify by code; transport-level errors
+// (timeouts, connection failures) are transient. Anything unrecognized is
+// permanent — failover never retries an outcome it cannot classify, and a
+// canceled caller context never triggers a dispatch nobody is waiting for.
+func ClassifyGenerateError(err error) failover.Classification {
+	if err == nil {
+		return failover.Classification{Class: failover.ClassNone, Transient: false}
+	}
+	var pe *ProviderError
+	if errors.As(err, &pe) {
+		return failover.ClassifyProviderCode(pe.Code)
+	}
+	if errors.Is(err, context.Canceled) {
+		return failover.Classification{Class: failover.ClassCanceled, Transient: false}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return failover.Classification{Class: failover.ClassTimeout, Transient: true}
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return failover.Classification{Class: failover.ClassTimeout, Transient: true}
+	}
+	var oe *net.OpError
+	if errors.As(err, &oe) {
+		return failover.Classification{Class: failover.ClassConnection, Transient: true}
+	}
+	return failover.Classification{Class: failover.ClassNone, Transient: false}
+}

--- a/internal/llm/failover_test.go
+++ b/internal/llm/failover_test.go
@@ -1,0 +1,156 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/failover"
+	"github.com/dativo-io/talon/internal/policy"
+)
+
+func TestClassifyGenerateError(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantClass     string
+		wantTransient bool
+	}{
+		{name: "nil", err: nil, wantClass: failover.ClassNone, wantTransient: false},
+		{name: "provider rate_limit", err: &ProviderError{Code: "rate_limit", Provider: "openai"}, wantClass: failover.ClassRateLimited, wantTransient: true},
+		{name: "provider server_error", err: &ProviderError{Code: "server_error", Provider: "openai"}, wantClass: failover.ClassUpstream5xx, wantTransient: true},
+		{name: "provider auth_failed permanent", err: &ProviderError{Code: "auth_failed", Provider: "openai"}, wantClass: failover.ClassAuth, wantTransient: false},
+		{name: "provider model_not_found permanent", err: &ProviderError{Code: "model_not_found", Provider: "openai"}, wantClass: failover.ClassClient, wantTransient: false},
+		{name: "wrapped provider error", err: fmt.Errorf("calling LLM: %w", &ProviderError{Code: "server_error"}), wantClass: failover.ClassUpstream5xx, wantTransient: true},
+		{name: "context canceled never transient", err: context.Canceled, wantClass: failover.ClassCanceled, wantTransient: false},
+		{name: "deadline exceeded transient", err: context.DeadlineExceeded, wantClass: failover.ClassTimeout, wantTransient: true},
+		{name: "connection error transient", err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}, wantClass: failover.ClassConnection, wantTransient: true},
+		{name: "unknown error is permanent (fail closed)", err: errors.New("json decode failed"), wantClass: failover.ClassNone, wantTransient: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyGenerateError(tt.err)
+			assert.Equal(t, tt.wantClass, got.Class)
+			assert.Equal(t, tt.wantTransient, got.Transient)
+		})
+	}
+}
+
+// stubRoutingEvaluator allows/denies candidates by provider jurisdiction:
+// EU and LOCAL allowed, everything else rejected (mimics eu_strict routing.rego).
+type stubRoutingEvaluator struct{}
+
+func (stubRoutingEvaluator) EvaluateRouting(_ context.Context, in *policy.RoutingInput) (*policy.Decision, error) {
+	if in.ProviderJurisdiction == "EU" || in.ProviderJurisdiction == "LOCAL" {
+		return &policy.Decision{Allowed: true}, nil
+	}
+	return &policy.Decision{Allowed: false, Reasons: []string{"sovereignty: provider " + in.ProviderID + " not allowed"}}, nil
+}
+
+// jurisdictionProvider is a mockProvider with a configurable jurisdiction.
+type jurisdictionProvider struct {
+	mockProvider
+	jurisdiction string
+}
+
+func (p *jurisdictionProvider) Metadata() ProviderMetadata {
+	return ProviderMetadata{ID: p.name, DisplayName: p.name, Jurisdiction: p.jurisdiction}
+}
+
+func TestResolveCandidates_FallbackChain(t *testing.T) {
+	providers := map[string]Provider{
+		"openai":    &jurisdictionProvider{mockProvider: mockProvider{name: "openai"}, jurisdiction: "US"},
+		"anthropic": &jurisdictionProvider{mockProvider: mockProvider{name: "anthropic"}, jurisdiction: "US"},
+		"ollama":    &jurisdictionProvider{mockProvider: mockProvider{name: "ollama"}, jurisdiction: "LOCAL"},
+	}
+	routing := &policy.ModelRoutingConfig{
+		Tier1: &policy.TierConfig{
+			Primary:       "gpt-4o",
+			FallbackChain: []string{"claude-sonnet-4-20250514", "llama3:70b", "not-a-known-model"},
+		},
+	}
+	router := NewRouter(routing, providers, nil)
+	ctx := context.Background()
+
+	t.Run("no compliance: full chain in order, unknown model rejected", func(t *testing.T) {
+		resolved, rejected, err := router.ResolveCandidates(ctx, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved, 3)
+		assert.Equal(t, "openai", resolved[0].ProviderName)
+		assert.Equal(t, 0, resolved[0].ChainPosition)
+		assert.Equal(t, "anthropic", resolved[1].ProviderName)
+		assert.Equal(t, "claude-sonnet-4-20250514", resolved[1].Model)
+		assert.Equal(t, 1, resolved[1].ChainPosition)
+		assert.Equal(t, "ollama", resolved[2].ProviderName)
+		assert.Contains(t, resolved[1].RuleID, "fallback_chain[0]")
+		require.Len(t, rejected, 1)
+		assert.Equal(t, "not-a-known-model", rejected[0].ProviderID)
+	})
+
+	t.Run("compliance mode filters sovereignty-rejected candidates", func(t *testing.T) {
+		opts := &RouteOptions{PolicyEngine: stubRoutingEvaluator{}, SovereigntyMode: "eu_strict", DataTier: 1}
+		resolved, rejected, err := router.ResolveCandidates(ctx, 1, opts)
+		require.NoError(t, err)
+		// openai (US) and anthropic (US) rejected; only ollama (LOCAL) remains.
+		require.Len(t, resolved, 1)
+		assert.Equal(t, "ollama", resolved[0].ProviderName)
+		assert.GreaterOrEqual(t, len(rejected), 3) // 2 US candidates + unknown model
+	})
+
+	t.Run("legacy fallback used only when chain is empty", func(t *testing.T) {
+		legacyRouting := &policy.ModelRoutingConfig{
+			Tier1: &policy.TierConfig{Primary: "gpt-4o", Fallback: "claude-sonnet-4-20250514"},
+		}
+		legacyRouter := NewRouter(legacyRouting, providers, nil)
+		resolved, _, err := legacyRouter.ResolveCandidates(ctx, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, "anthropic", resolved[1].ProviderName)
+		assert.Contains(t, resolved[1].RuleID, "tier_1.fallback")
+	})
+
+	t.Run("chain supersedes legacy fallback", func(t *testing.T) {
+		bothRouting := &policy.ModelRoutingConfig{
+			Tier1: &policy.TierConfig{Primary: "gpt-4o", Fallback: "claude-sonnet-4-20250514", FallbackChain: []string{"llama3:70b"}},
+		}
+		bothRouter := NewRouter(bothRouting, providers, nil)
+		resolved, _, err := bothRouter.ResolveCandidates(ctx, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, "ollama", resolved[1].ProviderName)
+	})
+
+	t.Run("duplicate chain entries deduplicated", func(t *testing.T) {
+		dupRouting := &policy.ModelRoutingConfig{
+			Tier1: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"gpt-4o", "llama3:70b", "llama3:70b"}},
+		}
+		dupRouter := NewRouter(dupRouting, providers, nil)
+		resolved, _, err := dupRouter.ResolveCandidates(ctx, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+	})
+}
+
+func TestRouteWithCompliance_UsesChainCandidates(t *testing.T) {
+	providers := map[string]Provider{
+		"openai": &jurisdictionProvider{mockProvider: mockProvider{name: "openai"}, jurisdiction: "US"},
+		"ollama": &jurisdictionProvider{mockProvider: mockProvider{name: "ollama"}, jurisdiction: "LOCAL"},
+	}
+	routing := &policy.ModelRoutingConfig{
+		Tier2: &policy.TierConfig{Primary: "gpt-4o", FallbackChain: []string{"llama3:70b"}},
+	}
+	router := NewRouter(routing, providers, nil)
+	opts := &RouteOptions{PolicyEngine: stubRoutingEvaluator{}, SovereigntyMode: "eu_strict", DataTier: 2}
+	provider, model, decision, err := router.Route(context.Background(), 2, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "ollama", provider.Name())
+	assert.Equal(t, "llama3:70b", model)
+	require.NotNil(t, decision)
+	assert.Equal(t, "ollama", decision.SelectedProvider)
+	assert.NotEmpty(t, decision.Rejected)
+}

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -102,7 +102,7 @@ func (r *Router) Route(ctx context.Context, tier int, opts *RouteOptions) (Provi
 	useCompliance := opts != nil && opts.PolicyEngine != nil && opts.SovereigntyMode != ""
 
 	if useCompliance {
-		return r.routeWithCompliance(ctx, span, tier, tierConfig, opts)
+		return r.routeWithCompliance(ctx, span, tier, opts)
 	}
 
 	model := tierConfig.Primary
@@ -147,97 +147,180 @@ func (r *Router) Route(ctx context.Context, tier int, opts *RouteOptions) (Provi
 	return provider, model, nil, nil
 }
 
-// routeWithCompliance builds candidate (provider, model) pairs, evaluates each with OPA routing
-// policy, and returns the first allowed provider plus a RouteDecision with rejected candidates.
-func (r *Router) routeWithCompliance(ctx context.Context, span trace.Span, tier int, tierConfig *policy.TierConfig, opts *RouteOptions) (Provider, string, *RouteDecision, error) {
-	dataTier := opts.DataTier
-	if dataTier < 0 || dataTier > 2 {
-		dataTier = tier
+// routeWithCompliance resolves the tier's candidate list (primary +
+// fallback_chain), evaluates each with OPA routing policy, and returns the
+// first allowed provider plus a RouteDecision with rejected candidates.
+func (r *Router) routeWithCompliance(ctx context.Context, span trace.Span, tier int, opts *RouteOptions) (Provider, string, *RouteDecision, error) {
+	resolved, rejected, err := r.ResolveCandidates(ctx, tier, opts)
+	if err != nil {
+		span.RecordError(err)
+		return nil, "", nil, err
 	}
-	requireEU := dataTier == 2
-
-	candidates := r.buildCandidates(tierConfig)
-	var rejected []RejectedRouteCandidate
-	for _, c := range candidates {
-		prov, ok := r.providers[c.providerName]
-		if !ok {
-			continue
-		}
-		meta := prov.Metadata()
+	if len(resolved) > 0 {
+		c := resolved[0]
+		meta := c.Provider.Metadata()
 		region := ""
 		if len(meta.EURegions) > 0 {
 			region = meta.EURegions[0]
 		}
-		dec, err := opts.PolicyEngine.EvaluateRouting(ctx, &policy.RoutingInput{
-			SovereigntyMode:      opts.SovereigntyMode,
-			ProviderID:           meta.ID,
-			ProviderJurisdiction: meta.Jurisdiction,
-			ProviderRegion:       region,
-			DataTier:             dataTier,
-			RequireEURouting:     requireEU,
-		})
-		if err != nil {
-			span.RecordError(err)
-			rejected = append(rejected, RejectedRouteCandidate{ProviderID: c.providerName, Reason: err.Error()})
-			continue
-		}
-		if dec.Allowed {
-			span.SetAttributes(
-				attribute.String("gen_ai.request.model", c.model),
-				attribute.String("llm.provider", c.providerName),
-				otel.TalonProviderJurisdiction.String(meta.Jurisdiction),
-				otel.TalonProviderRegion.String(region),
-				otel.TalonRoutingRejectedCount.Int(len(rejected)),
-				otel.TalonRoutingSelectionReason.String("first candidate allowed by routing policy"),
-			)
-			return prov, c.model, &RouteDecision{
-				SelectedProvider: c.providerName,
-				SelectedModel:    c.model,
-				Rejected:         rejected,
-			}, nil
-		}
-		for _, reason := range dec.Reasons {
-			rejected = append(rejected, RejectedRouteCandidate{ProviderID: c.providerName, Reason: reason})
-		}
+		span.SetAttributes(
+			attribute.String("gen_ai.request.model", c.Model),
+			attribute.String("llm.provider", c.ProviderName),
+			otel.TalonProviderJurisdiction.String(meta.Jurisdiction),
+			otel.TalonProviderRegion.String(region),
+			otel.TalonRoutingRejectedCount.Int(len(rejected)),
+			otel.TalonRoutingSelectionReason.String("first candidate allowed by routing policy"),
+		)
+		return c.Provider, c.Model, &RouteDecision{
+			SelectedProvider: c.ProviderName,
+			SelectedModel:    c.Model,
+			Rejected:         rejected,
+		}, nil
 	}
-	err := fmt.Errorf("no provider allowed by routing policy for tier %d (sovereignty %s): %d candidate(s) rejected", tier, opts.SovereigntyMode, len(rejected))
+	err = fmt.Errorf("no provider allowed by routing policy for tier %d (sovereignty %s): %d candidate(s) rejected", tier, opts.SovereigntyMode, len(rejected))
 	span.SetAttributes(otel.TalonRoutingRejectedCount.Int(len(rejected)))
 	span.RecordError(err)
 	return nil, "", nil, err
 }
 
 type routeCandidate struct {
-	providerName string
-	model        string
+	providerName  string
+	model         string
+	chainPosition int
+	ruleID        string
 }
 
-func (r *Router) buildCandidates(tierConfig *policy.TierConfig) []routeCandidate {
-	var out []routeCandidate
+// buildCandidates returns the ordered candidate list for a tier: the primary,
+// then the error-driven fallback_chain entries, then the legacy single
+// fallback when no chain is configured. Chain entries whose model cannot be
+// resolved to a provider are returned as rejected (fail-closed and visible in
+// evidence rather than silently dropped).
+func (r *Router) buildCandidates(tier int, tierConfig *policy.TierConfig) (candidates []routeCandidate, rejected []RejectedRouteCandidate) {
 	primary := strings.TrimSpace(tierConfig.Primary)
 	if primary == "" {
-		return out
+		return nil, nil
 	}
 	providerName, err := inferProvider(primary)
 	if err != nil {
-		return out
+		return nil, nil
 	}
 	if tierConfig.BedrockOnly {
 		providerName = "bedrock"
 	}
-	out = append(out, routeCandidate{providerName: providerName, model: primary})
-	if tierConfig.Fallback != "" {
-		fb := strings.TrimSpace(tierConfig.Fallback)
-		fbProvider, fbErr := inferProvider(fb)
-		if fbErr == nil {
-			if tierConfig.BedrockOnly {
-				fbProvider = "bedrock"
+	candidates = append(candidates, routeCandidate{
+		providerName: providerName, model: primary,
+		chainPosition: 0, ruleID: fmt.Sprintf("policies.model_routing.tier_%d.primary", tier),
+	})
+	seen := map[string]bool{providerName + "/" + primary: true}
+
+	appendCandidate := func(model, ruleID string) {
+		m := strings.TrimSpace(model)
+		if m == "" {
+			return
+		}
+		p, inferErr := inferProvider(m)
+		if inferErr != nil {
+			rejected = append(rejected, RejectedRouteCandidate{ProviderID: m, Reason: fmt.Sprintf("%s: %v", ruleID, inferErr)})
+			return
+		}
+		if tierConfig.BedrockOnly {
+			p = "bedrock"
+		}
+		if seen[p+"/"+m] {
+			return
+		}
+		seen[p+"/"+m] = true
+		candidates = append(candidates, routeCandidate{
+			providerName: p, model: m,
+			chainPosition: len(candidates), ruleID: ruleID,
+		})
+	}
+
+	for i, m := range tierConfig.FallbackChain {
+		appendCandidate(m, fmt.Sprintf("policies.model_routing.tier_%d.fallback_chain[%d]", tier, i))
+	}
+	if len(tierConfig.FallbackChain) == 0 && tierConfig.Fallback != "" {
+		appendCandidate(tierConfig.Fallback, fmt.Sprintf("policies.model_routing.tier_%d.fallback", tier))
+	}
+	return candidates, rejected
+}
+
+// ResolvedCandidate is a dispatchable (provider, model) pair from a tier's
+// candidate list, in dispatch order. ChainPosition 0 is the primary.
+type ResolvedCandidate struct {
+	Provider      Provider
+	ProviderName  string
+	Model         string
+	ChainPosition int
+	RuleID        string
+	Jurisdiction  string
+}
+
+// ResolveCandidates returns the ordered, policy-valid candidate list for a
+// tier. When opts enables compliance-aware routing, each candidate is
+// evaluated with the OPA routing policy (sovereignty-aware) and refused
+// candidates are returned in rejected — they are never dispatched, so
+// error-driven failover cannot become a sovereignty bypass.
+func (r *Router) ResolveCandidates(ctx context.Context, tier int, opts *RouteOptions) (resolved []ResolvedCandidate, rejected []RejectedRouteCandidate, err error) {
+	tierConfig, err := r.getTierConfig(tier)
+	if err != nil {
+		return nil, nil, err
+	}
+	if strings.TrimSpace(tierConfig.Primary) == "" {
+		return nil, nil, fmt.Errorf("tier %d: %w", tier, ErrNoPrimaryModel)
+	}
+	candidates, rejected := r.buildCandidates(tier, tierConfig)
+	useCompliance := opts != nil && opts.PolicyEngine != nil && opts.SovereigntyMode != ""
+	dataTier := tier
+	requireEU := false
+	if useCompliance {
+		dataTier = opts.DataTier
+		if dataTier < 0 || dataTier > 2 {
+			dataTier = tier
+		}
+		requireEU = dataTier == 2
+	}
+	for _, c := range candidates {
+		prov, ok := r.providers[c.providerName]
+		if !ok {
+			rejected = append(rejected, RejectedRouteCandidate{ProviderID: c.providerName, Reason: fmt.Sprintf("%s: provider not available", c.ruleID)})
+			continue
+		}
+		meta := prov.Metadata()
+		if useCompliance {
+			region := ""
+			if len(meta.EURegions) > 0 {
+				region = meta.EURegions[0]
 			}
-			if fbProvider != providerName || fb != primary {
-				out = append(out, routeCandidate{providerName: fbProvider, model: fb})
+			dec, evalErr := opts.PolicyEngine.EvaluateRouting(ctx, &policy.RoutingInput{
+				SovereigntyMode:      opts.SovereigntyMode,
+				ProviderID:           meta.ID,
+				ProviderJurisdiction: meta.Jurisdiction,
+				ProviderRegion:       region,
+				DataTier:             dataTier,
+				RequireEURouting:     requireEU,
+			})
+			if evalErr != nil {
+				rejected = append(rejected, RejectedRouteCandidate{ProviderID: c.providerName, Reason: evalErr.Error()})
+				continue
+			}
+			if !dec.Allowed {
+				for _, reason := range dec.Reasons {
+					rejected = append(rejected, RejectedRouteCandidate{ProviderID: c.providerName, Reason: reason})
+				}
+				continue
 			}
 		}
+		resolved = append(resolved, ResolvedCandidate{
+			Provider:      prov,
+			ProviderName:  c.providerName,
+			Model:         c.model,
+			ChainPosition: c.chainPosition,
+			RuleID:        c.ruleID,
+			Jurisdiction:  meta.Jurisdiction,
+		})
 	}
-	return out
+	return resolved, rejected, nil
 }
 
 // GracefulRoute selects provider and model like Route, but may downgrade to a fallback model

--- a/internal/otel/genai.go
+++ b/internal/otel/genai.go
@@ -33,6 +33,14 @@ const (
 	TalonDataTier               = attribute.Key("talon.data.tier")
 	TalonRoutingRejectedCount   = attribute.Key("talon.routing.rejected_count")
 
+	// Talon provider failover attributes (error-driven fallback chains)
+	TalonProviderOriginal       = attribute.Key("talon.provider.original")        // primary provider that failed
+	TalonProviderSelected       = attribute.Key("talon.provider.selected")        // provider actually used
+	TalonProviderFallbackReason = attribute.Key("talon.provider.fallback_reason") // error class that triggered failover
+	TalonFallbackChainPosition  = attribute.Key("talon.fallback.chain_position")  // position of selected candidate (0 = primary)
+	TalonFallbackFailedAttempts = attribute.Key("talon.fallback.failed_attempts") // number of failed runtime attempts
+	TalonFallbackFailClosed     = attribute.Key("talon.fallback.fail_closed")     // true when no policy-valid candidate existed
+
 	// Talon cost estimation attributes (from pricing table)
 	TalonCostEstimatedUSD = attribute.Key("talon.cost.estimated_usd")
 	TalonCostPricingKnown = attribute.Key("talon.cost.pricing_known")

--- a/internal/policy/agent.talon.schema.json
+++ b/internal/policy/agent.talon.schema.json
@@ -436,6 +436,11 @@
       "properties": {
         "primary": {"type": "string"},
         "fallback": {"type": "string"},
+        "fallback_chain": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Ordered error-driven fallback chain: on a transient provider failure (timeout/connection/429/5xx) the runner retries these models in order, subject to the same compliance/sovereignty routing checks as the primary. Supersedes the single `fallback` for error-driven failover."
+        },
         "location": {"type": "string"},
         "bedrock_only": {"type": "boolean"}
       }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -367,10 +367,17 @@ type ModelRoutingConfig struct {
 // provider registry metadata combined with llm.routing.data_sovereignty_mode
 // (routing.rego) and, at the gateway, egress rules.
 type TierConfig struct {
-	Primary     string `yaml:"primary" json:"primary"`
-	Fallback    string `yaml:"fallback,omitempty" json:"fallback,omitempty"`
-	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
-	BedrockOnly bool   `yaml:"bedrock_only,omitempty" json:"bedrock_only,omitempty"`
+	Primary  string `yaml:"primary" json:"primary"`
+	Fallback string `yaml:"fallback,omitempty" json:"fallback,omitempty"`
+	// FallbackChain is the ordered error-driven fallback chain for this tier:
+	// on a transient provider failure (timeout / connection / 429 / 5xx) the
+	// runner retries the request against each model in order, subject to the
+	// same compliance/sovereignty routing checks as the primary. When set it
+	// supersedes the single legacy Fallback entry for error-driven failover
+	// (Fallback still applies to provider-unavailable-at-route-time).
+	FallbackChain []string `yaml:"fallback_chain,omitempty" json:"fallback_chain,omitempty"`
+	Location      string   `yaml:"location,omitempty" json:"location,omitempty"`
+	BedrockOnly   bool     `yaml:"bedrock_only,omitempty" json:"bedrock_only,omitempty"`
 }
 
 // TimeRestrictionsConfig limits when the agent can run.
@@ -526,6 +533,18 @@ func validateTierRouting(tierName string, tier *TierConfig) (warnings []RoutingW
 					"fallback will also be forced through Bedrock provider",
 				tier.Fallback),
 		})
+	}
+
+	for i, m := range tier.FallbackChain {
+		if !isBedrockModelName(m) {
+			warnings = append(warnings, RoutingWarning{
+				Tier: tierName,
+				Message: fmt.Sprintf(
+					"bedrock_only is true but fallback_chain[%d] model %q does not use Bedrock naming; "+
+						"it will also be forced through Bedrock provider",
+					i, m),
+			})
+		}
 	}
 
 	return warnings, nil

--- a/internal/policy/schema_failover_test.go
+++ b/internal/policy/schema_failover_test.go
@@ -1,0 +1,50 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSchema_FallbackChain guards that the embedded agent schema
+// accepts the error-driven fallback_chain field (issue #138) — a config that
+// `talon validate` rejects is a feature nobody can use.
+func TestValidateSchema_FallbackChain(t *testing.T) {
+	yamlDoc := []byte(`
+agent:
+  name: failover-agent
+  version: 1.0.0
+
+policies:
+  cost_limits:
+    daily: 10.0
+  model_routing:
+    tier_1:
+      primary: gpt-4o
+      fallback_chain:
+        - mistral-large-latest
+        - llama3:70b
+`)
+	require.NoError(t, ValidateSchema(yamlDoc, false))
+}
+
+func TestValidateSchema_FallbackChainRejectsNonStringItems(t *testing.T) {
+	yamlDoc := []byte(`
+agent:
+  name: failover-agent
+  version: 1.0.0
+
+policies:
+  cost_limits:
+    daily: 10.0
+  model_routing:
+    tier_1:
+      primary: gpt-4o
+      fallback_chain:
+        - provider: mistral
+`)
+	err := ValidateSchema(yamlDoc, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fallback_chain")
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1245,6 +1245,9 @@ func (s *Server) handleGovernanceAlerts(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
+	if alerts == nil {
+		alerts = []evidence.GovernanceAlert{}
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{"alerts": alerts})
 }
 

--- a/internal/server/handlers_dashboard_alerts_test.go
+++ b/internal/server/handlers_dashboard_alerts_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// The dashboard contract is that "alerts" is always an array. A nil slice
+// from the store must serialize as [] — not null and not an absent key.
+func TestGovernanceAlerts_EmptyStoreReturnsEmptyArray(t *testing.T) {
+	dir := t.TempDir()
+	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	srv := NewServer(nil, store, nil, nil, nil, "", nil, "admin-secret", map[string]string{})
+	rec := doComplianceRequest(t, srv.Routes(), "/v1/dashboard/governance-alerts", adminHeader)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	raw, ok := resp["alerts"]
+	require.True(t, ok, "response must carry an alerts key: %s", rec.Body.String())
+
+	var alerts []json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &alerts), "alerts must be a JSON array, got: %s", string(raw))
+	require.Empty(t, alerts)
+}

--- a/schemas/agent.talon.schema.json
+++ b/schemas/agent.talon.schema.json
@@ -436,6 +436,11 @@
       "properties": {
         "primary": {"type": "string"},
         "fallback": {"type": "string"},
+        "fallback_chain": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Ordered error-driven fallback chain: on a transient provider failure (timeout/connection/429/5xx) the runner retries these models in order, subject to the same compliance/sovereignty routing checks as the primary. Supersedes the single `fallback` for error-driven failover."
+        },
         "location": {"type": "string"},
         "bedrock_only": {"type": "boolean"}
       }

--- a/schemas/talon.config.schema.json
+++ b/schemas/talon.config.schema.json
@@ -289,7 +289,24 @@
                 "type": "array",
                 "items": { "type": "string" }
               },
-              "tool_policy_action": { "$ref": "#/definitions/toolPolicyAction" }
+              "tool_policy_action": { "$ref": "#/definitions/toolPolicyAction" },
+              "api_family": {
+                "type": "string",
+                "enum": ["openai", "anthropic"],
+                "description": "Wire format of this provider for fallback-chain validation and upstream auth conventions. Defaults by name: 'anthropic' uses the Anthropic Messages API (x-api-key + anthropic-version); everything else is OpenAI-compatible. Set explicitly for aliased endpoints."
+              },
+              "fallback": {
+                "type": "array",
+                "description": "Ordered error-driven fallback chain: on a transient upstream failure (timeout/connection/429/5xx) the gateway retries these targets in order, subject to candidate filters (sovereignty under eu_strict, caller allowlists, gateway policy). All targets must share this provider's API family.",
+                "items": {
+                  "type": "object",
+                  "required": ["provider"],
+                  "properties": {
+                    "provider": { "type": "string", "description": "Name of an enabled gateway provider to fail over to." },
+                    "model": { "type": "string", "description": "Optional: rewrite the request body's model field for this target." }
+                  }
+                }
+              }
             }
           }
         },

--- a/tests/smoke_sections/29_consistency.sh
+++ b/tests/smoke_sections/29_consistency.sh
@@ -171,7 +171,11 @@ test_section_29_consistency() {
     ops_redacted="$(echo "$ops_json" | jq '[.records[] | select(.pii_redacted == true)] | length' 2>/dev/null || echo 0)"
     ops_routed="$(echo "$ops_json" | jq '[.records[] | select((.model_used // "") != "")] | length' 2>/dev/null || echo 0)"
 
-    if [[ "$ops_total" -eq $((ops_allowed + ops_blocked)) ]] && [[ "$ops_routed" -le "$ops_allowed" ]]; then
+    # routed counts records with a model_used, which includes DENIED gateway
+    # records (the routing decision is evidenced even when policy blocks the
+    # dispatch) — so routed is NOT a subset of allowed. Only the allow/block
+    # partition is an invariant.
+    if [[ "$ops_total" -eq $((ops_allowed + ops_blocked)) ]]; then
       echo "  ✓  CONSISTENCY: decision reconciliation from export is valid (block/redact/route/allow)"
       echo "[SMOKE] CONSISTENCY|ops_decision_reconcile_export|PASS|total=$ops_total allowed=$ops_allowed blocked=$ops_blocked redacted=$ops_redacted routed=$ops_routed"
       record_pass

--- a/tests/smoke_sections/35_failover.sh
+++ b/tests/smoke_sections/35_failover.sh
@@ -30,6 +30,13 @@ test_section_35_failover() {
     cd "$REPO_ROOT" || true
     return 0
   fi
+  # Scenario A fails over to the real OpenAI endpoint: skip the whole section
+  # when no credential is available rather than asserting a doomed 200.
+  if ! run_talon secrets list 2>/dev/null | grep -q openai-api-key; then
+    echo "  -  (skip failover: no openai-api-key credential in vault)"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
 
   local fo_key="talon-gw-failover-001"
   # Dead primary (nothing listens on this port) + real OpenAI as fallback target.

--- a/tests/smoke_sections/35_failover.sh
+++ b/tests/smoke_sections/35_failover.sh
@@ -11,6 +11,21 @@
 #   B) eu_strict with a US-only backup -> request fails closed (no dispatch to
 #      the US provider), recorded as a successful governance outcome.
 # -----------------------------------------------------------------------------
+# Backgrounding serve through the run_talon wrapper leaves $! pointing at a
+# wrapper subshell; killing it orphans the talon child, which keeps the port
+# and starves scenario B (and later sections). Stop by PID first, then kill
+# any talon serve still listening on the port.
+smoke_stop_gateway_35() {
+  local pid="$1" port="$2" waited=0
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  while is_port_in_use "$port" && [[ $waited -lt 15 ]]; do
+    pkill -f "talon serve --port ${port}" 2>/dev/null || true
+    sleep 1
+    ((waited += 1))
+  done
+}
+
 test_section_35_failover() {
   local section="35_failover"
   local gateway_port="8080"
@@ -71,12 +86,12 @@ GWEOF
 
   # --- Scenario A: transparent failover to the backup provider ---
   local gw_log_a="$dir/gateway_failover_a.log"
-  run_talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_a" >"$gw_log_a" 2>&1 &
+  env TALON_DATA_DIR="$TALON_DATA_DIR" talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_a" >"$gw_log_a" 2>&1 &
   local fo_pid_a=$!
   if ! smoke_wait_health "$gateway_base_url" 10 1; then
     log_failure "failover gateway (A) did not start on port ${gateway_port}" "pid=$fo_pid_a"
     dump_diag_file "section 35 serve log (A)" "$gw_log_a"
-    kill "$fo_pid_a" 2>/dev/null || true
+    smoke_stop_gateway_35 "$fo_pid_a" "$gateway_port"
     cd "$REPO_ROOT" || true
     return 0
   fi
@@ -94,8 +109,7 @@ GWEOF
   local fo_corr
   fo_corr="$(grep -i '^X-Talon-Session-ID:' "$fo_headers" 2>/dev/null | head -1 | tr -d '\r' | awk '{print $2}' | sed 's/^sess_//')"
 
-  kill "$fo_pid_a" 2>/dev/null || true
-  wait "$fo_pid_a" 2>/dev/null || true
+  smoke_stop_gateway_35 "$fo_pid_a" "$gateway_port"
 
   local export_out
   export_out="$(run_talon audit export --format json --from 2020-01-01 --to 2099-12-31 2>/dev/null)"; true
@@ -137,12 +151,12 @@ SOVEOF
     return 0
   fi
   local gw_log_b="$dir/gateway_failover_b.log"
-  run_talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_b" >"$gw_log_b" 2>&1 &
+  env TALON_DATA_DIR="$TALON_DATA_DIR" talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_b" >"$gw_log_b" 2>&1 &
   local fo_pid_b=$!
   if ! smoke_wait_health "$gateway_base_url" 10 1; then
     log_failure "failover gateway (B) did not start on port ${gateway_port}" "pid=$fo_pid_b"
     dump_diag_file "section 35 serve log (B)" "$gw_log_b"
-    kill "$fo_pid_b" 2>/dev/null || true
+    smoke_stop_gateway_35 "$fo_pid_b" "$gateway_port"
     cd "$REPO_ROOT" || true
     return 0
   fi
@@ -159,8 +173,7 @@ SOVEOF
   local fo_corr_b
   fo_corr_b="$(grep -i '^X-Talon-Session-ID:' "$fo_headers_b" 2>/dev/null | head -1 | tr -d '\r' | awk '{print $2}' | sed 's/^sess_//')"
 
-  kill "$fo_pid_b" 2>/dev/null || true
-  wait "$fo_pid_b" 2>/dev/null || true
+  smoke_stop_gateway_35 "$fo_pid_b" "$gateway_port"
 
   if [[ -n "$fo_corr_b" ]]; then
     local verify_out_b

--- a/tests/smoke_sections/35_failover.sh
+++ b/tests/smoke_sections/35_failover.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Smoke test section: 35_failover
+# Sourced by tests/smoke_test.sh — do not run directly.
+
+# -----------------------------------------------------------------------------
+# SECTION 35 — Provider fallback chains (issue #138)
+# Error-driven, sovereignty-respecting failover through the gateway:
+#   A) dead primary provider -> transparent failover to an OpenAI-compatible
+#      backup (real OpenAI endpoint), evidenced as failed attempt + fallback
+#      decision, verified by `talon audit verify --failover`.
+#   B) eu_strict with a US-only backup -> request fails closed (no dispatch to
+#      the US provider), recorded as a successful governance outcome.
+# -----------------------------------------------------------------------------
+test_section_35_failover() {
+  local section="35_failover"
+  local gateway_port="8080"
+  local gateway_base_url="http://127.0.0.1:${gateway_port}"
+  local dir; dir="$(setup_section_dir "$section")"
+  cd "$dir" || exit 1
+  if ! wait_port_free "$gateway_port" 180 10; then
+    log_failure "failover section could not acquire port ${gateway_port}" "port remained busy"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+  run_talon init --scaffold --name smoke-agent &>/dev/null; true
+  [[ -n "${OPENAI_API_KEY:-}" ]] && run_talon secrets set openai-api-key "$OPENAI_API_KEY" &>/dev/null; true
+  smoke_tighten_limits "$dir"
+  if [[ ! -f "$dir/talon.config.yaml" ]]; then
+    echo "  -  (skip failover: no config)"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+
+  local fo_key="talon-gw-failover-001"
+  # Dead primary (nothing listens on this port) + real OpenAI as fallback target.
+  local gw_cfg_a="$dir/talon.gateway.failover.yaml"
+  cat > "$gw_cfg_a" <<'GWEOF'
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "enforce"
+  providers:
+    openai:
+      enabled: true
+      secret_name: "openai-api-key"
+      base_url: "http://127.0.0.1:59973"
+      region: "EU"
+      fallback:
+        - provider: "backup"
+    backup:
+      enabled: true
+      secret_name: "openai-api-key"
+      base_url: "https://api.openai.com"
+      region: "EU"
+  callers:
+    - name: "smoke-failover"
+      tenant_key: "talon-gw-failover-001"
+      tenant_id: "default"
+  default_policy:
+    default_pii_action: "warn"
+    max_daily_cost: 100.00
+    require_caller_id: true
+GWEOF
+
+  # --- Scenario A: transparent failover to the backup provider ---
+  local gw_log_a="$dir/gateway_failover_a.log"
+  run_talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_a" >"$gw_log_a" 2>&1 &
+  local fo_pid_a=$!
+  if ! smoke_wait_health "$gateway_base_url" 10 1; then
+    log_failure "failover gateway (A) did not start on port ${gateway_port}" "pid=$fo_pid_a"
+    dump_diag_file "section 35 serve log (A)" "$gw_log_a"
+    kill "$fo_pid_a" 2>/dev/null || true
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+
+  local fo_headers="/tmp/talon_fo_headers.txt"
+  local fo_body="/tmp/talon_fo_resp.json"
+  local code
+  code="$(smoke_gw_post_chat_capture "$gateway_base_url" "Bearer $fo_key" "$SMOKE_BODY_SIMPLE" "$fo_headers" "$fo_body")"
+  if ! assert_pass "dead primary fails over transparently (POST returns 200)" test "$code" = "200"; then
+    dump_diag_kv "section 35 failover POST" "http_code=$code"
+    dump_diag_json "failover response body" "$(cat "$fo_body" 2>/dev/null || echo '(missing)')"
+    dump_diag_file "section 35 serve log (A)" "$gw_log_a" 50
+  fi
+  # Correlation ID is recoverable from the session header (sess_<correlation-id>).
+  local fo_corr
+  fo_corr="$(grep -i '^X-Talon-Session-ID:' "$fo_headers" 2>/dev/null | head -1 | tr -d '\r' | awk '{print $2}' | sed 's/^sess_//')"
+
+  kill "$fo_pid_a" 2>/dev/null || true
+  wait "$fo_pid_a" 2>/dev/null || true
+
+  local export_out
+  export_out="$(run_talon audit export --format json --from 2020-01-01 --to 2099-12-31 2>/dev/null)"; true
+  assert_pass "failed provider attempt is evidenced (gateway_failover_attempt record)" \
+    grep -q "gateway_failover_attempt" <<< "$export_out"
+
+  if [[ -n "$fo_corr" ]]; then
+    local verify_out
+    verify_out="$(run_talon audit verify --failover "$fo_corr" 2>&1)"
+    if [[ $? -eq 0 ]] && grep -q "valid_fallback" <<< "$verify_out"; then
+      echo "  ✓  audit verify --failover confirms valid fallback chain"
+      record_pass
+    else
+      log_failure "audit verify --failover should report valid_fallback" "$verify_out"
+    fi
+  else
+    log_failure "failover response should carry X-Talon-Session-ID for correlation" "headers=$(cat "$fo_headers" 2>/dev/null)"
+  fi
+
+  # --- Scenario B: eu_strict with a US-only backup fails closed ---
+  if ! grep -q "^sovereignty:" "$dir/talon.config.yaml" 2>/dev/null; then
+    cat >> "$dir/talon.config.yaml" <<'SOVEOF'
+
+sovereignty:
+  mode: eu_strict
+SOVEOF
+  fi
+  # Backup is US in scenario B: the only region change is the backup provider's.
+  local gw_cfg_b="$dir/talon.gateway.failclosed.yaml"
+  awk '
+    /backup:/ { in_backup=1 }
+    in_backup && /region: "EU"/ { sub(/region: "EU"/, "region: \"US\""); in_backup=0 }
+    { print }
+  ' "$gw_cfg_a" > "$gw_cfg_b"
+
+  if ! wait_port_free "$gateway_port" 60 5; then
+    log_failure "failover section (B) could not re-acquire port ${gateway_port}" "port remained busy"
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+  local gw_log_b="$dir/gateway_failover_b.log"
+  run_talon serve --port "$gateway_port" --gateway --gateway-config "$gw_cfg_b" >"$gw_log_b" 2>&1 &
+  local fo_pid_b=$!
+  if ! smoke_wait_health "$gateway_base_url" 10 1; then
+    log_failure "failover gateway (B) did not start on port ${gateway_port}" "pid=$fo_pid_b"
+    dump_diag_file "section 35 serve log (B)" "$gw_log_b"
+    kill "$fo_pid_b" 2>/dev/null || true
+    cd "$REPO_ROOT" || true
+    return 0
+  fi
+
+  local fo_headers_b="/tmp/talon_fo_headers_b.txt"
+  local fo_body_b="/tmp/talon_fo_resp_b.json"
+  local code_b
+  code_b="$(smoke_gw_post_chat_capture "$gateway_base_url" "Bearer $fo_key" "$SMOKE_BODY_SIMPLE" "$fo_headers_b" "$fo_body_b")"
+  if ! assert_pass "eu_strict with US-only backup fails closed (non-200)" test "$code_b" != "200"; then
+    dump_diag_kv "section 35 fail-closed POST" "http_code=$code_b"
+    dump_diag_json "fail-closed response body" "$(cat "$fo_body_b" 2>/dev/null || echo '(missing)')"
+    dump_diag_file "section 35 serve log (B)" "$gw_log_b" 50
+  fi
+  local fo_corr_b
+  fo_corr_b="$(grep -i '^X-Talon-Session-ID:' "$fo_headers_b" 2>/dev/null | head -1 | tr -d '\r' | awk '{print $2}' | sed 's/^sess_//')"
+
+  kill "$fo_pid_b" 2>/dev/null || true
+  wait "$fo_pid_b" 2>/dev/null || true
+
+  if [[ -n "$fo_corr_b" ]]; then
+    local verify_out_b
+    verify_out_b="$(run_talon audit verify --failover "$fo_corr_b" 2>&1)"
+    if [[ $? -eq 0 ]] && grep -q "valid_fail_closed" <<< "$verify_out_b"; then
+      echo "  ✓  audit verify --failover confirms fail-closed governance outcome"
+      record_pass
+    else
+      log_failure "audit verify --failover should report valid_fail_closed" "$verify_out_b"
+    fi
+  else
+    log_failure "fail-closed response should carry X-Talon-Session-ID for correlation" "headers=$(cat "$fo_headers_b" 2>/dev/null)"
+  fi
+
+  # Full sweep: every failover chain in the store must verify.
+  assert_pass "audit verify --failover (all chains) exits 0" run_talon audit verify --failover
+
+  rm -f "$fo_headers" "$fo_body" "$fo_headers_b" "$fo_body_b" 2>/dev/null || true
+  cd "$REPO_ROOT" || true
+}

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -540,6 +540,7 @@ main() {
   run_section "32_egress" test_section_32_egress
   run_section "33_auditor_documents" test_section_33_auditor_documents
   run_section "34_compliance_dashboard" test_section_34_compliance_dashboard
+  run_section "35_failover" test_section_35_failover
 
   # Section 29: Consistency checks — cross-command flow verification
   run_section "29_consistency" test_section_29_consistency

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -453,7 +453,7 @@ for _section_file in \
   23_dashboard_metrics.sh 24_plan_dispatch.sh 25_sessions.sh \
   26_pii_enrichment.sh 27_runtime_governance.sh 28_control_plane.sh \
   29_consistency.sh 30_graph_events.sh 31_quickstart.sh 32_egress.sh \
-  33_auditor_documents.sh 34_compliance_dashboard.sh; do
+  33_auditor_documents.sh 34_compliance_dashboard.sh 35_failover.sh; do
   # shellcheck source=/dev/null
   source "${SMOKE_SECTIONS_DIR}/${_section_file}"
 done

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -96,6 +96,19 @@ record_fail() {
   fi
 }
 
+# --- Redact credentials before any command line or output reaches a log ---
+# The harness logs fully expanded command lines and output tails, so without
+# this a `secrets set <name> <value>` assertion writes the real credential to
+# disk, and API keys can surface in dumped headers or bodies. Deliberately
+# short test tokens (test-key-123, talon-gw-*) stay readable for debugging.
+redact_secrets() {
+  sed -E \
+    -e 's/(secrets[[:space:]]+set[[:space:]]+[^[:space:]]+[[:space:]]+).*/\1***REDACTED***/' \
+    -e 's/sk-[A-Za-z0-9_-]{20,}/sk-***REDACTED***/g' \
+    -e 's/(Bearer[[:space:]]+)[A-Za-z0-9._~+\/=-]{32,}/\1***REDACTED***/g'
+}
+redact_str() { printf '%s' "$1" | redact_secrets; }
+
 # --- Write command execution to consolidated log (parseable: [SMOKE] CMD|... / EXIT|... / STDOUT_TAIL / STDERR_TAIL) ---
 write_cmd_log() {
   local description="$1" cmd="$2" code="$3" tmp_out="$4" tmp_err="$5"
@@ -103,13 +116,13 @@ write_cmd_log() {
   {
     echo "[SMOKE] SECTION|$CURRENT_SECTION"
     echo "[SMOKE] ASSERT_DESC|$description"
-    echo "[SMOKE] CMD|$cmd"
+    echo "[SMOKE] CMD|$(redact_str "$cmd")"
     echo "[SMOKE] EXIT|$code"
     echo "[SMOKE] STDOUT_TAIL<<"
-    [[ -f "$tmp_out" ]] && tail -30 "$tmp_out"
+    [[ -f "$tmp_out" ]] && tail -30 "$tmp_out" | redact_secrets
     echo "[SMOKE] STDOUT_TAIL>>"
     echo "[SMOKE] STDERR_TAIL<<"
-    [[ -f "$tmp_err" ]] && tail -30 "$tmp_err"
+    [[ -f "$tmp_err" ]] && tail -30 "$tmp_err" | redact_secrets
     echo "[SMOKE] STDERR_TAIL>>"
     echo ""
   } >> "$SMOKE_CONSOLIDATED_LOG"
@@ -129,7 +142,8 @@ assert_pass() {
   fi
   local code
   code=$?
-  local cmd_detail="$*"
+  local cmd_detail
+  cmd_detail="$(redact_str "$*")"
   echo "  ✗  $description (exit $code) [$cmd_detail]"
   write_cmd_log "$description" "$cmd_detail" "$code" "$tmp_out" "$tmp_err"
   record_fail "$description"
@@ -141,16 +155,16 @@ assert_pass() {
       echo "Command: $cmd_detail"
       echo "Exit code: $code"
       echo "Stdout (last 100 lines):"
-      tail -100 "$tmp_out"
+      tail -100 "$tmp_out" | redact_secrets
       echo "Stderr (last 100 lines):"
-      tail -100 "$tmp_err"
+      tail -100 "$tmp_err" | redact_secrets
       echo ""
     } >> "$SMOKE_LOG_FILE"
   fi
   # Show last few stderr lines so bugs are visible without opening the log
   if [[ -s "$tmp_err" ]]; then
     echo "    Last stderr:"
-    tail -5 "$tmp_err" | sed 's/^/    | /'
+    tail -5 "$tmp_err" | redact_secrets | sed 's/^/    | /'
   fi
   rm -f "$tmp_out" "$tmp_err"
   return 1
@@ -167,7 +181,7 @@ assert_fail() {
     write_cmd_log "$description" "$*" "$code" "$tmp_out" "$tmp_err"
     record_fail "$description"
     if [[ -n "$SMOKE_LOG_FILE" ]]; then
-      { echo "--- FAIL: $description ---"; echo "Section: $CURRENT_SECTION"; echo "Command succeeded but should have failed: $*"; echo ""; } >> "$SMOKE_LOG_FILE"
+      { echo "--- FAIL: $description ---"; echo "Section: $CURRENT_SECTION"; echo "Command succeeded but should have failed: $(redact_str "$*")"; echo ""; } >> "$SMOKE_LOG_FILE"
     fi
     rm -f "$tmp_out" "$tmp_err"
     return 1
@@ -187,6 +201,7 @@ assert_fail() {
 log_failure() {
   local description="$1"
   local detail="${2:-}"
+  [[ -n "$detail" ]] && detail="$(redact_str "$detail")"
   echo "  ✗  $description"
   record_fail "$description"
   if [[ -n "$SMOKE_LOG_FILE" ]]; then
@@ -204,10 +219,10 @@ log_failure() {
 dump_diag_kv() {
   local label="$1"; shift
   if [[ -n "$SMOKE_LOG_FILE" ]]; then
-    { echo "  [DIAG] $label"; for kv in "$@"; do echo "    $kv"; done; echo ""; } >> "$SMOKE_LOG_FILE"
+    { echo "  [DIAG] $label"; for kv in "$@"; do echo "    $(redact_str "$kv")"; done; echo ""; } >> "$SMOKE_LOG_FILE"
   fi
   if [[ -n "${SMOKE_CONSOLIDATED_LOG:-}" ]]; then
-    { echo "[SMOKE] DIAG|$label"; for kv in "$@"; do echo "[SMOKE] DIAG_KV|$kv"; done; } >> "$SMOKE_CONSOLIDATED_LOG"
+    { echo "[SMOKE] DIAG|$label"; for kv in "$@"; do echo "[SMOKE] DIAG_KV|$(redact_str "$kv")"; done; } >> "$SMOKE_CONSOLIDATED_LOG"
   fi
 }
 
@@ -215,16 +230,17 @@ dump_diag_kv() {
 dump_diag_file() {
   local label="$1" filepath="$2" max_lines="${3:-80}"
   if [[ -n "$SMOKE_LOG_FILE" ]] && [[ -f "$filepath" ]]; then
-    { echo "  [DIAG] $label ($filepath):"; tail -"$max_lines" "$filepath" | sed 's/^/    | /'; echo ""; } >> "$SMOKE_LOG_FILE"
+    { echo "  [DIAG] $label ($filepath):"; tail -"$max_lines" "$filepath" | redact_secrets | sed 's/^/    | /'; echo ""; } >> "$SMOKE_LOG_FILE"
   fi
   if [[ -n "${SMOKE_CONSOLIDATED_LOG:-}" ]] && [[ -f "$filepath" ]]; then
-    { echo "[SMOKE] DIAG_FILE|$label|$filepath"; tail -"$max_lines" "$filepath" | sed 's/^/[SMOKE] DIAG_LINE|/'; echo "[SMOKE] DIAG_FILE_END|$label"; } >> "$SMOKE_CONSOLIDATED_LOG"
+    { echo "[SMOKE] DIAG_FILE|$label|$filepath"; tail -"$max_lines" "$filepath" | redact_secrets | sed 's/^/[SMOKE] DIAG_LINE|/'; echo "[SMOKE] DIAG_FILE_END|$label"; } >> "$SMOKE_CONSOLIDATED_LOG"
   fi
 }
 
 # Dump JSON body (pretty-printed via jq if available) to the failure log.
 dump_diag_json() {
   local label="$1" json_str="$2" max_lines="${3:-60}"
+  [[ -n "$json_str" ]] && json_str="$(redact_str "$json_str")"
   if [[ -n "$SMOKE_LOG_FILE" ]] && [[ -n "$json_str" ]]; then
     {
       echo "  [DIAG] $label:"


### PR DESCRIPTION
Closes #138. Feature bet 5.4 (reliability layer), M2 parity. Implements the scope agreed in the issue thread: transient-only triggers, candidate filter pipeline with a #189 seam, dual signed evidence facts, fail-closed as a governance success, and semantic verifier rules.

## What

**Failover engine (both call paths)**
- `internal/failover` — new leaf package shared by the gateway and the LLM router: error classification (`timeout`/`connection_error`/`rate_limited`/`upstream_5xx` transient; auth/4xx permanent; caller-canceled never fails over) and the `CandidateFilter` pipeline. Sovereignty filter ships now; #189 model-policy-facts checks (availability, ZDR, retention, access scope) plug in as additional filters without rework.
- **Gateway proxy path** — `gateway.providers.<name>.fallback: [{provider, model?}]`, validated at load (targets enabled, no self/dupes, same API family since the body is forwarded as-is apart from a model rewrite). A deferred-commit `failoverWriter` buffers upstream error responses so they can be retried, while SSE success streams still pass through unbuffered (no failover after first byte — documented and tested). Each fallback attempt rebuilds auth from the target's own secret.
- **Agent runs (`talon run`)** — `policies.model_routing.tier_N.fallback_chain: [...]` (supersedes legacy single `fallback`); candidates are resolved through the compliance routing policy, so under `eu_strict` a non-EU candidate never enters the chain; the runner retries `Generate` across the resolved candidates.

**Evidence (issue-comment spec)** — two separate signed records linked by correlation ID, per the maintainer's stated preference for verifier simplicity:
1. *Failed provider attempt* (`gateway_failover_attempt` / `llm_failover_attempt`): provider, region, error class, upstream status, chain position, sovereignty mode — with its own data-flow section (the prompt did egress to the failed provider).
2. *Fallback decision* on the request's final record: provider actually used, fallback rule id, chain position, sovereignty check result, links to the failed attempts, and policy-skipped candidates recorded distinctly from runtime failures.

**Fail-closed** — when no policy-valid candidate succeeds, the caller gets the buffered upstream error (or a 502 when nothing was dispatched) and the final record carries `failover.role: fail_closed` with `failure_reason: no_valid_fallback_candidate`, signed. Under `eu_strict`, refusing to route to a US secondary is recorded as correct governance behavior, not degraded reliability.

**Verifier** — `talon audit verify --failover [correlation-id]` implements the issue's rules as the first semantic (cross-record) verification layer:
- failed EU primary + successful EU secondary + matching correlation id → `valid_fallback`
- failed primary + only non-allowed secondary + no dispatch → `valid_fail_closed`
- fallback dispatched to a sovereignty-rejected provider, or any bad signature → `invalid`
- evidence recording only the final provider without failed-attempt/decision context → `insufficient`

**Observability** — spans get `talon.provider.original`, `talon.provider.selected`, `talon.provider.fallback_reason`, chain position / attempt count / fail-closed attrs; `RecordFailover` metric reused with error-class reasons. Compliance mapping gains a DORA Art. 7 supporting-control entry (claims-discipline wording).

## Tests
- Gateway integration (httptest): kill primary mid-flight → secondary succeeds with both evidence facts; `eu_strict` + US-only secondary → fail-closed, secondary never called, signed; permanent 401 passthrough (no failover); 429 + model rewrite; both-fail exhaustion; failoverWriter unit tests; chain config validation table.
- LLM path: `ResolveCandidates` chain ordering/dedup/compliance filtering, `ClassifyGenerateError` table, runner failover units incl. sovereignty-excluded candidates never dispatched.
- Verifier: table-driven cases for all four rules.
- Smoke: new section `35_failover` — live dead-primary → OpenAI failover with `audit verify --failover`, plus the eu_strict fail-closed scenario.

`make check` (lint + vet + unit + integration) is green.

## Notes for review
- Streaming semantics: failover is only possible before the first byte reaches the client; a mid-stream drop after 200 OK behaves exactly as before.
- `Evidence.Failover` is appended after `egress_decision` so pre-existing record signatures remain valid (evidence-integrity-spec §2 convention).
- Positioning: this is the "we fail over, but never out of Europe — and we can prove it" step that unblocks the remaining reliability caveat in the north-star demo #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to gateway forwarding, LLM routing, and evidence shape on critical egress paths; misconfiguration or verifier gaps could affect availability, sovereignty guarantees, or audit trust.
> 
> **Overview**
> Adds **error-driven, same-wire-format provider failover** on transient upstream failures (timeouts, connection errors, 429, 5xx). Permanent primary errors (e.g. 401) do not trigger failover; once failover runs, the chain keeps walking until success or **fail-closed** with signed governance evidence.
> 
> **Gateway** gains per-provider `fallback` chains and `api_family`, load-time validation (enabled targets, no self/dupes, matching API family), a buffered `failoverWriter` so error responses can be retried before the client sees bytes, per-target auth/secrets, optional model rewrite, and re-checks of caller allowlists, target tool policy, gateway policy, and sovereignty (`eu_strict` never dispatches non-EU/LOCAL). Governance parsing and errors now follow **`api_family`**, not only the provider map key.
> 
> **Agent runs** use `policies.model_routing` **`fallback_chain`** (supersedes legacy single `fallback` for this path); `runFailover` retries `Generate` per LLM call with its own `failover_group_id`, compliance-filtered candidates, and truthful provider/model on success.
> 
> **Evidence & audit**: new `Failover` context on records; separate `*_failover_attempt` and terminal decision/`llm_failover_decision` records linked by correlation ID and group; **`talon audit verify --failover`**. Semantic verifier rules (`valid_fallback`, `valid_fail_closed`, `invalid`, `insufficient`). OTel attrs and DORA Art. 7 mapping entry.
> 
> **Other**: shared `internal/failover` classification/filters; config docs; project-local `talon.config.yaml` wins over `~/.talon`; Anthropic string content redaction fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85defa5c2a8cfe4d77e028e06b127a03432df350. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->