### PR TITLE
fix(server): answer HEAD on /health — compose healthchecks probed with wget --spider always failed

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,9 +247,14 @@ func (s *Server) Routes() http.Handler {
 	r.Use(otel.MiddlewareWithStatus())
 	r.Use(CORSMiddleware(s.corsOrigins))
 
-	// Unauthenticated
+	// Unauthenticated. HEAD is registered explicitly: chi's Get() answers 405
+	// to HEAD, and `wget --spider` (the healthcheck in every example compose
+	// stack) probes with HEAD — without this, containerized Talon reports
+	// permanently unhealthy while serving fine.
 	r.Get("/health", s.handleHealth)
+	r.Head("/health", s.handleHealth)
 	r.Get("/v1/health", s.handleHealth)
+	r.Head("/v1/health", s.handleHealth)
 
 	// Webhooks (no auth; signature validation can be added later)
 	r.Post("/v1/triggers/{name}", s.webhookHandler.HandleWebhook)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -47,6 +47,16 @@ func TestHealthEndpoint(t *testing.T) {
 	var out map[string]interface{}
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
 	assert.Equal(t, "ok", out["status"])
+
+	// HEAD must answer 200 too: `wget --spider` (the compose healthchecks)
+	// probes with HEAD, and chi's Get-only registration answered 405 —
+	// leaving every containerized Talon permanently "unhealthy" (#192 demo).
+	for _, path := range []string{"/health", "/v1/health"} {
+		headReq := httptest.NewRequestWithContext(context.Background(), http.MethodHead, path, nil)
+		headRec := httptest.NewRecorder()
+		r.ServeHTTP(headRec, headReq)
+		assert.Equal(t, http.StatusOK, headRec.Code, "HEAD %s must be 200 for wget --spider healthchecks", path)
+	}
 }
 
 func TestHealthDetail(t *testing.T) {


### PR DESCRIPTION
Fourth end-user acceptance finding from epic #192: `docker compose up --wait` on the coding-agents demo blocked forever with `container talon-1 is unhealthy` — while the same container served governed 200s the whole time (verified live with `curl -v` + `data_flow_recorded` logs).

**Root cause:** every talon healthcheck in the repo (`examples/docker-compose`, `examples/shortlist-demo`, `examples/coding-agents-demo`) is `wget -q --spider http://localhost:8080/health`, and `wget --spider` probes with **HEAD**. The health routes were registered via chi's `Get()` only → **405 to HEAD** → containerized Talon has reported unhealthy since the healthchecks were introduced. It went unnoticed because nothing gated on talon's health until #240 added `--wait`. (The mock provider passes the identical check because plain `http.ServeMux` is method-agnostic.)

**Fix:** register `Head()` alongside `Get()` for `/health` and `/v1/health` (`net/http` strips the response body for HEAD automatically). This repairs the healthchecks of all three example stacks server-side, with no compose changes. Test pins `HEAD /health` and `HEAD /v1/health` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing change on unauthenticated health endpoints plus regression tests; no auth, data, or business-logic impact.
> 
> **Overview**
> Registers **HEAD** on `/health` and `/v1/health` in addition to **GET**, using the same `handleHealth` handler. Chi only matched GET before, so **HEAD** returned **405** while example and image healthchecks use `wget -q --spider` (which probes with HEAD), which made containerized Talon look permanently unhealthy even when GET worked.
> 
> `TestHealthEndpoint` now asserts **HEAD** returns **200** on both paths so compose/Docker healthchecks keep working without changing compose files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230deaed8a4c6fea7345a38a49af75eaa688c103. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->