### PR TITLE
fix(audit): costs --session tenant scoping; session client label from earliest record

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -110,7 +110,11 @@ var costsCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("querying session %s: %w", costsSession, err)
 			}
-			records = scopeSessionRecords(records, tenantID, costsAgent)
+			// Scope by the tenant the user actually passed — NOT the "default"
+			// fallback used by the calendar rollups below. Defaulting here
+			// silently emptied the summary for any session owned by another
+			// tenant (bit the coding-agents demo, tenant "demo").
+			records = scopeSessionRecords(records, costsTenant, costsAgent)
 			sum := evidence.BuildSessionSummary(costsSession, records)
 			if costsJSON {
 				enc := json.NewEncoder(sessionOut)

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -243,3 +243,51 @@ func TestCostsExportCmd_JSONIncludesProviderAndDeniedRow(t *testing.T) {
 	assert.Equal(t, "deny", rows[0]["policy_action"])
 	assert.EqualValues(t, 0, rows[0]["cost"])
 }
+
+// `talon costs --session` without --tenant must be UNSCOPED, not silently
+// scoped to the "default" tenant: the calendar rollups' tenant defaulting
+// emptied session summaries for any other tenant (found live in the #203
+// demo, tenant "demo" → record_count 0 while audit list showed the session).
+func TestCostsCmd_SessionRollup_NonDefaultTenantWithoutFlag(t *testing.T) {
+	resetAuditCostFlags()
+	t.Cleanup(resetAuditCostFlags)
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SIGNING_KEY", "test-signing-key-1234567890123456")
+
+	store, err := evidence.NewStore(filepath.Join(dir, "evidence.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	gen := evidence.NewGenerator(store)
+	_, err = gen.Generate(context.Background(), evidence.GenerateParams{
+		CorrelationID: "c1", SessionID: "sess-demo-tenant", TenantID: "demo", AgentID: "claude-code",
+		InvocationType: "gateway", ModelUsed: "claude-sonnet-5", Cost: 0.05,
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		InputPrompt:    "a", OutputResponse: "b",
+	})
+	require.NoError(t, err)
+	store.Close()
+
+	// Set the writer on costsCmd itself: earlier tests SetOut the package-
+	// global costsCmd, and a subcommand's own writer shadows rootCmd's.
+	var buf bytes.Buffer
+	costsCmd.SetOut(&buf)
+	costsCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"costs", "--session", "sess-demo-tenant", "--json"})
+	require.NoError(t, rootCmd.Execute())
+
+	var sum evidence.SessionSummary
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &sum))
+	assert.Equal(t, 1, sum.RecordCount, "no --tenant flag → unscoped, tenant 'demo' session must be visible")
+	assert.Equal(t, "demo", sum.TenantID)
+	assert.InDelta(t, 0.05, sum.TotalCost, 1e-9)
+
+	// An explicit mismatching --tenant still scopes (and empties) correctly.
+	var buf2 bytes.Buffer
+	costsCmd.SetOut(&buf2)
+	costsCmd.SetErr(&buf2)
+	rootCmd.SetArgs([]string{"costs", "--session", "sess-demo-tenant", "--tenant", "other", "--json"})
+	require.NoError(t, rootCmd.Execute())
+	var sum2 evidence.SessionSummary
+	require.NoError(t, json.Unmarshal(buf2.Bytes(), &sum2))
+	assert.Equal(t, 0, sum2.RecordCount, "explicit foreign tenant → scoped out")
+}

--- a/internal/evidence/session_summary.go
+++ b/internal/evidence/session_summary.go
@@ -73,6 +73,9 @@ type sessionAgg struct {
 	providers map[string]struct{}
 	models    map[string]struct{}
 	agents    map[string]*SessionAgentRollup
+	// orchAt is the timestamp of the record whose orchestration block
+	// currently supplies SessionSource/Client (earliest wins).
+	orchAt time.Time
 }
 
 func newSessionAgg(sessionID string) *sessionAgg {
@@ -108,10 +111,13 @@ func (a *sessionAgg) addMetadata(ev *Evidence) {
 		a.providers[ev.RoutingDecision.SelectedProvider] = struct{}{}
 	}
 	if ev.Orchestration != nil {
-		if a.sum.SessionSource == "" {
+		// Session source/client come from the EARLIEST orchestrated record —
+		// the client that opened the session — independent of input order
+		// (ListBySessionID returns newest-first; taking the first iterated
+		// record labeled a mostly-claude-code session "codex").
+		if a.orchAt.IsZero() || ev.Timestamp.Before(a.orchAt) {
+			a.orchAt = ev.Timestamp
 			a.sum.SessionSource = ev.Orchestration.SessionSource
-		}
-		if a.sum.Client == "" {
 			a.sum.Client = ev.Orchestration.Client
 		}
 	}

--- a/internal/evidence/session_summary_test.go
+++ b/internal/evidence/session_summary_test.go
@@ -174,3 +174,27 @@ func TestListRecentOrchestrationSessionIDs(t *testing.T) {
 		t.Fatalf("limit=1 → %v, want [sess-new]", one)
 	}
 }
+
+// The session's client/source label comes from the EARLIEST orchestrated
+// record (the client that opened the session), regardless of input order —
+// ListBySessionID returns newest-first, which used to mislabel a
+// mostly-claude-code session as "codex" (found in the #203 demo).
+func TestBuildSessionSummary_ClientFromEarliestRecord(t *testing.T) {
+	older := rec("s", "acme", "coder", true, 0.01, 1, 1, 0, 0, "anthropic", "claude-sonnet-5",
+		&OrchestrationContext{AgentID: "generator", Client: "claude-code", SessionSource: "client_asserted"})
+	older.Timestamp = ts(1)
+	newer := rec("s", "acme", "coder", true, 0.01, 1, 1, 0, 0, "openai", "gpt-5.3-codex",
+		&OrchestrationContext{AgentID: "executor", Client: "codex", SessionSource: "vendor_asserted"})
+	newer.Timestamp = ts(30)
+
+	// Newest-first input (the ListBySessionID order).
+	sum := BuildSessionSummary("s", []*Evidence{newer, older})
+	if sum.Client != "claude-code" || sum.SessionSource != "client_asserted" {
+		t.Fatalf("client/source = %q/%q, want claude-code/client_asserted (earliest record)", sum.Client, sum.SessionSource)
+	}
+	// Order-independence: oldest-first gives the same answer.
+	sum2 := BuildSessionSummary("s", []*Evidence{older, newer})
+	if sum2.Client != sum.Client || sum2.SessionSource != sum.SessionSource {
+		t.Fatalf("client selection must be input-order independent")
+	}
+}


### PR DESCRIPTION
Two defects visible in the output of the first successful end-to-end run of the #203 demo (tenant `demo`):

1. **Act 4b returned an empty rollup.** `talon costs --session <id>` reused the calendar rollups' tenant defaulting (`"" → "default"`) for its record scoping, silently emptying the summary for any session owned by another tenant — while `talon audit list --session` (unscoped without `--tenant`) showed the same session in full. The session branch now scopes by the tenant the user actually passed (no flag = unscoped, matching audit semantics); an explicit `--tenant` still filters. Pinned by `TestCostsCmd_SessionRollup_NonDefaultTenantWithoutFlag`.
2. **`Source: codex (client_asserted)` on a session that was 8 parts claude-code.** `BuildSessionSummary` took client/source from the first record *iterated* — newest-first from `ListBySessionID`. It now takes them from the **earliest** orchestrated record (the client that opened the session), input-order independent — dashboard and CLI move together since they share the function. Pinned by `TestBuildSessionSummary_ClientFromEarliestRecord`.

Also fixed a test-infra trap discovered en route: earlier costs tests `SetOut` the package-global `costsCmd`, which shadows `rootCmd.SetOut` for all later tests in the package.

Full evidence/cmd/metrics/server/gateway packages + demo integration test green; lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CLI scoping and aggregation logic fixes with regression tests; no auth or persistence schema changes.
> 
> **Overview**
> Fixes two session rollup bugs surfaced in the #203 demo.
> 
> **`talon costs --session`** no longer applies the calendar rollups’ `"" → "default"` tenant default when filtering records. The session path now passes the raw `--tenant` value into `scopeSessionRecords`, so omitting the flag stays **unscoped** (aligned with audit list); an explicit `--tenant` still filters. This restores non-`default` sessions (e.g. tenant `demo`) that previously showed `record_count: 0`.
> 
> **`BuildSessionSummary`** now sets `Client` and `SessionSource` from the **earliest** orchestrated evidence row (session opener), not the first row in iteration order. That fixes mislabeling when `ListBySessionID` returns newest-first (e.g. a mostly claude-code session showing as codex). CLI and dashboard share this aggregator.
> 
> Adds regression tests for both behaviors and sets output on `costsCmd` in the session test so it isn’t shadowed by earlier package-global `SetOut` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7605868a95cf647994421edcfb969b9fb2528b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->