### PR TITLE
fix(demo): wait for gateway readiness before the first request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ verify-shortlist-demo: ## Run full #107 shortlist demo verification (Docker)
 	@bash scripts/verify-shortlist-demo.sh
 
 coding-agents-demo: ## Run #203 coding-agents demo (multi-model orchestration, offline mock, Docker)
-	@cd examples/coding-agents-demo && docker compose up -d --build && ./demo.sh all
+	@cd examples/coding-agents-demo && docker compose up -d --build --wait && ./demo.sh all
 
 # Provider registry and EU routing
 provider-list: build ## List registered LLM providers (compliance metadata)

--- a/examples/coding-agents-demo/demo.sh
+++ b/examples/coding-agents-demo/demo.sh
@@ -8,6 +8,9 @@
 # Commands: session | pii | budget | audit | verify | all
 set -euo pipefail
 
+# Never die silently: any failing step names itself and points at the stack.
+trap 'echo "ERROR: demo aborted at line $LINENO (see above). Stack state: docker compose ps · logs: docker compose logs talon" >&2' ERR
+
 GATEWAY="${GATEWAY:-http://localhost:8080}"
 TENANT_KEY="talon-gw-demo-coding-0001"
 SESSION="sess-coding-demo"
@@ -16,6 +19,18 @@ mkdir -p "$OUT_DIR"
 
 say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
 note() { printf '   %s\n' "$*"; }
+
+# The talon container seeds vault secrets before binding the port, so the
+# gateway is briefly unreachable after `docker compose up -d` returns
+# (started != ready). Gate every run on /health instead of racing it.
+wait_ready() {
+  for _ in $(seq 1 60); do
+    if curl -sf -o /dev/null "$GATEWAY/health"; then return 0; fi
+    sleep 1
+  done
+  echo "ERROR: gateway at $GATEWAY not ready after 60s — check: docker compose logs talon" >&2
+  return 1
+}
 
 talon_exec() { docker compose exec -T talon talon "$@"; }
 
@@ -97,6 +112,8 @@ cmd_all() {
   note "with structured {limit, spent, estimate} in signed evidence · zero real API keys."
   note "Dashboard: $GATEWAY/gateway/dashboard?talon_admin_key=demo-admin-key (Coding Sessions panel)"
 }
+
+wait_ready
 
 case "${1:-all}" in
   session) cmd_session ;;


### PR DESCRIPTION
Second end-user run of `make coding-agents-demo` (#238/#239) aborted with curl exit 56 on the demo's first request: `docker compose up -d` returns at container *start*, but the talon entrypoint seeds two vault secrets before `serve` binds — `demo.sh` raced the boot and `set -e` aborted.

- `demo.sh` now gates on a `/health` poll (60×1s; on timeout points at `docker compose logs talon`) — covers standalone use too.
- `make coding-agents-demo` adds `--wait` so compose blocks on the healthchecks.

No change to the demo sequence or the CI smoke (which already polls health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only Makefile and shell changes; no gateway, auth, or production runtime behavior.
> 
> **Overview**
> Fixes a **startup race** where `make coding-agents-demo` / `demo.sh` could hit the gateway before Talon finished vault seeding and bound its port (curl exit 56 under `set -e`).
> 
> **`demo.sh`** adds `wait_ready()` — up to 60s polling **`$GATEWAY/health`** before any subcommand — with a timeout message pointing at `docker compose logs talon`. Covers standalone `docker compose up -d && ./demo.sh` as well as the Make target.
> 
> **`make coding-agents-demo`** passes **`docker compose up --wait`** so Compose blocks until service healthchecks pass (Talon already exposes `/health` in `docker-compose.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee2ea66a10dca7cd80f0056a2e0f20a99578d45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->