### PR TITLE
fix(demo): drop root-owned ./out bind mount; fix parent-header word-split

### DIFF
--- a/examples/coding-agents-demo/demo.sh
+++ b/examples/coding-agents-demo/demo.sh
@@ -16,6 +16,13 @@ TENANT_KEY="talon-gw-demo-coding-0001"
 SESSION="sess-coding-demo"
 OUT_DIR="./out"
 mkdir -p "$OUT_DIR"
+# Fail loudly, not silently, if ./out isn't host-writable (e.g. a stale
+# root-owned dir from an older compose that bind-mounted it).
+if ! : >"$OUT_DIR/.wtest" 2>/dev/null; then
+  echo "ERROR: $OUT_DIR is not writable by $(id -un). Remove it (it may be root-owned from an older demo: sudo rm -rf $OUT_DIR) and re-run." >&2
+  exit 1
+fi
+rm -f "$OUT_DIR/.wtest"
 
 say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
 note() { printf '   %s\n' "$*"; }
@@ -34,21 +41,29 @@ wait_ready() {
 
 talon_exec() { docker compose exec -T talon talon "$@"; }
 
+# parent_header builds the optional -H array element(s) for a parent agent,
+# as a proper argv array so a value never word-splits into a broken header.
+parent_header() { # $1=parent (may be empty)
+  if [ -n "$1" ]; then printf '%s\n' "-H" "X-Talon-Parent-Agent-ID: $1"; fi
+}
+
 anthropic_call() { # $1=agent $2=parent $3=prompt -> prints http code
+  local parent=(); while IFS= read -r line; do parent+=("$line"); done < <(parent_header "$2")
   curl -s -o "$OUT_DIR/last-anthropic.json" -w '%{http_code}' \
     "$GATEWAY/v1/proxy/anthropic/v1/messages" \
     -H "Authorization: Bearer $TENANT_KEY" -H "content-type: application/json" \
     -H "X-Talon-Session-ID: $SESSION" -H "X-Talon-Agent-ID: $1" \
-    ${2:+-H "X-Talon-Parent-Agent-ID: $2"} -H "X-Talon-Client: claude-code" \
+    ${parent[@]+"${parent[@]}"} -H "X-Talon-Client: claude-code" \
     -d "{\"model\":\"claude-sonnet-5\",\"max_tokens\":128,\"messages\":[{\"role\":\"user\",\"content\":\"$3\"}]}"
 }
 
 responses_call() { # $1=agent $2=parent $3=prompt
+  local parent=(); while IFS= read -r line; do parent+=("$line"); done < <(parent_header "$2")
   curl -s -o "$OUT_DIR/last-responses.json" -w '%{http_code}' \
     "$GATEWAY/v1/proxy/openai/v1/responses" \
     -H "Authorization: Bearer $TENANT_KEY" -H "content-type: application/json" \
     -H "X-Talon-Session-ID: $SESSION" -H "X-Talon-Agent-ID: $1" \
-    ${2:+-H "X-Talon-Parent-Agent-ID: $2"} -H "X-Talon-Client: codex" \
+    ${parent[@]+"${parent[@]}"} -H "X-Talon-Client: codex" \
     -d "{\"model\":\"gpt-5.3-codex\",\"input\":\"$3\",\"store\":false}"
 }
 

--- a/examples/coding-agents-demo/docker-compose.yml
+++ b/examples/coding-agents-demo/docker-compose.yml
@@ -37,7 +37,11 @@ services:
     volumes:
       - ./talon.config.yaml:/etc/talon/talon.config.yaml:ro
       - ./talon.config.yaml:/home/talon/.talon/talon.config.yaml:ro
-      - ./out:/home/talon/demo-out
+      # NOTE: do not bind-mount ./out here. demo.sh writes ./out entirely
+      # host-side (curl -o, and `talon_exec … > ./out/…` redirects on the
+      # host), and a bind mount makes Docker create ./out as root — then the
+      # host-side curl can't write it and fails with exit 23 after the request
+      # already succeeded, killing the demo under `set -e`.
       - talon-data:/home/talon/.talon
     depends_on:
       mock-provider:


### PR DESCRIPTION
Third end-user acceptance run of `make coding-agents-demo` (#238) surfaced the real defect — `bash -x` pinpointed it. The demo's first request **succeeds** (Talon returns a governed 200 with `cache_read_input_tokens: 2048`, evidence recorded), but the script dies silently right after: `curl` prints the http_code via `-w` yet **exits 23** because it can't write `-o ./out/last-anthropic.json`. The compose file bind-mounts `./out` into the container, so Docker created `./out` as **root**, and host-side `curl` (a different uid) can't write it — `set -e` then kills the demo after the request already went through.

## Fixes
- **Remove the `./out:/home/talon/demo-out` volume.** `demo.sh` writes `./out` entirely host-side (`curl -o`, and `talon_exec … > ./out/…` redirects on the host), so the mount was pointless and actively harmful.
- **Writability guard.** `demo.sh` now fails loudly with a fix hint (`sudo rm -rf ./out`) if `./out` isn't host-writable — covering a stale root-owned dir left by the old compose.
- **Fix a latent word-split.** The optional parent-agent header used an unquoted `${2:+-H "…$2"}` that splits a non-empty value into three broken argv words; it would have corrupted every `executor ← generator` call once the first-call bug was past. Now built as a proper argv array with `set -u`-safe expansion (`${arr[@]+"${arr[@]}"}`), verified against both empty and non-empty parents.

## Why CI didn't catch it
The CI smoke (`TestCodingAgentsDemo_EndToEnd`) reimplements the sequence in Go and **never executes `demo.sh`** — so shell-only bugs (word-split, the mount interaction) are invisible to it. Filing a follow-up to either run `demo.sh` against the compose stack in CI or shellcheck the example scripts.

Verified: `bash -n` clean; array-expansion logic unit-tested for empty/non-empty parent; writability guard exercised. No change to the governance path (which returned a perfect 200 throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example demo scripts and compose only; no changes to Talon gateway governance or production paths.
> 
> **Overview**
> Fixes **`make coding-agents-demo`** failing after successful gateway calls: host `curl -o ./out/...` was exiting **23** under `set -e` when `./out` was **root-owned** from a compose bind mount.
> 
> **Compose** drops the `./out:/home/talon/demo-out` volume (outputs are written on the host only) and documents why remounting it breaks the script.
> 
> **`demo.sh`** adds an early **writability check** on `./out` with a clear `sudo rm -rf ./out` hint for stale dirs, and builds the optional **`X-Talon-Parent-Agent-ID`** header via `parent_header` + safe array expansion instead of unquoted `${2:+-H "…"}` word-splitting (affects executor ← generator calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e32132b9211e3a2d35b96824afab2e76b7093d3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->