### PR TITLE
ci: shellcheck every tracked shell script; fix all findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,17 @@ jobs:
       - uses: actions/checkout@v4
 
       # Lint every tracked shell script (#242): three shell-only demo bugs
-      # (#239 #240 #241) shipped because CI never looked at *.sh. shellcheck
-      # is preinstalled on ubuntu runners; config lives in .shellcheckrc.
+      # (#239 #240 #241) shipped because CI never looked at *.sh. Config lives
+      # in .shellcheckrc. The version is pinned: the runner's preinstalled
+      # shellcheck emits SC2317 false positives on indirectly-invoked
+      # functions that 0.11 correctly skips.
+      - name: Install shellcheck
+        run: |
+          curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz \
+            | tar -xJ -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/shellcheck-v0.11.0" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/shellcheck-v0.11.0/shellcheck" --version
+
       - name: shellcheck
         run: git ls-files -z '*.sh' | xargs -0 shellcheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,19 @@ jobs:
           version: latest
           args: --timeout 5m
 
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Lint every tracked shell script (#242): three shell-only demo bugs
+      # (#239 #240 #241) shipped because CI never looked at *.sh. shellcheck
+      # is preinstalled on ubuntu runners; config lives in .shellcheckrc.
+      - name: shellcheck
+        run: git ls-files -z '*.sh' | xargs -0 shellcheck
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# Shellcheck config for all repo scripts (CI lints every tracked *.sh — see #242).
+
+# Follow source'd files relative to the sourcing script.
+external-sources=true
+source-path=SCRIPTDIR
+
+# SC2016 flags single-quoted strings containing $. Every instance in this repo
+# is intentional: jq --arg variables ('.session_id == $sid') and bash -c child
+# shells ('echo "$1"'), where expansion by the parent would be the bug.
+disable=SC2016

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,7 +111,7 @@ CHECKSUM_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.t
 
 echo "Downloading ${ASSET_NAME}..."
 TMP_DIR=$(mktemp -d)
-trap "rm -rf ${TMP_DIR}" EXIT
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
 if ! curl -fsSL -o "${TMP_DIR}/${ARCHIVE_FILE}" "${DOWNLOAD_URL}"; then
     echo "Error: Download failed for ${ASSET_NAME}"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -21,7 +21,7 @@ cd "$(dirname "$0")/.."
 OUTPUT=""
 BENCH_TIME="${BENCH_TIME:-2s}"
 BENCH_COUNT="${BENCH_COUNT:-5}"
-BENCH_PKGS="./internal/gateway/... ./internal/classifier/... ./internal/evidence/..."
+BENCH_PKGS=(./internal/gateway/... ./internal/classifier/... ./internal/evidence/...)
 BENCH_REGEX='Benchmark(GatewayPipelineOverhead|GatewayPipelineOverheadLargePrompt|PIIScan|EvidenceStore)$'
 
 while getopts "o:" opt; do
@@ -43,7 +43,7 @@ bench_out=$("${GO_ENV[@]}" go test \
   -benchtime="$BENCH_TIME" \
   -count="$BENCH_COUNT" \
   -run='^$' \
-  $BENCH_PKGS 2>&1) || {
+  "${BENCH_PKGS[@]}" 2>&1) || {
   echo "$bench_out" >&2
   exit 1
 }

--- a/scripts/verify-newcomer-path.sh
+++ b/scripts/verify-newcomer-path.sh
@@ -24,7 +24,8 @@ if ! command -v talon >/dev/null 2>&1; then
     else
       make -C "$REPO_ROOT" install
     fi
-    export PATH="$(go env GOPATH)/bin:${PATH}"
+    GOPATH_BIN="$(go env GOPATH)/bin"
+    export PATH="${GOPATH_BIN}:${PATH}"
   else
     echo "Error: talon not found and go not available to build." >&2
     exit 1

--- a/tests/pii_enrichment_quality_test.sh
+++ b/tests/pii_enrichment_quality_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2034  # helpers/colour set mirror smoke_test.sh conventions; some are invoked or consumed indirectly
 #
 # Dativo Talon — PII Semantic Enrichment Quality Comparison Test
 #
@@ -65,8 +66,10 @@
 
 set -o pipefail
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+readonly REPO_ROOT
 readonly NUM_PROMPTS="${NUM_PROMPTS:-10}"
 readonly MODEL="${MODEL:-gpt-4o-mini}"
 

--- a/tests/smoke_lib.sh
+++ b/tests/smoke_lib.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # canonical paths/bodies are consumed by the scripts that source this lib
+#
 # Smoke test request layer — central place for all Talon HTTP requests and canonical payloads.
 # Sourced by smoke_test.sh. Use these helpers so we don't duplicate URLs or request bodies.
 #

--- a/tests/smoke_sections/01_binary.sh
+++ b/tests/smoke_sections/01_binary.sh
@@ -6,7 +6,6 @@
 # SECTION 01 — Binary and Version (docs/QUICKSTART.md, docs/README.md)
 # -----------------------------------------------------------------------------
 test_section_01_binary() {
-  local section="01_binary"
   echo ""
   echo "=== SECTION 01 — Binary and Version ==="
   # talon version exits 0 and stdout contains at least one digit

--- a/tests/smoke_sections/13_gateway.sh
+++ b/tests/smoke_sections/13_gateway.sh
@@ -99,9 +99,8 @@ GWEOF
   code_join="$(curl -s -o /tmp/talon_gw_resp_join.json -w '%{http_code}' -X POST "${gateway_base_url}${SMOKE_PATH_GW_PROXY}" \
     -H "Authorization: Bearer $gw_key" -H "Content-Type: application/json" -H "X-Talon-Session-ID: ${gw_sid}" -d "$SMOKE_BODY_SIMPLE" 2>/dev/null)"
   assert_pass "POST gateway chat/completions with provided session id returns 200" test "$code_join" = "200"
-  local gw_ev_index gw_ev_id gw_sid_match=0
+  local gw_ev_index gw_sid_match=0
   gw_ev_index="$(curl -s -H "X-Talon-Admin-Key: ${TALON_ADMIN_KEY}" "http://127.0.0.1:${gateway_port}/v1/evidence?limit=20")"
-  gw_ev_id="$(echo "$gw_ev_index" | jq -r '.entries[]? | select(.invocation_type=="gateway") | .id' | head -1)"
   if [[ -n "$gw_sid" ]]; then
     local evid
     while read -r evid; do

--- a/tests/smoke_sections/15_multi_tenant.sh
+++ b/tests/smoke_sections/15_multi_tenant.sh
@@ -13,7 +13,6 @@ test_section_15_multi_tenant() {
   [[ -n "${OPENAI_API_KEY:-}" ]] && run_talon secrets set openai-api-key "$OPENAI_API_KEY" &>/dev/null; true
   smoke_tighten_limits "$dir"
   local tenant_key_a="key-tenant-a"
-  local tenant_key_b="key-tenant-b"
   export TALON_TENANT_KEY="$tenant_key_a"
   run_talon run --tenant tenant-a "Hello from A" &>/dev/null; true
   run_talon run --tenant tenant-b "Hello from B" &>/dev/null; true

--- a/tests/smoke_sections/18_compliance_export.sh
+++ b/tests/smoke_sections/18_compliance_export.sh
@@ -18,7 +18,6 @@ test_section_18_compliance_export() {
   local csv_h; csv_h="$(run_talon audit export --format csv --from 2020-01-01 2>/dev/null | head -1)"; true
   assert_pass "CSV header contains id, timestamp, tenant_id, pii_detected" \
     grep -qE 'id|timestamp|tenant_id|pii' <<< "$csv_h"
-  local json_len; json_len="$(run_talon audit export --format json --from 2020-01-01 2>/dev/null | jq '.records | length')"
   assert_pass "talon audit export --format json returns valid JSON with records array" \
     jq -e '.records' <<< "$(run_talon audit export --format json --from 2020-01-01 2>/dev/null)" &>/dev/null
   local ev_id; ev_id="$(run_talon audit list --limit 1 2>/dev/null | awk '/req_/{print $2; exit}')"

--- a/tests/smoke_sections/29_consistency.sh
+++ b/tests/smoke_sections/29_consistency.sh
@@ -7,7 +7,7 @@
 # -----------------------------------------------------------------------------
 test_section_29_consistency() {
   local section="29_consistency"
-  local dir; dir="$(setup_section_dir "$section")"
+  setup_section_dir "$section" >/dev/null
   local ev_id list_out show_out
   list_out="$(env TALON_DATA_DIR="$TALON_DATA_DIR" talon audit list --limit 1 2>/dev/null)" || true
   ev_id="$(echo "$list_out" | awk '/req_/{print $2; exit}')"
@@ -61,8 +61,9 @@ test_section_29_consistency() {
   # Edge case: unknown evidence id should fail for show/verify
   local missing_id="req_nonexistent_smoke_consistency_00000"
   local missing_show missing_verify
-  missing_show="$(env TALON_DATA_DIR="$TALON_DATA_DIR" talon audit show "$missing_id" 2>&1)"
-  if [[ $? -ne 0 ]] || echo "$missing_show" | grep -qiE 'not found|no evidence|missing'; then
+  local show_rc=0
+  missing_show="$(env TALON_DATA_DIR="$TALON_DATA_DIR" talon audit show "$missing_id" 2>&1)" || show_rc=$?
+  if [[ $show_rc -ne 0 ]] || echo "$missing_show" | grep -qiE 'not found|no evidence|missing'; then
     echo "  ✓  CONSISTENCY: audit show rejects nonexistent evidence id"
     echo "[SMOKE] CONSISTENCY|audit_show_missing_id|PASS|id=$missing_id"
     record_pass
@@ -72,8 +73,9 @@ test_section_29_consistency() {
     record_fail "CONSISTENCY: audit_show_missing_id"
   fi
 
-  missing_verify="$(env TALON_DATA_DIR="$TALON_DATA_DIR" talon audit verify "$missing_id" 2>&1)"
-  if [[ $? -ne 0 ]] || echo "$missing_verify" | grep -qiE 'not found|invalid|missing'; then
+  local verify_rc=0
+  missing_verify="$(env TALON_DATA_DIR="$TALON_DATA_DIR" talon audit verify "$missing_id" 2>&1)" || verify_rc=$?
+  if [[ $verify_rc -ne 0 ]] || echo "$missing_verify" | grep -qiE 'not found|invalid|missing'; then
     echo "  ✓  CONSISTENCY: audit verify rejects nonexistent evidence id"
     echo "[SMOKE] CONSISTENCY|audit_verify_missing_id|PASS|id=$missing_id"
     record_pass

--- a/tests/smoke_sections/30_graph_events.sh
+++ b/tests/smoke_sections/30_graph_events.sh
@@ -110,8 +110,9 @@ GWEOF
   local tenant_hdr="Authorization: Bearer ${TALON_TENANT_KEY}"
   local admin_hdr="X-Talon-Admin-Key: ${TALON_ADMIN_KEY}"
   local graph_url="${ge_base}/v1/graph/events"
-  local graph_run_id="gr_smoke_$(date +%s)"
-  local graph_session_id="sess_graph_$(date +%s)"
+  local graph_run_id graph_session_id
+  graph_run_id="gr_smoke_$(date +%s)"
+  graph_session_id="sess_graph_$(date +%s)"
 
   # Helper: POST a graph event and capture HTTP code + body
   post_graph_event() {
@@ -237,7 +238,8 @@ GWEOF
   rm -f "$resp_30f"
 
   # --- 30g: run_end returns allow on a clean run ---
-  local clean_run_id="gr_smoke_run_end_allow_$(date +%s)"
+  local clean_run_id
+  clean_run_id="gr_smoke_run_end_allow_$(date +%s)"
   local resp_30g_start body_30g_start code_30g_start
   resp_30g_start="$(mktemp)"
   body_30g_start="{\"type\":\"run_start\",\"graph_run_id\":\"${clean_run_id}\",\"session_id\":\"${graph_session_id}\",\"agent_id\":\"smoke-graph-agent\",\"run_meta\":{\"framework\":\"langgraph\",\"node_count\":1,\"model\":\"gpt-4o\"}}"
@@ -356,7 +358,8 @@ GWEOF
   fi
 
   # --- 30n: full lifecycle — 3-node google_search agent run ---
-  local lifecycle_id="gr_smoke_lifecycle_$(date +%s)"
+  local lifecycle_id
+  lifecycle_id="gr_smoke_lifecycle_$(date +%s)"
   local all_ok=true
 
   local events=(
@@ -409,7 +412,8 @@ GWEOF
   fi
 
   # --- 30p: max_tool_calls_per_run exceeded is denied ---
-  local toolcap_id="gr_smoke_tool_cap_$(date +%s)"
+  local toolcap_id
+  toolcap_id="gr_smoke_tool_cap_$(date +%s)"
   local resp_30p_start resp_30p_first resp_30p_second
   local code_30p_start code_30p_first code_30p_second
   resp_30p_start="$(mktemp)"
@@ -437,7 +441,8 @@ GWEOF
   rm -f "$resp_30p_start" "$resp_30p_first" "$resp_30p_second"
 
   # --- 30q: run_end final cost overrun is denied ---
-  local runend_cost_id="gr_smoke_run_end_cost_$(date +%s)"
+  local runend_cost_id
+  runend_cost_id="gr_smoke_run_end_cost_$(date +%s)"
   local resp_30q_start resp_30q_step resp_30q_end
   local code_30q_start code_30q_step code_30q_end
   resp_30q_start="$(mktemp)"
@@ -464,7 +469,8 @@ GWEOF
   rm -f "$resp_30q_start" "$resp_30q_step" "$resp_30q_end"
 
   # --- 30r: prior mid-run deny causes run_end deny ---
-  local denied_run_id="gr_smoke_midrun_denied_$(date +%s)"
+  local denied_run_id
+  denied_run_id="gr_smoke_midrun_denied_$(date +%s)"
   local resp_30r_start resp_30r_deny_step resp_30r_end
   local code_30r_start code_30r_deny_step code_30r_end
   resp_30r_start="$(mktemp)"

--- a/tests/smoke_sections/35_failover.sh
+++ b/tests/smoke_sections/35_failover.sh
@@ -117,9 +117,9 @@ GWEOF
     grep -q "gateway_failover_attempt" <<< "$export_out"
 
   if [[ -n "$fo_corr" ]]; then
-    local verify_out
-    verify_out="$(run_talon audit verify --failover "$fo_corr" 2>&1)"
-    if [[ $? -eq 0 ]] && grep -q "valid_fallback" <<< "$verify_out"; then
+    local verify_out verify_rc=0
+    verify_out="$(run_talon audit verify --failover "$fo_corr" 2>&1)" || verify_rc=$?
+    if [[ $verify_rc -eq 0 ]] && grep -q "valid_fallback" <<< "$verify_out"; then
       echo "  ✓  audit verify --failover confirms valid fallback chain"
       record_pass
     else
@@ -176,9 +176,9 @@ SOVEOF
   smoke_stop_gateway_35 "$fo_pid_b" "$gateway_port"
 
   if [[ -n "$fo_corr_b" ]]; then
-    local verify_out_b
-    verify_out_b="$(run_talon audit verify --failover "$fo_corr_b" 2>&1)"
-    if [[ $? -eq 0 ]] && grep -q "valid_fail_closed" <<< "$verify_out_b"; then
+    local verify_out_b verify_rc_b=0
+    verify_out_b="$(run_talon audit verify --failover "$fo_corr_b" 2>&1)" || verify_rc_b=$?
+    if [[ $verify_rc_b -eq 0 ]] && grep -q "valid_fail_closed" <<< "$verify_out_b"; then
       echo "  ✓  audit verify --failover confirms fail-closed governance outcome"
       record_pass
     else

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2329  # helpers are invoked from section files sourced in a loop, invisible to shellcheck
 #
 # Dativo Talon — Smoke Test Suite
 # Brief version 1.0 — March 2026 — Dativo Talon CPO/CTO
@@ -58,9 +59,11 @@
 set -o pipefail
 # Do NOT use set -e: individual assertion failures must not abort the suite.
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 # Repo root: one level up from tests/ when script lives in tests/
-readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+readonly REPO_ROOT
 
 # --- Counters and state ---
 PASS_COUNT=0


### PR DESCRIPTION
Fixes #242 (option 1 — the cheap guard; option 2, a compose-up demo job, stays open as a possible follow-up).

CI never executed or linted the demo/ops shell scripts, so three shell-only bugs (#239 #240 #241) reached end users in sequence. This adds a `shellcheck` job over `git ls-files '*.sh'` (shellcheck is preinstalled on ubuntu runners) and makes the tree clean — 65 findings triaged:

- **Real hazards fixed:** unquoted `$BENCH_PKGS` in `run-benchmarks.sh` (the exact SC2086 class from #241) is now an array; `install.sh`'s trap expands `TMP_DIR` at signal time.
- **Dead code removed:** `tenant_key_b`, `gw_ev_id`, `json_len`, unused `section`/`dir` locals in smoke sections (verified no functional impact).
- **Style with substance:** SC2155 declare/assign splits (masked exit codes), SC2181 `$?` checks made direct.
- **`.shellcheckrc`:** follows sourced files (kills SC1091); disables SC2016 repo-wide — every instance is an intentional `jq --arg` or `bash -c` child-shell pattern where parent expansion would be the bug.
- **Justified directives:** `smoke_test.sh`/`smoke_lib.sh`/`pii_enrichment_quality_test.sh` get file-level SC2329/SC2034 disables — helpers and canonical payloads are consumed by section files sourced in a loop, which shellcheck cannot follow.

`bash -n` passes on every touched script; full `git ls-files -z '*.sh' | xargs -0 shellcheck` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to shell scripts and CI linting; no Go application or auth logic is modified, aside from safer installer temp-dir cleanup.
> 
> **Overview**
> Adds a **Shellcheck** CI job that lints every tracked `*.sh` via `git ls-files` and a new **`.shellcheckrc`** (follows sourced files; repo-wide **SC2016** disable for intentional `jq --arg` / `bash -c` patterns).
> 
> Fixes real shell hazards: **`run-benchmarks.sh`** uses a proper array for benchmark package paths (avoids word-splitting); **`install.sh`** EXIT trap now cleans up `TMP_DIR` at signal time instead of expanding an empty path at trap registration.
> 
> The rest is shellcheck-driven cleanup across smoke/ops scripts—unused locals removed, declare/assign splits, direct exit-code capture instead of **`$?`** after assignments, and targeted **`shellcheck disable`** on **`smoke_test.sh`**, **`smoke_lib.sh`**, and **`pii_enrichment_quality_test.sh`** where helpers are sourced from section files shellcheck cannot follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5795cfc9b88313ea137de65b0a5f29dfaffc966c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->