### PR TITLE
feat(secrets): --tenant/--agent ACL flags for talon secrets set

### DIFF
--- a/docs/PERSONA_GUIDES.md
+++ b/docs/PERSONA_GUIDES.md
@@ -157,7 +157,7 @@ talon run --dry-run "..."                    # Policy decision without LLM (no s
 # Multi-tenant (isolation)
 talon run --tenant acme --agent sales-bot "..."  # Scoped run
 talon audit list --tenant acme               # Only acme evidence
-talon secrets set openai-api-key "..."       # Per-tenant key when using vault
+talon secrets set acme-key "..." --tenant acme   # Scope secret to a tenant (default is allow-all)
 ```
 
 ### Workflow example

--- a/docs/guides/multi-tenant-msp.md
+++ b/docs/guides/multi-tenant-msp.md
@@ -50,6 +50,20 @@ gateway:
 
 Customers use their own caller API key; they never see other customers’ keys or data. Costs and evidence are stored under their `tenant_id`.
 
+### Scope vault secrets per tenant
+
+`talon secrets set` stores an **allow-all** ACL by default — any authenticated tenant's gateway traffic can trigger retrieval of that secret. In a multi-tenant deployment, scope every provider key to the tenants (and optionally agents) that may use it:
+
+```bash
+# Only acme's traffic may use this key (repeat --tenant for more; globs allowed)
+talon secrets set acme-openai-key "sk-..." --tenant acme
+
+# Tenant- and agent-scoped
+talon secrets set acme-sales-key "sk-..." --tenant acme --agent "sales-*"
+```
+
+An unscoped `talon secrets set` prints a notice reminding you of the allow-all default. `talon secrets audit` shows per-tenant allow/deny decisions for every retrieval.
+
 ---
 
 ## 3. Operations: data directory and exports

--- a/examples/coding-agents-demo/docker-compose.yml
+++ b/examples/coding-agents-demo/docker-compose.yml
@@ -55,10 +55,10 @@ services:
     command:
       - |
         set -e
-        # Demo scope: `talon secrets set` writes an allow-all ACL (the CLI has
-        # no per-tenant ACL flags yet) — fine here because this stack has
-        # exactly one tenant and the keys are fakes. Do NOT copy this pattern
-        # into multi-tenant deployments; scope secrets per tenant there.
+        # Demo scope: these secrets are stored with the default allow-all ACL —
+        # fine here because this stack has exactly one tenant and the keys are
+        # fakes. In multi-tenant deployments, scope each secret with
+        # `talon secrets set <name> <value> --tenant <tenant>` (#237).
         talon secrets set anthropic-api-key mock-demo-not-a-real-key >/dev/null 2>&1 || true
         talon secrets set openai-api-key mock-demo-not-a-real-key >/dev/null 2>&1 || true
         exec talon serve --port 8080 --gateway --gateway-config /etc/talon/talon.config.yaml

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,6 +16,11 @@ var secretsCmd = &cobra.Command{
 	Use:   "secrets",
 	Short: "Manage encrypted secrets vault",
 }
+
+var (
+	secretsSetTenants []string
+	secretsSetAgents  []string
+)
 
 var secretsSetCmd = &cobra.Command{
 	Use:   "set [name] [value]",
@@ -43,6 +49,10 @@ var secretsRotateCmd = &cobra.Command{
 }
 
 func init() {
+	secretsSetCmd.Flags().StringSliceVar(&secretsSetTenants, "tenant", nil,
+		"Restrict retrieval to this tenant (repeatable; glob patterns allowed). Empty means every tenant.")
+	secretsSetCmd.Flags().StringSliceVar(&secretsSetAgents, "agent", nil,
+		"Restrict retrieval to this agent (repeatable; glob patterns allowed). Empty means every agent.")
 	secretsCmd.AddCommand(secretsSetCmd)
 	secretsCmd.AddCommand(secretsListCmd)
 	secretsCmd.AddCommand(secretsAuditCmd)
@@ -76,13 +86,28 @@ func secretsSet(cmd *cobra.Command, args []string) error {
 	}
 	defer store.Close()
 
-	acl := secrets.ACL{}
+	acl := secrets.ACL{Tenants: secretsSetTenants, Agents: secretsSetAgents}
 	if err := store.Set(ctx, name, []byte(value), acl); err != nil {
 		return fmt.Errorf("storing secret: %w", err)
 	}
 
 	fmt.Printf("\u2713 Secret '%s' stored (encrypted at rest)\n", name)
+	switch {
+	case len(acl.Tenants) == 0 && len(acl.Agents) == 0:
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"notice: stored with allow-all ACL \u2014 any tenant's gateway traffic can use this secret; scope with --tenant/--agent for multi-tenant deployments")
+	default:
+		fmt.Printf("  ACL: tenants=%s agents=%s (empty list = all)\n",
+			formatACLList(acl.Tenants), formatACLList(acl.Agents))
+	}
 	return nil
+}
+
+func formatACLList(patterns []string) string {
+	if len(patterns) == 0 {
+		return "[*]"
+	}
+	return "[" + strings.Join(patterns, ", ") + "]"
 }
 
 func secretsList(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/secrets_test.go
+++ b/internal/cmd/secrets_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/secrets"
 )
 
 func TestSecretsCmd_HasSubcommands(t *testing.T) {
@@ -48,6 +52,67 @@ func TestSecretsAuditCmd_UseLine(t *testing.T) {
 
 func TestSecretsRotateCmd_UseLine(t *testing.T) {
 	assert.Equal(t, "rotate [name]", secretsRotateCmd.Use)
+}
+
+func TestSecretsSetCmd_HasACLFlags(t *testing.T) {
+	assert.NotNil(t, secretsSetCmd.Flags().Lookup("tenant"), "--tenant flag should be registered")
+	assert.NotNil(t, secretsSetCmd.Flags().Lookup("agent"), "--agent flag should be registered")
+}
+
+// setSecretViaCLI runs the secrets set handler with the given ACL flag values
+// against a temp data dir and returns the opened store for assertions.
+func setSecretViaCLI(t *testing.T, tenants, agents []string) *secrets.SecretStore {
+	t.Helper()
+	t.Setenv("TALON_DATA_DIR", t.TempDir())
+	t.Setenv("TALON_SECRETS_KEY", "abcdefghijklmnopqrstuvwxyz012345")
+
+	secretsSetTenants, secretsSetAgents = tenants, agents
+	t.Cleanup(func() { secretsSetTenants, secretsSetAgents = nil, nil })
+
+	secretsSetCmd.SetContext(context.Background())
+	require.NoError(t, secretsSet(secretsSetCmd, []string{"provider-key", "v1"}))
+
+	store, err := openSecretsStore()
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestSecretsSet_ScopedACL(t *testing.T) {
+	store := setSecretViaCLI(t, []string{"acme"}, nil)
+	ctx := context.Background()
+
+	sec, err := store.Get(ctx, "provider-key", "acme", "any-agent")
+	require.NoError(t, err, "listed tenant must be allowed")
+	require.Equal(t, "v1", string(sec.Value))
+
+	_, err = store.Get(ctx, "provider-key", "globex", "any-agent")
+	require.Error(t, err, "tenant outside the ACL must be denied (#237)")
+}
+
+func TestSecretsSet_AgentScopedACL(t *testing.T) {
+	store := setSecretViaCLI(t, nil, []string{"sales-*"})
+	ctx := context.Background()
+
+	_, err := store.Get(ctx, "provider-key", "any-tenant", "sales-bot")
+	require.NoError(t, err, "glob-matched agent must be allowed")
+
+	_, err = store.Get(ctx, "provider-key", "any-tenant", "ops-bot")
+	require.Error(t, err, "agent outside the ACL must be denied (#237)")
+}
+
+func TestSecretsSet_DefaultAllowAllWithNotice(t *testing.T) {
+	var stderr bytes.Buffer
+	secretsSetCmd.SetErr(&stderr)
+	t.Cleanup(func() { secretsSetCmd.SetErr(nil) })
+
+	store := setSecretViaCLI(t, nil, nil)
+	ctx := context.Background()
+
+	_, err := store.Get(ctx, "provider-key", "any-tenant", "any-agent")
+	require.NoError(t, err, "empty ACL keeps allow-all semantics")
+	assert.Contains(t, stderr.String(), "allow-all ACL",
+		"unscoped set must print the multi-tenant notice (#237)")
 }
 
 func TestOpenSecretsStore_DefaultKey(t *testing.T) {

--- a/tests/e2e/secrets_test.go
+++ b/tests/e2e/secrets_test.go
@@ -13,13 +13,24 @@ func TestE2E_SecretsLifecycle(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("talon init failed: %d", code)
 	}
-	// set
+	// set — unscoped stores allow-all and must say so on stderr (#237)
 	_, stderr, code := RunTalon(t, dir, nil, "secrets", "set", "test-secret", "secret-value")
 	if code != 0 {
 		t.Fatalf("talon secrets set exited %d\nstderr: %s", code, stderr)
 	}
+	if !strings.Contains(stderr, "allow-all ACL") {
+		t.Errorf("unscoped secrets set should print the allow-all notice, stderr: %s", stderr)
+	}
+	// set with a tenant-scoped ACL (#237)
+	stdout, stderr, code := RunTalon(t, dir, nil, "secrets", "set", "scoped-secret", "v", "--tenant", "acme", "--agent", "sales-*")
+	if code != 0 {
+		t.Fatalf("talon secrets set --tenant exited %d\nstderr: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "acme") {
+		t.Errorf("scoped secrets set should echo the ACL, stdout: %s", stdout)
+	}
 	// list (should show test-secret or mask it)
-	stdout, stderr, code := RunTalon(t, dir, nil, "secrets", "list")
+	stdout, stderr, code = RunTalon(t, dir, nil, "secrets", "list")
 	if code != 0 {
 		t.Fatalf("talon secrets list exited %d\nstderr: %s", code, stderr)
 	}


### PR DESCRIPTION
Fixes #237.

`talon secrets set` stored every secret with an empty ACL — allow-all per `internal/secrets/acl.go` — and offered no way to scope it, so in multi-tenant deployments any authenticated tenant's gateway traffic could retrieve any CLI-set secret.

## Change

- Repeatable `--tenant` and `--agent` flags (glob patterns allowed) populate `secrets.ACL{Tenants, Agents}`; `SecretStore.Set` already accepted the ACL, so this is pure CLI wiring.
- Default stays allow-all for backward compatibility, now with a stderr notice: `stored with allow-all ACL — ... scope with --tenant/--agent for multi-tenant deployments`. Scoped sets echo the stored ACL on stdout.

## Tests

- `internal/cmd`: CLI-set secret readable only by listed tenants / glob-matched agents; unscoped set keeps allow-all and prints the notice.
- `tests/e2e`: scoped set + notice through the real binary.

## Docs

Multi-tenant/MSP guide gains a "Scope vault secrets per tenant" section; persona guide example updated; the coding-agents demo's do-not-copy comment now points at the flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret retrieval ACL wiring in the CLI; mis-scoped flags could deny legitimate access or leave allow-all secrets exposed in multi-tenant setups, though defaults and notices preserve backward compatibility.
> 
> **Overview**
> **`talon secrets set`** now accepts repeatable **`--tenant`** and **`--agent`** flags (glob patterns supported) and passes them into the existing vault **`secrets.ACL`** on store, so multi-tenant deployments can restrict which gateway traffic may retrieve a secret.
> 
> **Default behavior is unchanged** (empty ACL = allow-all). Unscoped sets print a **stderr notice** about allow-all risk; scoped sets print the stored ACL on stdout.
> 
> Docs (MSP guide, persona guide, coding-agents demo comment) describe scoping secrets per tenant. **Unit and e2e tests** cover tenant/agent enforcement, allow-all notice, and scoped CLI output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2926ddaf0a45b68599bda0ee66aa047c6bdcae2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->