### PR TITLE
fix(demo): no host port for the mock; DEMO_GATEWAY_PORT override

### DIFF
--- a/examples/coding-agents-demo/README.md
+++ b/examples/coding-agents-demo/README.md
@@ -13,6 +13,15 @@ cd examples/coding-agents-demo
 docker compose up -d --build && ./demo.sh all
 ```
 
+Port busy? The gateway publishes host port 8080 by default (the mock is
+network-internal and publishes nothing). If another stack or a local
+`talon serve` holds 8080:
+
+```bash
+DEMO_GATEWAY_PORT=18080 docker compose up -d --build
+GATEWAY=http://localhost:18080 ./demo.sh all
+```
+
 The same sequence is smoke-run in CI without Docker:
 `go test -tags=integration ./tests/integration -run TestCodingAgentsDemo_EndToEnd`.
 

--- a/examples/coding-agents-demo/docker-compose.yml
+++ b/examples/coding-agents-demo/docker-compose.yml
@@ -10,8 +10,10 @@ services:
   mock-provider:
     build:
       context: ../docker-compose/mock-provider
-    ports:
-      - "9090:9090"
+    # No host port: Talon reaches the mock over the compose network, and a
+    # published 9090 collides with the other example stacks when two demos
+    # run on one box. Add `ports: ["9090:9090"]` locally if you want to poke
+    # the mock directly.
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/health || exit 1"]
       interval: 5s
@@ -22,7 +24,10 @@ services:
     build:
       context: ../../
     ports:
-      - "8080:8080"
+      # Override when 8080 is busy on the host (a local `talon serve`, the
+      # other example stacks): DEMO_GATEWAY_PORT=18080 docker compose up -d
+      # then GATEWAY=http://localhost:18080 ./demo.sh all
+      - "${DEMO_GATEWAY_PORT:-8080}:8080"
     environment:
       - TALON_SECRETS_KEY=abcdefghijklmnopqrstuvwxyz012345
       - TALON_SIGNING_KEY=demo-signing-key-not-for-production


### PR DESCRIPTION
First end-user run of `make coding-agents-demo` (#238) hit `Bind for 0.0.0.0:9090 failed: port is already allocated` — the shortlist/docker-compose example stacks publish the same mock port, so any two demos collide on one box.

- The demo's mock-provider no longer publishes a host port (Talon reaches it via the compose network; nothing in `demo.sh` touches 9090). A comment explains how to re-add it for direct poking.
- The gateway's host port is now `${DEMO_GATEWAY_PORT:-8080}`, pairing with `demo.sh`'s existing `GATEWAY` env override; README documents the port-busy escape hatch.

No behavior change when ports are free. Compose YAML validated; the CI smoke (`TestCodingAgentsDemo_EndToEnd`) doesn't use compose and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only Compose and documentation; no application or gateway logic changes.
> 
> **Overview**
> Fixes **Docker port collisions** when running the coding-agents demo alongside other example stacks or a local gateway on the same machine.
> 
> **`mock-provider`** no longer maps **9090** to the host—Talon still talks to it on the compose network, and comments note how to re-publish the port for debugging. **`talon`** gateway binding is now **`${DEMO_GATEWAY_PORT:-8080}:8080`**, aligned with **`demo.sh`**’s existing **`GATEWAY`** override. The **README** documents using **`DEMO_GATEWAY_PORT`** and **`GATEWAY`** when **8080** is taken.
> 
> Default behavior is unchanged when ports are free.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedcc9b767ff57770f0501d970e0275196a2d50b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->