### PR TITLE
docs(coding-agents): define the roles; add the no-Docker testing path

### DIFF
--- a/docs/guides/claude-code-integration.md
+++ b/docs/guides/claude-code-integration.md
@@ -70,7 +70,7 @@ curl -s -X POST http://localhost:8080/v1/proxy/anthropic/v1/messages \
 
 You should get a JSON completion, not "Invalid or missing API key" (wrong tenant key) or "Service configuration error" (vault key mismatch).
 
-The Anthropic wire path — streaming SSE, cache-token accounting, `count_tokens` — is covered by conformance fixtures in `internal/gateway/conformance_anthropic_test.go` and `internal/gateway/testdata/conformance/anthropic/`.
+The Anthropic wire path — streaming SSE, cache-token accounting, `count_tokens` — is covered by conformance fixtures in `internal/gateway/conformance_anthropic_test.go` and `internal/gateway/testdata/conformance/anthropic/`. Note that `count_tokens` calls (Claude Code makes them constantly) are fully governed — PII-scanned, policy-checked, evidenced as `invocation_type: gateway_count_tokens` — but recorded at **cost 0** with zero budget impact: the endpoint is free at the provider, and a fabricated estimate would corrupt signed spend totals.
 
 ### 4. Point Claude Code at the gateway
 

--- a/docs/guides/governing-coding-agents.md
+++ b/docs/guides/governing-coding-agents.md
@@ -12,6 +12,18 @@ A platform team runs an orchestrator that plans a change, then fans out:
 - **Codex executors** call OpenAI's Responses API.
 - One logical coding session spans **both providers** and a tree of subagents.
 
+### Terminology: the roles are labels, not Talon concepts
+
+Every role name in this guide — *orchestrator*, *planner*, *generator*, *reviewer*, *executor*, *judge* — is an **illustration, not a vocabulary Talon knows**:
+
+- An **orchestrator** is simply whatever client code coordinates the work (a lead agent session, a script, a CI job) and passes one session id to everything it spawns. Talon never sees a role called "orchestrator" — it sees a caller, a session id, and per-request agent labels.
+- **`X-Talon-Agent-ID` / `X-Talon-Parent-Agent-ID` / `X-Talon-Client` values are free-form strings you choose.** Talon does not validate them against any known set, assigns them no semantics, and never uses them in policy — it records them as attribution (`provenance: client_asserted`) and rolls costs up by them. Name your subagents whatever your fleet calls them.
+- **The one enforced vocabulary is `X-Talon-Stage`**: exactly `generation` (producing candidate work), `judge` (evaluating or selecting between candidates), or `commit` (finalizing the chosen result). Any other value is silently dropped at ingestion — the request proceeds, no stage is recorded.
+- **Caller ≠ tenant ≠ agent.** A *caller* is a configured identity in `talon.config.yaml`, authenticated by its tenant key (e.g. one caller per tool); a *tenant* is the owning account callers belong to; an *agent id* is the client-asserted runtime label above. Budgets and policy bind to callers and tenants — never to agent ids.
+- A **wire family** (`api_family`) is the provider's HTTP API shape — `anthropic` (Messages API) or `openai` (Chat Completions / Responses) — which determines how Talon parses, redacts, and prices traffic on that route.
+
+In practice: with **Claude Code** and **Codex CLI**, the vendor adapters pick up whatever session/subagent headers the tools emit — nothing to invent. With a **custom orchestrator**, you choose the labels and set the generic headers yourself; if a tool version doesn't emit identity headers, set the generic ones from the process that launches it.
+
 The platform team wants three things:
 
 1. **Budgets** — a runaway session stops burning money, no matter which provider route it uses.
@@ -118,11 +130,11 @@ The first adapter with any populated header wins. Onboarding a new client is exa
 
 #### Precedence and provenance
 
-- **Precedence per field: generic > vendor > synthetic.** If both `X-Talon-Session-ID` and a vendor session header are present, the generic one wins (`TestResolveOrchestration_Precedence`).
+- **Precedence per field: generic > vendor > synthetic.** If both `X-Talon-Session-ID` and a vendor session header are present *with different values*, the generic value is recorded and the vendor value is ignored — per field, so a generic session id can coexist with a vendor-asserted agent id (`TestResolveOrchestration_Precedence`).
 - **`session_source`** records how the session id was obtained: `client_asserted` (generic header), `vendor_asserted` (adapter header), or `synthetic` (no client assertion; Talon derives `sess_<correlation-id>`).
 - **`provenance` is always `client_asserted`.** Orchestration identity distinguishes subagents *within an already-authenticated caller*; it does not authenticate them. It is exactly as trustworthy as the caller that presented the tenant key.
 - **Identity is never a policy input.** Budgets bind to the caller and the caller-scoped session tuple, never to `agent_id` (`TestPolicyInputParity_WithAssertedSession`). Acting on client-asserted identity waits for workload attestation (#149).
-- **Per-caller opt-out**: `accept_client_metadata: false` on a caller ignores asserted agent/parent/client identity and vendor session headers (the generic `X-Talon-Session-ID` still resolves the session id). Default is `true`; the flag gates *recording* only (`TestGatewayOrchestration_FlagOff`).
+- **Per-caller opt-out**: `accept_client_metadata: false` on a caller ignores asserted agent/parent/client identity and vendor session headers (the generic `X-Talon-Session-ID` still resolves the session id). Default is `true`; the flag gates *recording* only (`TestGatewayOrchestration_FlagOff`). Requests without any asserted session id get a synthetic `sess_<correlation-id>` in evidence either way — synthetic ids never create session-store state or budgets.
 - Optional `X-Talon-Stage` tags a request's pipeline stage; only `generation`, `judge`, `commit` are accepted — anything else is dropped at ingestion (`TestNormalizeStage`).
 
 #### Header hygiene
@@ -164,12 +176,15 @@ talon audit list --session sess-feature-4711
 # Verify HMAC integrity of every record in the session
 talon audit verify --session sess-feature-4711
 
-# Export only this session's records (for hand-off)
+# Export only this session's records (for hand-off). Cache-aware cost columns
+# (cache_read_tokens, cache_write_tokens, pricing_basis) are included.
 talon audit export --session sess-feature-4711
 
 # Per-session cost rollup, machine-readable
 talon costs --session sess-feature-4711 --json
 ```
+
+Scoping: without `--tenant`/`--caller` these session commands are **unscoped** (they show the whole session, whichever tenant owns it — local CLI access implies DB access anyway); pass `--tenant` and/or `--caller` to filter. Note `talon costs`' *calendar* rollups (no `--session`) default to tenant `default` — the session forms do not.
 
 The dashboard (`talon serve`) has a **Coding Sessions (orchestration)** panel showing active sessions with per-subagent attribution and `denials_by_reason` — budget trips show up as `session_budget_exceeded` counts.
 

--- a/examples/coding-agents-demo/README.md
+++ b/examples/coding-agents-demo/README.md
@@ -25,6 +25,73 @@ GATEWAY=http://localhost:18080 ./demo.sh all
 The same sequence is smoke-run in CI without Docker:
 `go test -tags=integration ./tests/integration -run TestCodingAgentsDemo_EndToEnd`.
 
+## Run it without Docker
+
+The mock provider is a plain zero-dependency Go binary — Docker is packaging,
+not a requirement. Two paths:
+
+**Path A — one command, CI-identical:**
+
+```bash
+go test -tags=integration ./tests/integration -run TestCodingAgentsDemo_EndToEnd -v
+```
+
+Compiles the real mock, drives a real gateway through the full sequence
+(cross-provider session, subagent rollup, budget deny with structured detail,
+cache tokens from both SSE wires, signature verification), ~2s.
+
+**Path B — hands-on, both processes under your control:**
+
+```bash
+# Terminal 1 — the dual-wire mock (Anthropic Messages + OpenAI Responses + Chat, all SSE)
+cd examples/docker-compose/mock-provider && go run . -port 9090
+```
+
+```bash
+# Terminal 2 — gateway in a scratch dir, pointed at the mock
+mkdir /tmp/talon-demo && cd /tmp/talon-demo
+cat > talon.config.yaml <<'EOF'
+gateway:
+  enabled: true
+  mode: enforce
+  providers:
+    anthropic:
+      enabled: true
+      base_url: "http://localhost:9090"
+      secret_name: "anthropic-api-key"
+      api_family: "anthropic"
+    openai:
+      enabled: true
+      base_url: "http://localhost:9090"
+      secret_name: "openai-api-key"
+  callers:
+    - name: "claude-code"
+      tenant_key: "talon-gw-demo-coding-0001"
+      tenant_id: "demo"
+      policy_overrides:
+        pii_action: "warn"
+        response_pii_action: "allow"
+        max_session_cost: 0.02
+EOF
+export TALON_SECRETS_KEY=$(openssl rand -hex 16) TALON_SIGNING_KEY=$(openssl rand -hex 16) TALON_ADMIN_KEY=demo-admin-key
+talon secrets set anthropic-api-key fake   # the mock ignores auth
+talon secrets set openai-api-key fake
+talon serve --gateway --gateway-config talon.config.yaml --port 8080
+```
+
+Then run the whole walk-through from a third terminal — `TALON_BIN` routes
+the script's CLI steps to your local binary instead of the container:
+
+```bash
+cd <repo>/examples/coding-agents-demo
+TALON_BIN=talon TALON_DATA_DIR=$HOME/.talon ./demo.sh all
+```
+
+(Use the same shell env — `TALON_SIGNING_KEY` etc. — as the serve terminal so
+`talon audit verify` checks against the right key.) This is also the setup
+for iterating on the mock itself: edit `main.go`, restart `go run`, re-fire
+a curl.
+
 ## What you'll watch (about 30 seconds)
 
 **1. One session, two providers.** A `generator` subagent calls the
@@ -32,6 +99,13 @@ The same sequence is smoke-run in CI without Docker:
 *openai Responses* route — both carrying `X-Talon-Session-ID: sess-coding-demo`.
 Talon records them as **one session** with per-subagent attribution
 (`provenance: client_asserted` — attribution, not authentication).
+
+> **The cast is made up.** `generator` and `executor` are arbitrary labels
+> `demo.sh` passes in `X-Talon-Agent-ID`; Talon assigns them no meaning and
+> validates them against no list — it records and rolls up whatever your
+> fleet sends (see [Governing coding agents →
+> Terminology](../../docs/guides/governing-coding-agents.md)). Only
+> `X-Talon-Stage` has a fixed vocabulary.
 
 **2. A PII event.** A prompt containing an email address is scanned, warned,
 and evidenced (`pii_action: warn`) — the request still flows, because

--- a/examples/coding-agents-demo/demo.sh
+++ b/examples/coding-agents-demo/demo.sh
@@ -39,7 +39,11 @@ wait_ready() {
   return 1
 }
 
-talon_exec() { docker compose exec -T talon talon "$@"; }
+# CLI steps run inside the compose container by default; set TALON_BIN to a
+# local binary for the no-Docker path (see README "Run it without Docker").
+talon_exec() {
+  if [ -n "${TALON_BIN:-}" ]; then "$TALON_BIN" "$@"; else docker compose exec -T talon talon "$@"; fi
+}
 
 # parent_header builds the optional -H array element(s) for a parent agent,
 # as a proper argv array so a value never word-splits into a broken header.


### PR DESCRIPTION
Follow-up from the CTO's post-acceptance walkthrough of epic #192: the question "what agent is orchestrator and what is executor?" revealed the guides *use* the role names without defining them. A 2-auditor coverage audit of the guide surface (17-item feature checklist + terminology) confirmed:

- **17/17 shipped features are documented and reachable** from `governing-coding-agents.md`,
- **1 blocking gap**: no self-serve "test without Docker" instructions (the mock is a zero-dep Go binary — Docker was packaging, not a requirement),
- several terminology holes (roles undefined, "wire family" undefined, caller/tenant/agent conflated, stage enum values unexplained).

## Changes
- **`governing-coding-agents.md` — "Terminology: the roles are labels, not Talon concepts"**: orchestrator/planner/generator/reviewer/executor/judge are illustrations; `X-Talon-Agent-ID`/`-Parent-Agent-ID`/`-Client` are free-form, unvalidated, never policy inputs; the only enforced vocabulary is `X-Talon-Stage` (`generation`/`judge`/`commit`, with meanings); caller ≠ tenant ≠ agent; "wire family" defined. Plus: per-field generic-vs-vendor conflict semantics, session-command scoping (`--session` forms are unscoped without `--tenant`, unlike the calendar rollups — matches #244), export cache columns, `accept_client_metadata`+synthetic clarification.
- **Demo README — "Run it without Docker"**: Path A (`go test -tags=integration … TestCodingAgentsDemo_EndToEnd`, CI-identical) and Path B (mock via `go run`, scratch gateway config, `TALON_BIN=talon ./demo.sh all`); "the cast is made up" callout.
- **`demo.sh`**: `TALON_BIN` env routes the CLI steps to a local binary instead of `docker compose exec` — makes Path B work end-to-end, not just the curls.
- **`claude-code-integration.md`**: `count_tokens` governed-but-cost-0 note.

Docs + one shell function; `bash -n` clean, relative links verified, demo integration test unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small optional env hook in demo.sh only; no gateway or policy behavior changes.
> 
> **Overview**
> Clarifies **coding-agent orchestration terminology** in `governing-coding-agents.md`: role names (orchestrator, generator, etc.) are illustrative; agent/parent/client headers are free-form attribution, not policy inputs; only **`X-Talon-Stage`** (`generation` / `judge` / `commit`) is enforced; caller vs tenant vs agent and **wire family** are defined. The guide also tightens precedence (generic vs vendor **per field**), synthetic sessions with `accept_client_metadata`, session CLI **scoping** vs calendar `talon costs`, and export **cache cost columns**.
> 
> Adds a **“Run it without Docker”** section to the coding-agents demo README (integration test path + mock + local `talon serve`), a **“cast is made up”** callout, and **`demo.sh`** support for **`TALON_BIN`** so audit/cost/verify steps use a local CLI instead of `docker compose exec`.
> 
> Documents in **`claude-code-integration.md`** that **`count_tokens`** is fully governed but recorded at **cost 0** with no budget impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57a4204b9bd798ca21cf4ea228537be20802c65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->