### PR TITLE
test(agent): deflake TestToolApprovalStore_Cleanup and TestBudgetAlertClaimFire

### DIFF
--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -1403,6 +1403,12 @@ func TestActiveRunTracker(t *testing.T) {
 }
 
 func TestBudgetAlertClaimFire(t *testing.T) {
+	// The dedupe table is package-global with a 1h cooldown; start from a
+	// clean slate so repeat in-process runs (-count>1) stay independent (#246).
+	budgetAlertDedupe.mu.Lock()
+	budgetAlertDedupe.lastFired = make(map[string]time.Time)
+	budgetAlertDedupe.mu.Unlock()
+
 	// First claim for (t1, daily) succeeds
 	assert.True(t, budgetAlertClaimFire("t1", "daily"))
 

--- a/internal/agent/tool_approval_test.go
+++ b/internal/agent/tool_approval_test.go
@@ -145,7 +145,10 @@ func TestToolApprovalStore_ListPending_Empty(t *testing.T) {
 }
 
 func TestToolApprovalStore_Cleanup(t *testing.T) {
-	store := NewToolApprovalStore(50 * time.Millisecond)
+	// The approval timeout must be far larger than any scheduling delay: with a
+	// short timeout the request can expire (and leave pending state) before the
+	// polling loop below ever observes it, hanging Eventually (#234).
+	store := NewToolApprovalStore(10 * time.Second)
 	ctx := context.Background()
 
 	// Create and resolve a request
@@ -158,16 +161,15 @@ func TestToolApprovalStore_Cleanup(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return len(store.ListPending()) > 0
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 10*time.Second, 10*time.Millisecond)
 
 	reqID := store.ListPending()[0].ID
 	store.Approve(reqID, "admin", "")
 	wg.Wait()
 
-	// Wait for the request to become old enough for cleanup
-	time.Sleep(60 * time.Millisecond)
-
-	removed := store.Cleanup(50 * time.Millisecond)
+	// ResolvedAt was set at Approve, strictly before now — a zero max age
+	// removes the request without depending on wall-clock sleeps.
+	removed := store.Cleanup(0)
 	assert.Equal(t, 1, removed)
 	assert.Nil(t, store.Get(reqID))
 }


### PR DESCRIPTION
Fixes #234. Fixes #246.

## TestToolApprovalStore_Cleanup (#234)

The store's approval timeout was 50ms. Under heavy parallel package load the request could expire — leaving pending state — before the test's `Eventually` poll ever observed it, so `ListPending()` stayed empty for the full 2s window and the test failed at exactly 2.00s (the reported flake signature). Now:

- store timeout 10s (it never fires; the test approves explicitly),
- observation window 10s,
- the `time.Sleep(60ms)` + `Cleanup(50ms)` wall-clock dance is replaced with `Cleanup(0)`, satisfied by any already-resolved request.

`-run TestToolApprovalStore_Cleanup -count=50` passes.

## TestBudgetAlertClaimFire (#246, found while validating this fix)

`budgetAlertDedupe` is package-global with a 1h cooldown; the test claimed fixed keys without resetting it, so **any** `-count>1` run failed deterministically on the second pass. The test now resets the dedupe table at start. `go test -race ./internal/agent/ -count=3` passes (it failed on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test setup and timing in agent tests; no production code paths change.
> 
> **Overview**
> **Test-only** changes to stop flaky or deterministic failures in `internal/agent` under parallel load and repeated `-count`.
> 
> **`TestToolApprovalStore_Cleanup` (#234):** Raises the store approval timeout from 50ms to 10s and widens the `Eventually` window to 10s so slow scheduling cannot expire the request before it appears in `ListPending`. Replaces `time.Sleep` + `Cleanup(50ms)` with **`Cleanup(0)`**, relying on `ResolvedAt` from `Approve` instead of wall-clock aging.
> 
> **`TestBudgetAlertClaimFire` (#246):** Clears the package-global **`budgetAlertDedupe`** map at test start so `-count>1` runs do not inherit a 1h cooldown from the previous subtest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6522c1cc70509b114bbaf626155452e917c575. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->