### PR TITLE
test(gateway): Anthropic conformance suite for Claude Code traffic + truthful usage/cost fixes (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For user-facing entries, include:
 ### Added
 
 - **Anthropic protocol conformance suite (#193, epic #192 PR-A).** Recorded Claude-Code-shaped fixtures (streaming SSE, block-array system + `cache_control`, tool_use/tool_result round-trips, `count_tokens`, image blocks, `tool_choice`, ~50KB system prompts) replayed through the full gateway pipeline against a canned upstream, plus a transform-determinism guarantee: identical input yields byte-identical rewritten bodies (non-determinism would silently break provider-side prompt caching for clients). Fixtures are sanitized (synthetic keys, corpus emails) with a scripted recapture procedure (`scripts/record-conformance-fixtures.sh`) and a pinned last-verified client version (`internal/gateway/testdata/conformance/README.md`).
+- **Pricing table refreshed to the current Anthropic and OpenAI lineups** (verified against vendor pricing pages, 2026-07): Claude Fable 5 / Opus 4.8-4.5 / Sonnet 5 / Sonnet 4.6-4.5 / Haiku 4.5, and GPT-5.5/5.4 families + gpt-5.3-codex. Fixes `unknown model for cost estimation` warnings (and the resulting flat-fallback cost evidence) for current-model traffic. Legacy entries retained; operators can still override in `pricing/models.yaml`. Cache read/write rates land with the cache-aware pricing schema (#196).
 - **Large-prompt pipeline benchmark.** `BenchmarkGatewayPipelineOverheadLargePrompt` runs a ~50KB PII-bearing system prompt through the full pipeline (informational row in `docs/reference/benchmarks.md`; not regression-gated yet).
 
 ## [1.6.8] - 2026-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+### Fixed
+
+- **Anthropic streaming cost evidence was silently input-only (#211).** Real `message_delta` SSE events carry top-level `usage`, which matched the OpenAI parsing branch first — streaming output tokens were never captured, so signed cost undercounted every streamed Anthropic response and TPOT was never computed. Typed Anthropic events are now parsed before the generic branch. Who cares: anyone reading `talon costs` or signed FinOps evidence for streamed Anthropic traffic. Verify: `go test ./internal/gateway/ -run TestConformanceAnthropic_Fixtures/streaming_sse -v`.
+- **`count_tokens` recorded fabricated spend (#218).** The free `/v1/messages/count_tokens` endpoint returns no `usage` wrapper, so evidence fell back to the fixed pre-request estimate and the invented cost counted against caller budgets. Now classified as `invocation_type: "gateway_count_tokens"` with cost 0 and zero budget estimate — still fully governed (PII scan + policy run; the token count is recorded in evidence). Verify: `go test ./internal/gateway/ -run TestConformanceAnthropic_Fixtures/count_tokens -v`.
+- **Block-array `system` prompts could not be redacted.** The form Claude Code sends on every request (with `cache_control`) was extracted for detection but only string-form `system` was rewritten, so PII + `pii_action: redact` failed closed with HTTP 400 on every such request. Block arrays are now redacted; `cache_control` and untouched blocks survive byte-identically.
+- **Client backoff headers were dropped.** `Retry-After`, `request-id`/`anthropic-request-id`, and the Anthropic token-remaining/reset rate-limit headers are now forwarded to callers — coding-agent 429 backoff depends on them.
+
+### Added
+
+- **Anthropic protocol conformance suite (#193, epic #192 PR-A).** Recorded Claude-Code-shaped fixtures (streaming SSE, block-array system + `cache_control`, tool_use/tool_result round-trips, `count_tokens`, image blocks, `tool_choice`, ~50KB system prompts) replayed through the full gateway pipeline against a canned upstream, plus a transform-determinism guarantee: identical input yields byte-identical rewritten bodies (non-determinism would silently break provider-side prompt caching for clients). Fixtures are sanitized (synthetic keys, corpus emails) with a scripted recapture procedure (`scripts/record-conformance-fixtures.sh`) and a pinned last-verified client version (`internal/gateway/testdata/conformance/README.md`).
+- **Large-prompt pipeline benchmark.** `BenchmarkGatewayPipelineOverheadLargePrompt` runs a ~50KB PII-bearing system prompt through the full pipeline (informational row in `docs/reference/benchmarks.md`; not regression-gated yet).
+
 ## [1.6.8] - 2026-07-04
 
 ### Added

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -29,8 +29,14 @@ Requirements: Go 1.22+ (project pins 1.25.x in CI), CGO enabled (SQLite), repo r
 | Metric | Go benchmark | Package | What it includes |
 |--------|--------------|---------|------------------|
 | **Gateway pipeline overhead** | `BenchmarkGatewayPipelineOverhead` | `internal/gateway` | One non-streaming `ServeHTTP` round trip: route, caller auth, request extract, PII scan, OPA policy evaluation, forward to a **local** `httptest` mock upstream, response PII scan, signed evidence write, metrics. Representative payload includes EU email + IBAN patterns. |
+| **Gateway overhead — large Anthropic prompt** (informational) | `BenchmarkGatewayPipelineOverheadLargePrompt` | `internal/gateway` | Same non-streaming `ServeHTTP` round trip through the Anthropic wire format (`/v1/messages`), with a deterministic ~50KB system prompt built from a repeated fixed sentence containing a corpus email — exercises the PII scanner at large-prompt scale. |
 | **PII scan latency** | `BenchmarkPIIScan` | `internal/classifier` | One `Scanner.Scan` on fixed text (email, IBAN, card). Isolates classifier cost without HTTP or SQLite. |
 | **Evidence write throughput** | `BenchmarkEvidenceStore` | `internal/evidence` | One `Generator.Generate` (HMAC-signed SQLite insert) per iteration. Isolates evidence path without gateway HTTP. |
+
+> **Note:** `BenchmarkGatewayPipelineOverheadLargePrompt` is **informational**. It tracks
+> large-prompt scaling on the Anthropic path (its numbers are expected to sit well above
+> the 15 ms small-payload budget because the PII scan cost scales with input size) and
+> does **not** join the benchmark regression gate yet.
 
 ### What is excluded
 

--- a/internal/gateway/bench_test.go
+++ b/internal/gateway/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dativo-io/talon/internal/classifier"
@@ -97,6 +98,108 @@ func BenchmarkGatewayPipelineOverhead(b *testing.B) {
 			b.Fatal(err)
 		}
 		req.Header.Set("Authorization", "Bearer talon-gw-bench")
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			b.Fatalf("status %d: %s", w.Code, w.Body.String())
+		}
+	}
+}
+
+// BenchmarkGatewayPipelineOverheadLargePrompt measures the same end-to-end
+// gateway wall time as BenchmarkGatewayPipelineOverhead, but through the
+// Anthropic wire format (/v1/messages) with a deterministic ~50KB system
+// prompt. The prompt repeats a fixed sentence containing a corpus email
+// (jane.doe@example.com) so the PII scanner does real work at large-prompt
+// scale: route, caller auth, request extract, PII scan, policy evaluation,
+// forward, response PII scan, evidence write, and metrics.
+//
+// Informational only: this benchmark does not participate in the benchmark
+// regression gate yet. See docs/reference/benchmarks.md.
+func BenchmarkGatewayPipelineOverheadLargePrompt(b *testing.B) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_bench","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":100,"output_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	dir := b.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"anthropic": {Enabled: true, BaseURL: upstream.URL},
+		},
+		Callers: []CallerConfig{
+			{
+				Name: "bench-caller-large", TenantKey: "talon-gw-bench-large", TenantID: "default",
+				PolicyOverrides: &CallerPolicyOverrides{
+					AllowedModels: []string{"claude-sonnet-4-20250514"},
+					MaxDailyCost:  1000,
+				},
+			},
+		},
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn"},
+		RateLimits: RateLimitsConfig{
+			GlobalRequestsPerMin:    1_000_000,
+			PerCallerRequestsPerMin: 1_000_000,
+		},
+		Timeouts: TimeoutsConfig{
+			ConnectTimeout:    "5s",
+			RequestTimeout:    "30s",
+			StreamIdleTimeout: "60s",
+		},
+	}
+
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer evStore.Close()
+
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer secStore.Close()
+
+	cls := classifier.MustNewScanner()
+	policyEngine, err := policy.NewGatewayEngine(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	gw, err := NewGateway(cfg, cls, evStore, secStore, policyEngine, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	router := chi.NewRouter()
+	router.Route("/v1/proxy", func(r chi.Router) {
+		r.Handle("/*", gw)
+	})
+
+	// Deterministic ~50KB system prompt: a fixed 89-byte sentence repeated
+	// 575 times (~51,175 bytes). No randomness, no clock — byte-identical on
+	// every run. The sentence is plain ASCII with no JSON metacharacters, so
+	// it is safe to splice into the JSON body directly.
+	const sentence = "Please contact jane.doe@example.com about GDPR data processing requests and escalations. "
+	system := strings.Repeat(sentence, 575)
+	body := []byte(`{"model":"claude-sonnet-4-20250514","max_tokens":128,"system":"` + system +
+		`","messages":[{"role":"user","content":"Summarize the escalation contacts."}]}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://test/v1/proxy/anthropic/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			b.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer talon-gw-bench-large")
 		req.Header.Set("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()

--- a/internal/gateway/conformance_anthropic_test.go
+++ b/internal/gateway/conformance_anthropic_test.go
@@ -1,0 +1,324 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/classifier"
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// Anthropic protocol conformance suite (#193, epic #192 PR-A).
+//
+// Each fixture under testdata/conformance/anthropic/ replays a recorded
+// Claude-Code-shaped request through the FULL gateway pipeline (extraction,
+// PII scan/redaction, tool governance, forward, evidence) against a canned
+// upstream, asserting the transform did not corrupt the wire format and that
+// signed evidence records truthful usage and cost. Fixtures are sanitized:
+// synthetic keys, example.com corpus emails only. Recapture procedure:
+// scripts/record-conformance-fixtures.sh; see testdata/conformance/README.md.
+
+const (
+	confTenantKeyWarn   = "talon-gw-conf-warn-0001"
+	confTenantKeyRedact = "talon-gw-conf-redact-0001"
+)
+
+type conformanceFixture struct {
+	Name            string          `json:"name"`
+	Path            string          `json:"path"`
+	CallerPIIAction string          `json:"caller_pii_action"`
+	RequestBody     json.RawMessage `json:"request_body"`
+	Upstream        struct {
+		Status    int             `json:"status"`
+		JSON      json.RawMessage `json:"json,omitempty"`
+		SSEEvents []string        `json:"sse_events,omitempty"`
+	} `json:"upstream"`
+	Expect struct {
+		Status                 int      `json:"status"`
+		ForwardedContains      []string `json:"forwarded_contains,omitempty"`
+		ForwardedNotContains   []string `json:"forwarded_not_contains,omitempty"`
+		ForwardedJSONValid     bool     `json:"forwarded_json_valid,omitempty"`
+		ResponseEqualsUpstream bool     `json:"response_equals_upstream,omitempty"`
+		Evidence               *struct {
+			InputTokens    *int    `json:"input_tokens,omitempty"`
+			OutputTokens   *int    `json:"output_tokens,omitempty"`
+			CostZero       *bool   `json:"cost_zero,omitempty"`
+			InvocationType *string `json:"invocation_type,omitempty"`
+		} `json:"evidence,omitempty"`
+	} `json:"expect"`
+}
+
+// conformanceUpstream captures the forwarded request and replays a canned
+// JSON or SSE response from the active fixture.
+type conformanceUpstream struct {
+	server   *httptest.Server
+	lastBody atomic.Value // string
+	fixture  atomic.Value // *conformanceFixture
+	rawSSE   atomic.Value // string: exact bytes served for SSE fixtures
+}
+
+func newConformanceUpstream(t *testing.T) *conformanceUpstream {
+	t.Helper()
+	u := &conformanceUpstream{}
+	u.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		u.lastBody.Store(string(raw))
+		fx, _ := u.fixture.Load().(*conformanceFixture)
+		if fx == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		status := fx.Upstream.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if len(fx.Upstream.SSEEvents) > 0 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(status)
+			var sb strings.Builder
+			for _, ev := range fx.Upstream.SSEEvents {
+				sb.WriteString(ev)
+				sb.WriteString("\n\n")
+			}
+			u.rawSSE.Store(sb.String())
+			_, _ = w.Write([]byte(sb.String()))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(fx.Upstream.JSON)
+	}))
+	t.Cleanup(u.server.Close)
+	return u
+}
+
+func newConformanceGateway(t *testing.T, upstreamURL string) (*Gateway, *evidence.Store, http.Handler) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := &GatewayConfig{
+		Enabled:      true,
+		ListenPrefix: "/v1/proxy",
+		Mode:         ModeEnforce,
+		Providers: map[string]ProviderConfig{
+			"anthropic": {Enabled: true, BaseURL: upstreamURL, SecretName: "anthropic-key"},
+		},
+		Callers: []CallerConfig{
+			{
+				Name: "conf-warn", TenantKey: confTenantKeyWarn, TenantID: "conf-tenant",
+				PolicyOverrides: &CallerPolicyOverrides{PIIAction: "warn", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+			},
+			{
+				Name: "conf-redact", TenantKey: confTenantKeyRedact, TenantID: "conf-tenant",
+				PolicyOverrides: &CallerPolicyOverrides{PIIAction: "redact", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+			},
+		},
+		// Response-side scanning is out of scope for request-path conformance:
+		// "allow" keeps streams passing through byte-identically.
+		ServerDefaults: ServerDefaults{DefaultPIIAction: "warn", ResponsePIIAction: "allow", MaxDailyCost: 100, MaxMonthlyCost: 2000},
+		// The whole corpus runs through one gateway; default per-caller RPM
+		// would 429 everything after the first fixture.
+		RateLimits: RateLimitsConfig{GlobalRequestsPerMin: 10000, PerCallerRequestsPerMin: 10000},
+		Timeouts:   TimeoutsConfig{ConnectTimeout: "5s", RequestTimeout: "30s", StreamIdleTimeout: "60s"},
+	}
+	require.NoError(t, cfg.Validate())
+	evStore, err := evidence.NewStore(filepath.Join(dir, "e.db"), testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = evStore.Close() })
+	secStore, err := secrets.NewSecretStore(filepath.Join(dir, "s.db"), testutil.TestEncryptionKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = secStore.Close() })
+	require.NoError(t, secStore.Set(context.Background(), "anthropic-key", []byte("sk-ant-test-000-conformance"),
+		secrets.ACL{Tenants: []string{"conf-tenant"}, Agents: []string{"*"}}))
+	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, nil, nil)
+	require.NoError(t, err)
+	r := chi.NewRouter()
+	r.Route("/v1/proxy", func(r chi.Router) { r.Handle("/*", gw) })
+	return gw, evStore, r
+}
+
+func loadConformanceFixtures(t *testing.T, dir string) []*conformanceFixture {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "fixture dir must exist")
+	var out []*conformanceFixture
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, e.Name())) // #nosec G304 -- test fixtures
+		require.NoError(t, err)
+		var fx conformanceFixture
+		require.NoError(t, json.Unmarshal(raw, &fx), "fixture %s must parse", e.Name())
+		require.NotEmpty(t, fx.Name, "fixture %s needs a name", e.Name())
+		out = append(out, &fx)
+	}
+	require.NotEmpty(t, out, "no fixtures found in %s", dir)
+	return out
+}
+
+func runConformanceFixture(t *testing.T, fx *conformanceFixture, upstream *conformanceUpstream, router http.Handler, evStore *evidence.Store) {
+	t.Helper()
+	upstream.fixture.Store(fx)
+
+	key := confTenantKeyWarn
+	if fx.CallerPIIAction == "redact" {
+		key = confTenantKeyRedact
+	}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"http://test/v1/proxy/anthropic"+fx.Path, bytes.NewReader(fx.RequestBody))
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	wantStatus := fx.Expect.Status
+	if wantStatus == 0 {
+		wantStatus = http.StatusOK
+	}
+	require.Equal(t, wantStatus, w.Code, "fixture %s: body: %s", fx.Name, w.Body.String())
+
+	forwarded, _ := upstream.lastBody.Load().(string)
+	require.NotEmpty(t, forwarded, "fixture %s: nothing reached the upstream", fx.Name)
+	for _, s := range fx.Expect.ForwardedContains {
+		assert.Contains(t, forwarded, s, "fixture %s: forwarded body must contain %q", fx.Name, s)
+	}
+	for _, s := range fx.Expect.ForwardedNotContains {
+		assert.NotContains(t, forwarded, s, "fixture %s: forwarded body must not contain %q", fx.Name, s)
+	}
+	if fx.Expect.ForwardedJSONValid {
+		var js map[string]interface{}
+		assert.NoError(t, json.Unmarshal([]byte(forwarded), &js),
+			"fixture %s: forwarded body must remain valid JSON", fx.Name)
+	}
+	if fx.Expect.ResponseEqualsUpstream {
+		if len(fx.Upstream.SSEEvents) > 0 {
+			raw, _ := upstream.rawSSE.Load().(string)
+			assert.Equal(t, raw, w.Body.String(),
+				"fixture %s: SSE stream must reach the client byte-identical", fx.Name)
+		} else {
+			assert.JSONEq(t, string(fx.Upstream.JSON), w.Body.String(),
+				"fixture %s: response must pass through", fx.Name)
+		}
+	}
+
+	if fx.Expect.Evidence != nil {
+		// The gateway does not echo the correlation id directly; the synthesized
+		// session id is "sess_"+correlationID (same derivation as failover tests).
+		sid := w.Header().Get("X-Talon-Session-ID")
+		require.True(t, strings.HasPrefix(sid, "sess_"), "fixture %s: session header %q", fx.Name, sid)
+		correlationID := strings.TrimPrefix(sid, "sess_")
+		records, err := evStore.ListByCorrelationID(context.Background(), correlationID)
+		require.NoError(t, err)
+		require.NotEmpty(t, records, "fixture %s: evidence must be written", fx.Name)
+		rec := records[len(records)-1]
+		exp := fx.Expect.Evidence
+		if exp.InputTokens != nil {
+			assert.Equal(t, *exp.InputTokens, rec.Execution.Tokens.Input,
+				"fixture %s: evidence input tokens", fx.Name)
+		}
+		if exp.OutputTokens != nil {
+			assert.Equal(t, *exp.OutputTokens, rec.Execution.Tokens.Output,
+				"fixture %s: evidence output tokens", fx.Name)
+		}
+		if exp.CostZero != nil {
+			if *exp.CostZero {
+				assert.Zero(t, rec.Execution.Cost, "fixture %s: cost must be zero", fx.Name)
+				assert.Zero(t, rec.Execution.EstimatedCost, "fixture %s: estimated cost must be zero", fx.Name)
+			} else {
+				assert.Greater(t, rec.Execution.Cost, 0.0, "fixture %s: cost must be non-zero", fx.Name)
+			}
+		}
+		if exp.InvocationType != nil {
+			assert.Equal(t, *exp.InvocationType, rec.InvocationType,
+				"fixture %s: invocation type", fx.Name)
+		}
+	}
+}
+
+func TestConformanceAnthropic_Fixtures(t *testing.T) {
+	fixtures := loadConformanceFixtures(t, filepath.Join("testdata", "conformance", "anthropic"))
+	upstream := newConformanceUpstream(t)
+	_, evStore, router := newConformanceGateway(t, upstream.server.URL)
+	for _, fx := range fixtures {
+		fx := fx
+		t.Run(fx.Name, func(t *testing.T) {
+			runConformanceFixture(t, fx, upstream, router, evStore)
+		})
+	}
+}
+
+// A ~50KB system prompt (Claude Code's norm) must survive the full pipeline
+// under redact without corruption or failure. Generated, not stored: the
+// content is deterministic (strings.Repeat), so a checked-in 50KB fixture
+// would add nothing but repo weight.
+func TestConformanceAnthropic_LargeSystemPrompt(t *testing.T) {
+	upstream := newConformanceUpstream(t)
+	_, evStore, router := newConformanceGateway(t, upstream.server.URL)
+
+	sentence := "You are a careful coding assistant; when unsure, ask. Escalations go to jane.doe@example.com for review. "
+	system := strings.Repeat(sentence, 500) // ~52KB
+	require.Greater(t, len(system), 50*1024)
+	body := map[string]interface{}{
+		"model":      "claude-sonnet-5",
+		"max_tokens": 100,
+		"system":     system,
+		"messages":   []map[string]interface{}{{"role": "user", "content": "hello"}},
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	fx := &conformanceFixture{Name: "large_system_prompt", Path: "/v1/messages", CallerPIIAction: "redact"}
+	fx.RequestBody = raw
+	fx.Upstream.Status = 200
+	fx.Upstream.JSON = json.RawMessage(`{"id":"msg_conf_large","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":13000,"output_tokens":2}}`)
+	fx.Expect.Status = 200
+	fx.Expect.ForwardedNotContains = []string{"jane.doe@example.com"}
+	fx.Expect.ForwardedJSONValid = true
+	runConformanceFixture(t, fx, upstream, router, evStore)
+}
+
+// Identical PII-bearing input must produce byte-identical transformed output
+// across repeated requests: non-deterministic rewrites silently break
+// provider-side prompt caching for clients — a 10x+ cost regression Talon
+// must never cause.
+func TestConformanceAnthropic_TransformDeterminism(t *testing.T) {
+	upstream := newConformanceUpstream(t)
+	_, _, router := newConformanceGateway(t, upstream.server.URL)
+
+	raw, err := os.ReadFile(filepath.Join("testdata", "conformance", "anthropic", "system_block_array_cache_control.json"))
+	require.NoError(t, err)
+	var fx conformanceFixture
+	require.NoError(t, json.Unmarshal(raw, &fx))
+	upstream.fixture.Store(&fx)
+
+	send := func() string {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://test/v1/proxy/anthropic"+fx.Path, bytes.NewReader(fx.RequestBody))
+		req.Header.Set("Authorization", "Bearer "+confTenantKeyRedact)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		body, _ := upstream.lastBody.Load().(string)
+		return body
+	}
+	first := send()
+	second := send()
+	assert.Equal(t, first, second, "transformed bodies must be byte-identical across repeats")
+}

--- a/internal/gateway/extract.go
+++ b/internal/gateway/extract.go
@@ -344,8 +344,17 @@ func redactAnthropicBody(ctx context.Context, body []byte, scanner classifier.Fa
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, err
 	}
+	// system is a string or an array of content blocks. Claude Code sends the
+	// block-array form (with cache_control) on every request; redacting only
+	// the string form would leave detected PII in place and fail closed.
 	if s, ok := req["system"].(string); ok && s != "" {
 		redacted, err := scanner.RedactText(ctx, s)
+		if err != nil {
+			return nil, err
+		}
+		req["system"] = redacted
+	} else if arr, ok := req["system"].([]interface{}); ok {
+		redacted, err := redactAnthropicContent(ctx, arr, scanner)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gateway/extract_test.go
+++ b/internal/gateway/extract_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -251,4 +252,67 @@ func TestGateway_PIIBlockModePreventsForwarding(t *testing.T) {
 		"upstream must NOT be called when PII is blocked")
 	assert.Contains(t, w.Body.String(), "PII",
 		"error response should mention PII")
+}
+
+// TestRedactAnthropicBody_SystemBlockArray verifies that PII inside a
+// block-array system prompt (the form Claude Code sends on every request) is
+// redacted while cache_control markers on the blocks survive untouched.
+func TestRedactAnthropicBody_SystemBlockArray(t *testing.T) {
+	scanner := classifier.MustNewScanner()
+	ctx := context.Background()
+
+	t.Run("block_array_system", func(t *testing.T) {
+		body := []byte(`{"model":"claude-3-5-sonnet","system":[{"type":"text","text":"contact jane.doe@example.com now","cache_control":{"type":"ephemeral"}},{"type":"text","text":"clean block"}],"messages":[{"role":"user","content":"Hi"}]}`)
+		redacted, err := RedactRequestBody(ctx, "anthropic", body, scanner)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(redacted, &m), "redacted body must be valid JSON")
+		require.NotContains(t, string(redacted), "jane.doe@example.com",
+			"email in block-array system must be redacted")
+		require.Contains(t, string(redacted), "[EMAIL]",
+			"redaction placeholder must be present")
+
+		sys, ok := m["system"].([]interface{})
+		require.True(t, ok, "system must remain a block array")
+		require.Len(t, sys, 2)
+
+		first, ok := sys[0].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, map[string]interface{}{"type": "ephemeral"}, first["cache_control"],
+			"cache_control must survive redaction exactly")
+
+		second, ok := sys[1].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "clean block", second["text"],
+			"PII-free block text must be unchanged")
+	})
+
+	t.Run("string_system_still_redacts", func(t *testing.T) {
+		body := []byte(`{"model":"claude-3-5-sonnet","system":"escalate to jane.doe@example.com","messages":[{"role":"user","content":"Hi"}]}`)
+		redacted, err := RedactRequestBody(ctx, "anthropic", body, scanner)
+		require.NoError(t, err)
+		require.NotContains(t, string(redacted), "jane.doe@example.com",
+			"string-form system must still be redacted")
+		require.Contains(t, string(redacted), "[EMAIL]")
+	})
+}
+
+// TestRedactAnthropicBody_Deterministic verifies that redacting the same
+// PII-bearing body twice produces byte-identical output (evidence hashes and
+// dedup depend on this).
+func TestRedactAnthropicBody_Deterministic(t *testing.T) {
+	scanner := classifier.MustNewScanner()
+	ctx := context.Background()
+
+	body := []byte(`{"model":"claude-3-5-sonnet","system":[{"type":"text","text":"contact jane.doe@example.com now","cache_control":{"type":"ephemeral"}},{"type":"text","text":"clean block"}],"messages":[{"role":"user","content":[{"type":"text","text":"My email is test@example.com and my colleague is bob@example.com"}]}]}`)
+
+	first, err := RedactRequestBody(ctx, "anthropic", body, scanner)
+	require.NoError(t, err)
+
+	second, err := RedactRequestBody(ctx, "anthropic", body, scanner)
+	require.NoError(t, err)
+
+	require.Equal(t, string(first), string(second),
+		"redacting the same body twice must produce byte-identical output")
 }

--- a/internal/gateway/forward.go
+++ b/internal/gateway/forward.go
@@ -98,11 +98,14 @@ func Forward(w http.ResponseWriter, p ForwardParams) error {
 }
 
 func copyResponseHeaders(w http.ResponseWriter, from http.Header, upstreamHeaders map[string]string) {
-	// Forward rate-limit and other provider headers
+	// Forward rate-limit and other provider headers. Retry-After and the
+	// Anthropic request-id/token-remaining/reset headers matter for client
+	// backoff during 429s; dropping them breaks coding-agent retry behavior.
 	for _, h := range []string{
-		"Content-Type", "X-Request-Id",
+		"Content-Type", "X-Request-Id", "Request-Id", "Anthropic-Request-Id", "Retry-After",
 		"x-ratelimit-limit-requests", "x-ratelimit-remaining-requests", "x-ratelimit-reset-requests",
-		"anthropic-ratelimit-requests-limit", "anthropic-ratelimit-requests-remaining", "anthropic-ratelimit-tokens-limit",
+		"anthropic-ratelimit-requests-limit", "anthropic-ratelimit-requests-remaining", "anthropic-ratelimit-requests-reset",
+		"anthropic-ratelimit-tokens-limit", "anthropic-ratelimit-tokens-remaining", "anthropic-ratelimit-tokens-reset",
 	} {
 		if v := from.Get(h); v != "" {
 			w.Header().Set(h, v)
@@ -224,18 +227,13 @@ func extractUsageFromJSONPayload(payload []byte, usage *TokenUsage) {
 	if err := json.Unmarshal(payload, &m); err != nil {
 		return
 	}
-	// OpenAI usage at top level
-	if u, ok := m["usage"].(map[string]interface{}); ok {
-		if n, _ := u["prompt_tokens"].(float64); n > 0 {
-			usage.Input = int(n)
-		}
-		if n, _ := u["completion_tokens"].(float64); n > 0 {
-			usage.Output = int(n)
-		}
-		return
-	}
-	// Anthropic message_start has message.usage.input_tokens
-	if typ, _ := m["type"].(string); typ == "message_start" {
+	// Anthropic events are typed and must be handled before the generic
+	// top-level "usage" branch: a real message_delta event carries usage as a
+	// top-level sibling of "delta", so the OpenAI branch would match it, find
+	// no prompt/completion tokens, and return — losing output tokens entirely.
+	switch typ, _ := m["type"].(string); typ {
+	case "message_start":
+		// message_start has message.usage.input_tokens
 		if msg, ok := m["message"].(map[string]interface{}); ok {
 			if u, ok := msg["usage"].(map[string]interface{}); ok {
 				if n, _ := u["input_tokens"].(float64); n > 0 {
@@ -244,13 +242,22 @@ func extractUsageFromJSONPayload(payload []byte, usage *TokenUsage) {
 			}
 		}
 		return
-	}
-	// Anthropic message_delta has usage.output_tokens
-	if typ, _ := m["type"].(string); typ == "message_delta" {
+	case "message_delta":
+		// message_delta has top-level usage.output_tokens (cumulative)
 		if u, ok := m["usage"].(map[string]interface{}); ok {
 			if n, _ := u["output_tokens"].(float64); n > 0 {
 				usage.Output = int(n)
 			}
+		}
+		return
+	}
+	// OpenAI usage at top level
+	if u, ok := m["usage"].(map[string]interface{}); ok {
+		if n, _ := u["prompt_tokens"].(float64); n > 0 {
+			usage.Input = int(n)
+		}
+		if n, _ := u["completion_tokens"].(float64); n > 0 {
+			usage.Output = int(n)
 		}
 	}
 }
@@ -275,6 +282,13 @@ func parseUsageFromJSON(body []byte, _ string, usage *TokenUsage) {
 				usage.Output = int(n)
 			}
 		}
+		return
+	}
+	// Anthropic /v1/messages/count_tokens responds {"input_tokens": N} with no
+	// usage wrapper; record the count so evidence carries a meaningful token
+	// figure (the request itself is free — cost is zeroed by the caller).
+	if n, _ := m["input_tokens"].(float64); n > 0 {
+		usage.Input = int(n)
 	}
 }
 

--- a/internal/gateway/forward_test.go
+++ b/internal/gateway/forward_test.go
@@ -443,3 +443,117 @@ func TestGateway_Upstream429_RateLimitError(t *testing.T) {
 	assert.Equal(t, "0", w.Header().Get("x-ratelimit-remaining-requests"),
 		"rate-limit headers from upstream must be forwarded")
 }
+
+// TestExtractUsageFromJSONPayload_AnthropicMessageDelta is the regression test
+// for #211: Anthropic message_delta events carry usage as a top-level sibling
+// of "delta", so the generic OpenAI usage branch used to match first, find no
+// prompt/completion tokens, and drop output tokens entirely. Typed Anthropic
+// events must be handled before the generic branch.
+func TestExtractUsageFromJSONPayload_AnthropicMessageDelta(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    string
+		wantInput  int
+		wantOutput int
+	}{
+		{
+			name:       "anthropic_message_delta_sets_output",
+			payload:    `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":23}}`,
+			wantInput:  0,
+			wantOutput: 23,
+		},
+		{
+			name:       "anthropic_message_start_sets_input_ignores_cache_fields",
+			payload:    `{"type":"message_start","message":{"usage":{"input_tokens":25,"cache_creation_input_tokens":100,"cache_read_input_tokens":2000}}}`,
+			wantInput:  25,
+			wantOutput: 0,
+		},
+		{
+			name:       "openai_final_chunk_sets_both",
+			payload:    `{"usage":{"prompt_tokens":10,"completion_tokens":5}}`,
+			wantInput:  10,
+			wantOutput: 5,
+		},
+		{
+			name:       "openai_delta_chunk_without_usage_sets_nothing",
+			payload:    `{"choices":[{"delta":{"content":"Hi"}}]}`,
+			wantInput:  0,
+			wantOutput: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var usage TokenUsage
+			extractUsageFromJSONPayload([]byte(tt.payload), &usage)
+			require.Equal(t, tt.wantInput, usage.Input, "input tokens")
+			require.Equal(t, tt.wantOutput, usage.Output, "output tokens")
+		})
+	}
+}
+
+// TestParseUsageFromJSON_CountTokensShape verifies that the Anthropic
+// count_tokens response shape {"input_tokens": N} (no usage wrapper) is
+// recorded, and that the normal OpenAI/Anthropic wrapped shapes still parse.
+func TestParseUsageFromJSON_CountTokensShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantInput  int
+		wantOutput int
+	}{
+		{
+			name:       "anthropic_count_tokens_no_usage_wrapper",
+			body:       `{"input_tokens":2095}`,
+			wantInput:  2095,
+			wantOutput: 0,
+		},
+		{
+			name:       "anthropic_wrapped_usage",
+			body:       `{"usage":{"input_tokens":10,"output_tokens":4}}`,
+			wantInput:  10,
+			wantOutput: 4,
+		},
+		{
+			name:       "openai_wrapped_usage",
+			body:       `{"usage":{"prompt_tokens":7,"completion_tokens":3}}`,
+			wantInput:  7,
+			wantOutput: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var usage TokenUsage
+			parseUsageFromJSON([]byte(tt.body), "", &usage)
+			require.Equal(t, tt.wantInput, usage.Input, "input tokens")
+			require.Equal(t, tt.wantOutput, usage.Output, "output tokens")
+		})
+	}
+}
+
+// TestCopyResponseHeaders_BackoffHeaders verifies that Retry-After and the
+// Anthropic request-id/rate-limit headers clients need for 429 backoff are
+// forwarded, and that headers outside the allowlist are dropped.
+func TestCopyResponseHeaders_BackoffHeaders(t *testing.T) {
+	from := http.Header{}
+	from.Set("Retry-After", "13")
+	from.Set("request-id", "req_test_0001")
+	from.Set("anthropic-request-id", "req_ant_test_0001")
+	from.Set("anthropic-ratelimit-tokens-remaining", "12000")
+	from.Set("anthropic-ratelimit-tokens-reset", "2026-07-04T00:00:30Z")
+	from.Set("anthropic-ratelimit-requests-reset", "2026-07-04T00:00:10Z")
+	from.Set("x-internal-debug", "should-not-leak")
+
+	w := httptest.NewRecorder()
+	copyResponseHeaders(w, from, nil)
+
+	require.Equal(t, "13", w.Header().Get("Retry-After"))
+	require.Equal(t, "req_test_0001", w.Header().Get("Request-Id"))
+	require.Equal(t, "req_ant_test_0001", w.Header().Get("Anthropic-Request-Id"))
+	require.Equal(t, "12000", w.Header().Get("anthropic-ratelimit-tokens-remaining"))
+	require.Equal(t, "2026-07-04T00:00:30Z", w.Header().Get("anthropic-ratelimit-tokens-reset"))
+	require.Equal(t, "2026-07-04T00:00:10Z", w.Header().Get("anthropic-ratelimit-requests-reset"))
+	require.Empty(t, w.Header().Get("x-internal-debug"),
+		"non-allowlisted headers must not be forwarded")
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -247,6 +247,11 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Anthropic parsing, not the OpenAI default.
 	wire := g.config.providerAPIFamily(route.Provider)
 
+	// count_tokens is governed like any request (the body egresses) but is
+	// free at the provider and returns a count, not a completion: cost and
+	// budget input must be zero or signed evidence records fabricated spend.
+	isCountTokens := wire == "anthropic" && strings.HasSuffix(route.Path, "/count_tokens")
+
 	// Step 2: Identify
 	var caller *CallerConfig
 	qc := QuickstartCallerFromContext(ctx)
@@ -449,6 +454,9 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Estimated cost for policy (use default token estimate if we don't have real tokens yet)
 	estTokensIn, estTokensOut := 500, 500
 	estimatedCost := g.costEstimate(extracted.Model, estTokensIn, estTokensOut)
+	if isCountTokens {
+		estimatedCost = 0 // free endpoint: a nonzero estimate would leak into budget input and deny evidence (#218)
+	}
 	dailyCost, monthlyCost := g.callerCostTotals(ctx, caller)
 	if d := g.config.ServerDefaults.MaxDailyCost; d > 0 {
 		pct := (dailyCost / d) * 100
@@ -1024,6 +1032,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if tokenUsage.Input == 0 && tokenUsage.Output == 0 {
 		cost = estimatedCost
 	}
+	if isCountTokens {
+		// tokenUsage.Input holds the count *result*, not consumed tokens; the
+		// endpoint is free. Cost stays zero so CostByAgent budget sums (which
+		// have no invocation-type filter) remain truthful (#218).
+		cost = 0
+	}
 
 	// Streaming metrics: TTFT and TPOT for GenAI SemConv
 	var ttftMS int64
@@ -1059,12 +1073,19 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			p.Status = "failed"
 			p.FailureReason = evidence.FailureReasonNoValidFallbackCandidate
 		}
+		if isCountTokens {
+			p.InvocationType = "gateway_count_tokens"
+		}
 	})
 	if recordErr != nil {
 		g.handleEvidenceWriteFailure(ctx, recordErr)
 		return
 	}
-	g.trackSessionUsage(ctx, sessionID, caller.TenantID, caller.Name, cost, tokenUsage.Input+tokenUsage.Output)
+	if !isCountTokens {
+		// count_tokens neither spends nor consumes: keep session cost/token
+		// accumulation and stage counts free of count-only traffic.
+		g.trackSessionUsage(ctx, sessionID, caller.TenantID, caller.Name, cost, tokenUsage.Input+tokenUsage.Output)
+	}
 
 	// Emit OTel + dashboard metrics
 	g.emitMetrics(ctx, caller, selectedProvider, selectedModel, classification, toolResult, shadowViolations,

--- a/internal/gateway/testdata/conformance/README.md
+++ b/internal/gateway/testdata/conformance/README.md
@@ -1,0 +1,59 @@
+# Gateway protocol conformance fixtures
+
+Recorded request/response shapes replayed through the **full** gateway pipeline
+(extraction → PII scan/redaction → tool governance → forward → evidence) by
+`conformance_anthropic_test.go`. No live provider calls in CI.
+
+## Fixture schema
+
+```json
+{
+  "name": "unique_snake_case_name",
+  "path": "/v1/messages",                    // appended to /v1/proxy/anthropic
+  "caller_pii_action": "warn" | "redact",    // selects the test caller
+  "request_body": { ... },                   // raw provider-wire request
+  "upstream": {
+    "status": 200,
+    "json": { ... }                          // OR "sse_events": ["event: ...\ndata: {...}", ...]
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["..."],           // substrings of the body that reached the upstream
+    "forwarded_not_contains": ["..."],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,        // byte-identical passthrough (SSE) / JSONEq (non-stream)
+    "evidence": {                            // all optional
+      "input_tokens": 0, "output_tokens": 0,
+      "cost_zero": false,
+      "invocation_type": "..."
+    }
+  }
+}
+```
+
+Assertions not expressible in the schema live as dedicated Go tests in
+`conformance_anthropic_test.go` (transform determinism, ~50KB system prompt —
+the large prompt is generated with `strings.Repeat`, not stored).
+
+## Sanitization rules (enforced in review)
+
+- **No real credentials.** Keys look like `sk-ant-test-000-*`.
+- **No real PII.** Emails come from the test corpus (`*@example.com`) only.
+- Upstream response IDs are synthetic (`msg_conf_*`).
+
+## Provenance and recapture
+
+Last verified against: **Claude Code v2.1.x (2026-07)** — fixtures hand-authored
+from the Anthropic Messages API reference and the Claude Code LLM gateway
+protocol docs (code.claude.com/docs/en/llm-gateway-protocol.md), then verified
+once against a live endpoint by the author.
+
+To recapture against current client/provider versions:
+
+```
+RECORD=1 ANTHROPIC_API_KEY=... scripts/record-conformance-fixtures.sh
+```
+
+then sanitize per the rules above and update the version line here. Client
+protocol drift (renamed headers, new usage fields) is expected — recapture on
+every Claude Code major and on any Anthropic API version bump.

--- a/internal/gateway/testdata/conformance/anthropic/count_tokens.json
+++ b/internal/gateway/testdata/conformance/anthropic/count_tokens.json
@@ -1,0 +1,22 @@
+{
+  "name": "count_tokens",
+  "path": "/v1/messages/count_tokens",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "messages": [
+      {"role": "user", "content": "Count the tokens of this coding prompt before sending it."}
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {"input_tokens": 2095}
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["claude-sonnet-5"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,
+    "evidence": {"input_tokens": 2095, "output_tokens": 0, "cost_zero": true, "invocation_type": "gateway_count_tokens"}
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/image_block.json
+++ b/internal/gateway/testdata/conformance/anthropic/image_block.json
@@ -1,0 +1,43 @@
+{
+  "name": "image_block",
+  "path": "/v1/messages",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "What is in this screenshot?"},
+          {
+            "type": "image",
+            "source": {
+              "type": "base64",
+              "media_type": "image/png",
+              "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {
+      "id": "msg_conf_image",
+      "type": "message",
+      "role": "assistant",
+      "model": "claude-sonnet-5",
+      "content": [{"type": "text", "text": "A single dark pixel."}],
+      "stop_reason": "end_turn",
+      "usage": {"input_tokens": 90, "output_tokens": 6}
+    }
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==", "image/png"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/non_streaming_basic.json
+++ b/internal/gateway/testdata/conformance/anthropic/non_streaming_basic.json
@@ -1,0 +1,31 @@
+{
+  "name": "non_streaming_basic",
+  "path": "/v1/messages",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "Summarize the build failure in ci.log"}
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {
+      "id": "msg_conf_basic",
+      "type": "message",
+      "role": "assistant",
+      "model": "claude-sonnet-5",
+      "content": [{"type": "text", "text": "The build failed because of a missing dependency."}],
+      "stop_reason": "end_turn",
+      "usage": {"input_tokens": 12, "output_tokens": 8}
+    }
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["claude-sonnet-5", "ci.log"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,
+    "evidence": {"input_tokens": 12, "output_tokens": 8, "cost_zero": false}
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/streaming_sse.json
+++ b/internal/gateway/testdata/conformance/anthropic/streaming_sse.json
@@ -1,0 +1,32 @@
+{
+  "name": "streaming_sse",
+  "path": "/v1/messages",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "Explain the diff in two sentences"}
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "sse_events": [
+      "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_conf_stream\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-5\",\"content\":[],\"usage\":{\"input_tokens\":25,\"cache_creation_input_tokens\":100,\"cache_read_input_tokens\":2000,\"output_tokens\":1}}}",
+      "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}",
+      "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"The diff renames \"}}",
+      "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"the config loader.\"}}",
+      "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}",
+      "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":23}}",
+      "event: message_stop\ndata: {\"type\":\"message_stop\"}"
+    ]
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["\"stream\": true"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,
+    "evidence": {"input_tokens": 25, "output_tokens": 23, "cost_zero": false}
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/system_block_array_cache_control.json
+++ b/internal/gateway/testdata/conformance/anthropic/system_block_array_cache_control.json
@@ -1,0 +1,41 @@
+{
+  "name": "system_block_array_cache_control",
+  "path": "/v1/messages",
+  "caller_pii_action": "redact",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "system": [
+      {
+        "type": "text",
+        "text": "You are a coding assistant. Escalate anything sensitive to jane.doe@example.com immediately.",
+        "cache_control": {"type": "ephemeral"}
+      },
+      {
+        "type": "text",
+        "text": "Prefer small, reviewable diffs."
+      }
+    ],
+    "messages": [
+      {"role": "user", "content": "Refactor the session store"}
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {
+      "id": "msg_conf_sysarray",
+      "type": "message",
+      "role": "assistant",
+      "model": "claude-sonnet-5",
+      "content": [{"type": "text", "text": "Done."}],
+      "stop_reason": "end_turn",
+      "usage": {"input_tokens": 40, "output_tokens": 2}
+    }
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_not_contains": ["jane.doe@example.com"],
+    "forwarded_contains": ["cache_control", "ephemeral", "Prefer small, reviewable diffs."],
+    "forwarded_json_valid": true
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/tool_choice_auto.json
+++ b/internal/gateway/testdata/conformance/anthropic/tool_choice_auto.json
@@ -1,0 +1,39 @@
+{
+  "name": "tool_choice_auto",
+  "path": "/v1/messages",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "tools": [
+      {
+        "name": "run_tests",
+        "description": "Run the test suite",
+        "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}}}
+      }
+    ],
+    "tool_choice": {"type": "auto"},
+    "messages": [
+      {"role": "user", "content": "Run the gateway tests"}
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {
+      "id": "msg_conf_toolchoice",
+      "type": "message",
+      "role": "assistant",
+      "model": "claude-sonnet-5",
+      "content": [{"type": "tool_use", "id": "toolu_conf_02", "name": "run_tests", "input": {"pattern": "./internal/gateway/"}}],
+      "stop_reason": "tool_use",
+      "usage": {"input_tokens": 30, "output_tokens": 15}
+    }
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["tool_choice", "run_tests"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,
+    "evidence": {"input_tokens": 30, "output_tokens": 15}
+  }
+}

--- a/internal/gateway/testdata/conformance/anthropic/tool_use_round_trip.json
+++ b/internal/gateway/testdata/conformance/anthropic/tool_use_round_trip.json
@@ -1,0 +1,50 @@
+{
+  "name": "tool_use_round_trip",
+  "path": "/v1/messages",
+  "caller_pii_action": "warn",
+  "request_body": {
+    "model": "claude-sonnet-5",
+    "max_tokens": 1024,
+    "tools": [
+      {
+        "name": "read_file",
+        "description": "Read a file from the workspace",
+        "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}
+      }
+    ],
+    "messages": [
+      {"role": "user", "content": "What does config.go do?"},
+      {
+        "role": "assistant",
+        "content": [
+          {"type": "tool_use", "id": "toolu_conf_01", "name": "read_file", "input": {"path": "internal/config/config.go"}}
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {"type": "tool_result", "tool_use_id": "toolu_conf_01", "content": "package config // loads talon.yaml"}
+        ]
+      }
+    ]
+  },
+  "upstream": {
+    "status": 200,
+    "json": {
+      "id": "msg_conf_tools",
+      "type": "message",
+      "role": "assistant",
+      "model": "claude-sonnet-5",
+      "content": [{"type": "text", "text": "It loads talon.yaml."}],
+      "stop_reason": "end_turn",
+      "usage": {"input_tokens": 55, "output_tokens": 7}
+    }
+  },
+  "expect": {
+    "status": 200,
+    "forwarded_contains": ["tool_use", "tool_result", "toolu_conf_01", "read_file", "input_schema"],
+    "forwarded_json_valid": true,
+    "response_equals_upstream": true,
+    "evidence": {"input_tokens": 55, "output_tokens": 7}
+  }
+}

--- a/internal/pricing/default_models.yaml
+++ b/internal/pricing/default_models.yaml
@@ -25,9 +25,65 @@ providers:
       o3-mini:
         input_per_1m: 1.10
         output_per_1m: 4.40
+      # Current lineup, verified against developers.openai.com/api/docs/pricing,
+      # 2026-07. Cached-input rates land with the cache-aware pricing schema
+      # (epic #192 PR-E / #196).
+      gpt-5.5:
+        input_per_1m: 5.00
+        output_per_1m: 30.00
+      gpt-5.5-pro:
+        input_per_1m: 30.00
+        output_per_1m: 180.00
+      gpt-5.4:
+        input_per_1m: 2.50
+        output_per_1m: 15.00
+      gpt-5.4-mini:
+        input_per_1m: 0.75
+        output_per_1m: 4.50
+      gpt-5.4-nano:
+        input_per_1m: 0.20
+        output_per_1m: 1.25
+      gpt-5.4-pro:
+        input_per_1m: 30.00
+        output_per_1m: 180.00
+      gpt-5.3-codex:
+        input_per_1m: 1.75
+        output_per_1m: 14.00
 
   anthropic:
+    # Verified against platform.claude.com pricing, 2026-07. Cache read/write
+    # rates land with the cache-aware pricing schema (epic #192 PR-E / #196).
     models:
+      claude-fable-5:
+        input_per_1m: 10.00
+        output_per_1m: 50.00
+      claude-opus-4-8:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-7:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-6:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-5:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      # Standard rate; introductory $2/$10 applies through 2026-08-31 —
+      # operators on intro pricing can lower this locally.
+      claude-sonnet-5:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-sonnet-4-6:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-sonnet-4-5:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-haiku-4-5:
+        input_per_1m: 1.00
+        output_per_1m: 5.00
+      # Deprecated / legacy models still callable:
       claude-sonnet-4-20250514:
         input_per_1m: 3.00
         output_per_1m: 15.00

--- a/pricing/models.yaml
+++ b/pricing/models.yaml
@@ -29,9 +29,65 @@ providers:
       o3-mini:
         input_per_1m: 1.10
         output_per_1m: 4.40
+      # Current lineup, verified against developers.openai.com/api/docs/pricing,
+      # 2026-07. Cached-input rates land with the cache-aware pricing schema
+      # (epic #192 PR-E / #196).
+      gpt-5.5:
+        input_per_1m: 5.00
+        output_per_1m: 30.00
+      gpt-5.5-pro:
+        input_per_1m: 30.00
+        output_per_1m: 180.00
+      gpt-5.4:
+        input_per_1m: 2.50
+        output_per_1m: 15.00
+      gpt-5.4-mini:
+        input_per_1m: 0.75
+        output_per_1m: 4.50
+      gpt-5.4-nano:
+        input_per_1m: 0.20
+        output_per_1m: 1.25
+      gpt-5.4-pro:
+        input_per_1m: 30.00
+        output_per_1m: 180.00
+      gpt-5.3-codex:
+        input_per_1m: 1.75
+        output_per_1m: 14.00
 
   anthropic:
+    # Verified against platform.claude.com pricing, 2026-07. Cache read/write
+    # rates land with the cache-aware pricing schema (epic #192 PR-E / #196).
     models:
+      claude-fable-5:
+        input_per_1m: 10.00
+        output_per_1m: 50.00
+      claude-opus-4-8:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-7:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-6:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      claude-opus-4-5:
+        input_per_1m: 5.00
+        output_per_1m: 25.00
+      # Standard rate; introductory $2/$10 applies through 2026-08-31 —
+      # operators on intro pricing can lower this locally.
+      claude-sonnet-5:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-sonnet-4-6:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-sonnet-4-5:
+        input_per_1m: 3.00
+        output_per_1m: 15.00
+      claude-haiku-4-5:
+        input_per_1m: 1.00
+        output_per_1m: 5.00
+      # Deprecated / legacy models still callable:
       claude-sonnet-4-20250514:
         input_per_1m: 3.00
         output_per_1m: 15.00

--- a/scripts/record-conformance-fixtures.sh
+++ b/scripts/record-conformance-fixtures.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Recapture gateway conformance fixtures against the live Anthropic API.
+#
+# Produces raw request/response pairs for the shapes covered in
+# internal/gateway/testdata/conformance/anthropic/. Output goes to a scratch
+# directory and MUST be sanitized by hand before updating fixtures:
+#   - replace any real key material (fixtures use sk-ant-test-000-*)
+#   - replace any real emails/PII with *@example.com corpus values
+#   - replace response ids with msg_conf_* synthetics
+# See internal/gateway/testdata/conformance/README.md for the fixture schema.
+#
+# Requires: RECORD=1 (explicit opt-in), ANTHROPIC_API_KEY, curl, jq.
+set -euo pipefail
+
+if [[ "${RECORD:-}" != "1" ]]; then
+  echo "refusing to run without RECORD=1 (this script calls the live Anthropic API and spends tokens)" >&2
+  exit 1
+fi
+: "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY to record}"
+
+OUT="${OUT:-$(mktemp -d)/conformance-capture}"
+mkdir -p "$OUT"
+API="https://api.anthropic.com"
+MODEL="${MODEL:-claude-sonnet-5}"
+HDRS=(-H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" -H "content-type: application/json")
+
+capture() { # name path body
+  local name="$1" path="$2" body="$3"
+  echo "== $name"
+  printf '%s' "$body" >"$OUT/$name.request.json"
+  curl -sS "${HDRS[@]}" -d "$body" "$API$path" | jq . >"$OUT/$name.response.json"
+}
+
+capture non_streaming_basic /v1/messages \
+  '{"model":"'"$MODEL"'","max_tokens":64,"messages":[{"role":"user","content":"Say hi in one word"}]}'
+
+capture count_tokens /v1/messages/count_tokens \
+  '{"model":"'"$MODEL"'","messages":[{"role":"user","content":"Count the tokens of this prompt"}]}'
+
+capture system_block_array /v1/messages \
+  '{"model":"'"$MODEL"'","max_tokens":64,"system":[{"type":"text","text":"You are terse.","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":"Say hi"}]}'
+
+echo "== streaming_sse (raw SSE)"
+curl -sS "${HDRS[@]}" -d '{"model":"'"$MODEL"'","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Say hi in one word"}]}' \
+  "$API/v1/messages" >"$OUT/streaming_sse.response.sse"
+
+echo
+echo "captures in $OUT — sanitize before touching testdata/ (see README)."
+echo "then update the 'Last verified against' line in testdata/conformance/README.md."

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -4,6 +4,7 @@
 #
 # Measures:
 #   - Gateway pipeline overhead (ServeHTTP + local mock upstream, no WAN RTT)
+#   - Gateway pipeline overhead with a ~50KB Anthropic prompt (informational)
 #   - PII scan latency (classifier)
 #   - Evidence write throughput (signed SQLite record per op)
 #
@@ -21,7 +22,7 @@ OUTPUT=""
 BENCH_TIME="${BENCH_TIME:-2s}"
 BENCH_COUNT="${BENCH_COUNT:-5}"
 BENCH_PKGS="./internal/gateway/... ./internal/classifier/... ./internal/evidence/..."
-BENCH_REGEX='Benchmark(GatewayPipelineOverhead|PIIScan|EvidenceStore)$'
+BENCH_REGEX='Benchmark(GatewayPipelineOverhead|GatewayPipelineOverheadLargePrompt|PIIScan|EvidenceStore)$'
 
 while getopts "o:" opt; do
   case "$opt" in
@@ -48,16 +49,18 @@ bench_out=$("${GO_ENV[@]}" go test \
 }
 
 # Parse last result line per benchmark name (go test -count repeats runs).
+# The name match is anchored ("Name" or "Name-GOMAXPROCS", nothing after) so
+# BenchmarkGatewayPipelineOverhead never swallows ...OverheadLargePrompt lines.
 parse_ns_per_op() {
   local name="$1"
   printf '%s\n' "$bench_out" \
-    | awk -v n="$name" '$1 ~ "^Benchmark" n && $1 !~ "/" { last=$3 } END { print last+0 }'
+    | awk -v n="$name" '$1 ~ ("^Benchmark" n "(-[0-9]+)?$") { last=$3 } END { print last+0 }'
 }
 
 parse_allocs() {
   local name="$1"
   printf '%s\n' "$bench_out" \
-    | awk -v n="$name" '$1 ~ "^Benchmark" n && $1 !~ "/" && $0 ~ /allocs\/op/ { last=$(NF-1)" "$NF } END { print last }'
+    | awk -v n="$name" '$1 ~ ("^Benchmark" n "(-[0-9]+)?$") && $0 ~ /allocs\/op/ { last=$(NF-1)" "$NF } END { print last }'
 }
 
 ns_to_ms() {
@@ -69,15 +72,18 @@ ns_to_ops_per_sec() {
 }
 
 gw_ns=$(parse_ns_per_op GatewayPipelineOverhead)
+gwlp_ns=$(parse_ns_per_op GatewayPipelineOverheadLargePrompt)
 pii_ns=$(parse_ns_per_op PIIScan)
 ev_ns=$(parse_ns_per_op EvidenceStore)
 
 gw_ms=$(ns_to_ms "$gw_ns")
+gwlp_ms=$(ns_to_ms "$gwlp_ns")
 pii_ms=$(ns_to_ms "$pii_ns")
 ev_ms=$(ns_to_ms "$ev_ns")
 ev_ops=$(ns_to_ops_per_sec "$ev_ns")
 
 gw_allocs=$(parse_allocs GatewayPipelineOverhead)
+gwlp_allocs=$(parse_allocs GatewayPipelineOverheadLargePrompt)
 pii_allocs=$(parse_allocs PIIScan)
 ev_allocs=$(parse_allocs EvidenceStore)
 
@@ -93,6 +99,7 @@ table=$(cat <<EOF
 | Metric | Benchmark | Median (last of ${BENCH_COUNT} runs) | Allocs/op |
 |--------|-----------|--------------------------------------|-----------|
 | Gateway pipeline overhead | \`BenchmarkGatewayPipelineOverhead\` | **${gw_ms} ms**/req | ${gw_allocs:-n/a} |
+| Gateway overhead — ~50KB Anthropic prompt (informational) | \`BenchmarkGatewayPipelineOverheadLargePrompt\` | **${gwlp_ms} ms**/req | ${gwlp_allocs:-n/a} |
 | PII scan latency | \`BenchmarkPIIScan\` | **${pii_ms} ms**/scan | ${pii_allocs:-n/a} |
 | Evidence write throughput | \`BenchmarkEvidenceStore\` | **${ev_ops} writes/s** (~${ev_ms} ms/write) | ${ev_allocs:-n/a} |
 
@@ -105,6 +112,8 @@ Gateway overhead uses a local \`httptest\` upstream (no WAN RTT). Compare to the
 [What Talon does to your request](../explanation/what-talon-does-to-your-request.md).
 
 Retry/fallback decision overhead is **not** included until Epic #113 (#138/#139) lands.
+The ~50KB Anthropic large-prompt benchmark is informational only and does not join the
+benchmark regression gate yet.
 EOF
 )
 


### PR DESCRIPTION
**PR-A of epic #192's execution graph** (#192 §4). Closes #193, closes #211, closes #218. First PR of the epic: conformance fixtures plus the live bugs they flush out — tests and fixes only, no features.

## What

### Fixed (all live defects affecting current gateway users)

1. **Anthropic streaming output tokens were never captured** (#211). Real `message_delta` SSE events carry `usage` as a top-level sibling of `delta`; the generic OpenAI branch of `extractUsageFromJSONPayload` matched it first, found no `prompt_tokens`/`completion_tokens`, and returned — the `message_delta` branch was unreachable. Every streamed Anthropic response recorded `output=0`, and because `input>0` the estimate fallback never engaged: signed cost silently undercounted, TPOT was never computed. Typed Anthropic events are now parsed before the generic branch.
2. **`count_tokens` recorded fabricated spend** (#218). The free endpoint's `{"input_tokens":N}` response parsed as 0/0 usage, so evidence fell back to the fixed 500+500-token pre-request estimate — invented cost in signed evidence that also counted against caller budgets (`CostByAgent` has no invocation-type filter). Now classified by path suffix: `invocation_type: "gateway_count_tokens"`, cost 0, budget estimate 0, session usage not accumulated. The request stays **fully governed** (PII scan + policy run; the token count is recorded in evidence).
3. **Block-array `system` prompts could not be redacted.** The form Claude Code sends on every request (with `cache_control`) was extracted for detection, but only string-form `system` was rewritten — PII + `pii_action: redact` deterministically failed closed with HTTP 400. Block arrays now route through `redactAnthropicContent`; `cache_control` and untouched blocks survive byte-identically.
4. **Backoff headers were dropped.** `Retry-After`, `request-id`/`anthropic-request-id`, and `anthropic-ratelimit-tokens-remaining`/`*-reset` are now forwarded (the allowlist previously missed all of them; Anthropic's `request-id` doesn't canonicalize to `X-Request-Id`).

### Added

- **Anthropic protocol conformance suite** (`internal/gateway/conformance_anthropic_test.go` + `testdata/conformance/anthropic/`): sanitized recorded fixtures replayed through the full pipeline (extract → PII → tools → redact → forward → evidence) against a canned upstream — non-streaming, native SSE with cache-token usage, block-array system + `cache_control` under `redact`, tool_use/tool_result round-trip transform safety, `count_tokens`, image blocks, `tool_choice`, ~50KB system prompt under `redact`.
- **Transform-determinism guarantee**: identical input ⇒ byte-identical rewritten bodies across repeats (non-determinism would silently break provider-side prompt caching for clients — a 10x+ cost regression Talon must never cause).
- **Recapture procedure**: `scripts/record-conformance-fixtures.sh` (RECORD=1-gated, sanitization rules documented) + pinned last-verified client version in `testdata/conformance/README.md`.
- **Large-prompt benchmark**: `BenchmarkGatewayPipelineOverheadLargePrompt` (~50KB PII-bearing system prompt, ~42ms/op full pipeline on M1 Max), informational row in `docs/reference/benchmarks.md`.

## Explicit non-goals (per #193 execution contract)

Tool-content **scanning** (#212 → PR-B) · cache-token pricing / Responses streaming usage (#196 → PR-E) · orchestration headers (#194 → PR-D) · Codex fixtures (#200 → PR-C) · streaming-architecture changes.

## Behavior notes for reviewers

- No config changes; no evidence schema changes (`invocation_type` is an existing free-form column). Old evidence verifies unchanged.
- The only user-visible behavior changes are the four fixes above — each makes recorded evidence *more* truthful or unbreaks a documented client shape; none loosens governance (`count_tokens` remains policy-checked and PII-scanned).
- Fixtures contain zero real credentials/PII (synthetic `sk-ant-test-*` keys, `example.com` corpus emails).

## Test plan

- `go test ./internal/gateway/ -run TestConformanceAnthropic -v` — 7 fixtures + large-prompt + determinism, all green.
- New unit regressions: `TestExtractUsageFromJSONPayload_AnthropicMessageDelta` (dead-branch), `TestParseUsageFromJSON_CountTokensShape`, `TestCopyResponseHeaders_BackoffHeaders`, `TestRedactAnthropicBody_SystemBlockArray` (+ determinism).
- Full `./internal/gateway` and `./internal/evidence` packages green.
- `go test ./internal/gateway/ -bench BenchmarkGatewayPipelineOverheadLargePrompt -benchtime=2x -run '^$'`.

Part of #192. Next in graph: PR-B (#212), PR-C (#200/#213) — both parallel to this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the hot gateway path (PII redaction, SSE usage parsing, cost/budget accounting, header forwarding); behavior is tightened for truthfulness and client compatibility, with broad new regression coverage rather than new governance surface.
> 
> **Overview**
> Fixes four **live Anthropic gateway bugs** and adds a **Claude-Code-shaped conformance harness** so they stay fixed.
> 
> **Evidence & forwarding:** Streaming SSE now records **output tokens** from `message_delta` by parsing typed Anthropic events before the generic `usage` branch (#211). **`/v1/messages/count_tokens`** is treated as free: zero cost and budget estimate, `invocation_type: gateway_count_tokens`, token count in evidence, no session spend accumulation (#218). **`count_tokens`** and bare `{"input_tokens": N}` responses parse correctly in `parseUsageFromJSON`.
> 
> **Request transforms:** **`system` block arrays** (with `cache_control`) redact like string `system`, so `pii_action: redact` no longer fails closed on Claude Code-shaped bodies.
> 
> **Client behavior:** **`Retry-After`**, Anthropic **`request-id`** headers, and token/request **rate-limit reset** headers are forwarded on upstream responses.
> 
> **Added:** JSON fixtures replayed through the full pipeline (`conformance_anthropic_test.go`), plus determinism and ~50KB system-prompt tests; informational **`BenchmarkGatewayPipelineOverheadLargePrompt`**; `scripts/record-conformance-fixtures.sh` and benchmark script parsing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1406cea0907726d184a678cf1dad2b4dcd7250a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->