### PR TITLE
fix(gateway): provider-native envelopes — Anthropic fallback types, PII blocks, cache hits (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+### Fixed
+
+- **Gateway error envelopes are now provider-native on three more paths (#195).** (1) Anthropic-family denials without a machine code carried `"type": "error"` — not a member of Anthropic's error enum, so typed SDK error handling fell through; the fallback now maps the HTTP status to the correct enum member (`400→invalid_request_error`, `401→authentication_error`, `403→permission_error`, `404→not_found_error`, `413→request_too_large`, `429→rate_limit_error`, `529→overloaded_error`, other `5xx→api_error`). Machine codes from the documented prefix convention (e.g. `session_budget_exceeded`) still travel in `error.type`; the final enum contract table is #142's. (2) Response-PII blocks (HTTP 451) and scanner-unavailable blocks (502) — streaming and non-streaming — previously returned a bare `{"error":{…}}` on both wire families; they now render through the shared per-family envelopes (Anthropic `{"type":"error","error":{…}}`; OpenAI envelope gains its `code` field). (3) Semantic-cache hits on anthropic routes returned an OpenAI chat completion; they now return an Anthropic Messages object. Also documented: pre-route errors (unknown provider prefix) intentionally use the OpenAI shape since no wire family is resolved yet. Who cares: anyone whose Claude-family client parses gateway denials — typed error handling and retry logic now see valid shapes. Verify: `go test ./internal/gateway/ -run 'TestWriteAnthropicError_StatusMappedTypes|TestScanResponseForPII_BlockBodyPerFamily|TestWriteCachedCompletion_AnthropicShape' -v`.
+
 ## [1.7.0] - 2026-07-06
 
 ### Added

--- a/docs/guides/governing-coding-agents.md
+++ b/docs/guides/governing-coding-agents.md
@@ -158,7 +158,7 @@ policy_overrides:
 
 How `max_session_cost` behaves — precisely:
 
-- A **new** request is denied once accrued session spend + the pre-request estimate exceeds the limit. The denial is HTTP 403 with a **provider-native error body** (`session_budget_exceeded: session spend 6.00 + estimate 1.00 exceeds limit 5.00`), so clients surface it like any provider error.
+- A **new** request is denied once accrued session spend + the pre-request estimate exceeds the limit. The denial is HTTP 403 with a **provider-native error body** (`session_budget_exceeded: session spend 6.00 + estimate 1.00 exceeds limit 5.00`), so clients surface it like any provider error. One documented exception: errors emitted **before routing** (e.g. a request for an unknown provider prefix) use the OpenAI error shape, since no provider — and therefore no wire family — was resolved yet (#195).
 - Spend accumulates **per session, not per provider** — the same session is denied on the other provider's route too (`TestSessionBudget_CrossProviderDeny`).
 - It is a **soft cap**: one in-flight request whose real cost exceeds the estimate can overshoot, and N concurrent first requests are bounded only by N × per-request cost. Atomic reservation is #144 (`TestSessionBudget_SoftCapOvershoot`, `TestSessionBudget_ConcurrentBurstBound`).
 - Session denies carry a **structured evidence detail** (limit, spent, estimate) — populated only for session-budget denies, not other reasons (`TestSessionBudgetDetail_OnlyOnSessionDeny`).

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -40,10 +40,40 @@ func WriteOpenAIError(w http.ResponseWriter, status int, message, errType string
 	})
 }
 
-// WriteAnthropicError writes an Anthropic-format error response.
+// anthropicTypeForStatus maps an HTTP status to a member of Anthropic's error
+// type enum (https://docs.anthropic.com/en/api/errors) — the fallback when a
+// denial carries no machine code. Talon machine codes (session_budget_exceeded,
+// egress_*, ...) still travel in error.type by the documented prefix
+// convention; the enum contract table is owned by #142.
+func anthropicTypeForStatus(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusRequestEntityTooLarge:
+		return "request_too_large"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case 529: // Anthropic's overloaded status
+		return "overloaded_error"
+	}
+	if status >= 500 {
+		return "api_error"
+	}
+	return "invalid_request_error"
+}
+
+// WriteAnthropicError writes an Anthropic-format error response. An empty
+// errType falls back to the status-mapped member of Anthropic's error enum —
+// never the invalid literal "error" (#195).
 func WriteAnthropicError(w http.ResponseWriter, status int, message, errType string) {
 	if errType == "" {
-		errType = "error"
+		errType = anthropicTypeForStatus(status)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -51,6 +81,30 @@ func WriteAnthropicError(w http.ResponseWriter, status int, message, errType str
 		Type:  "error",
 		Error: anthropicError{Type: errType, Message: message},
 	})
+}
+
+// providerErrorBody renders the provider-native error envelope as bytes, for
+// paths that return bodies instead of writing responses directly (e.g. the
+// response-PII block bodies, #195). Same shapes as the Write* functions —
+// never a second envelope implementation.
+func providerErrorBody(apiFamily string, status int, message, errType string) []byte {
+	if apiFamily == "anthropic" {
+		if errType == "" {
+			errType = anthropicTypeForStatus(status)
+		}
+		b, _ := json.Marshal(anthropicErrorBody{
+			Type:  "error",
+			Error: anthropicError{Type: errType, Message: message},
+		})
+		return b
+	}
+	if errType == "" {
+		errType = "invalid_request_error"
+	}
+	b, _ := json.Marshal(openAIErrorBody{
+		Error: openAIError{Message: message, Type: errType, Code: errType},
+	})
+	return b
 }
 
 // WriteProviderError writes a provider-native error response based on provider name.

--- a/internal/gateway/errors_test.go
+++ b/internal/gateway/errors_test.go
@@ -78,3 +78,111 @@ func TestWriteProviderError(t *testing.T) {
 		}
 	})
 }
+
+// #195: an empty errType must fall back to a member of Anthropic's error
+// enum mapped from the HTTP status — never the invalid literal "error".
+func TestWriteAnthropicError_StatusMappedTypes(t *testing.T) {
+	cases := map[int]string{
+		400: "invalid_request_error",
+		401: "authentication_error",
+		403: "permission_error",
+		404: "not_found_error",
+		413: "request_too_large",
+		429: "rate_limit_error",
+		500: "api_error",
+		502: "api_error",
+		529: "overloaded_error",
+		418: "invalid_request_error", // unmapped 4xx → safest member
+	}
+	for status, wantType := range cases {
+		w := httptest.NewRecorder()
+		WriteAnthropicError(w, status, "denied", "")
+		var body struct {
+			Type  string `json:"type"`
+			Error struct {
+				Type    string `json:"type"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("status %d: %v", status, err)
+		}
+		if body.Error.Type != wantType {
+			t.Errorf("status %d: error.type = %q, want %q", status, body.Error.Type, wantType)
+		}
+		if body.Type != "error" {
+			t.Errorf("status %d: envelope type = %q, want error", status, body.Type)
+		}
+		if body.Error.Type == "error" {
+			t.Errorf("status %d: the invalid literal \"error\" must never appear as error.type", status)
+		}
+	}
+
+	// Machine codes from the prefix convention are preserved, not remapped.
+	w := httptest.NewRecorder()
+	WriteAnthropicError(w, 403, "session spend 6.00 exceeds limit", "session_budget_exceeded")
+	if !strings.Contains(w.Body.String(), `"type":"session_budget_exceeded"`) {
+		t.Errorf("machine code must stay in error.type: %s", w.Body.String())
+	}
+}
+
+// #195: providerErrorBody renders the same envelopes as the Write* functions.
+func TestProviderErrorBody_PerFamily(t *testing.T) {
+	anth := providerErrorBody("anthropic", 451, "blocked", "pii_policy_violation")
+	var ab struct {
+		Type  string `json:"type"`
+		Error struct{ Type, Message string }
+	}
+	if err := json.Unmarshal(anth, &ab); err != nil {
+		t.Fatal(err)
+	}
+	if ab.Type != "error" || ab.Error.Type != "pii_policy_violation" {
+		t.Errorf("anthropic envelope wrong: %s", anth)
+	}
+
+	oai := providerErrorBody("openai", 451, "blocked", "pii_policy_violation")
+	var ob struct {
+		Error struct{ Message, Type, Code string }
+	}
+	if err := json.Unmarshal(oai, &ob); err != nil {
+		t.Fatal(err)
+	}
+	if ob.Error.Type != "pii_policy_violation" || ob.Error.Code != "pii_policy_violation" {
+		t.Errorf("openai envelope wrong: %s", oai)
+	}
+
+	// Empty errType: anthropic maps by status; openai uses its default.
+	anthEmpty := providerErrorBody("anthropic", 502, "scanner down", "")
+	if !strings.Contains(string(anthEmpty), `"type":"api_error"`) {
+		t.Errorf("anthropic empty type must map 502→api_error: %s", anthEmpty)
+	}
+}
+
+// #195: a semantic-cache hit on an anthropic route must be an Anthropic
+// Messages object, not an OpenAI chat completion.
+func TestWriteCachedCompletion_AnthropicShape(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeCachedCompletion(w, "anthropic", "claude-opus-4-8", "cached answer")
+	var msg struct {
+		Type       string `json:"type"`
+		Role       string `json:"role"`
+		Content    []struct{ Type, Text string }
+		StopReason string `json:"stop_reason"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != "message" || msg.Role != "assistant" || msg.StopReason != "end_turn" {
+		t.Errorf("not a Messages object: %s", w.Body.String())
+	}
+	if len(msg.Content) != 1 || msg.Content[0].Text != "cached answer" {
+		t.Errorf("content block wrong: %s", w.Body.String())
+	}
+
+	// OpenAI routes keep the chat-completion shape.
+	w2 := httptest.NewRecorder()
+	writeCachedCompletion(w2, "openai", "gpt-5.3-codex", "cached answer")
+	if !strings.Contains(w2.Body.String(), `"object":"chat.completion"`) {
+		t.Errorf("openai cache hit must stay chat.completion: %s", w2.Body.String())
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1022,7 +1022,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		capture := &responseCapture{ResponseWriter: w}
 		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt, checkCandidate)
 		if forwardErr == nil {
-			scannedBody, scanResult := scanResponseForPII(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), capture.body.Bytes(), responsePIIAction, g.classifier)
+			scannedBody, scanResult := scanResponseForPII(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), wire, capture.body.Bytes(), responsePIIAction, g.classifier)
 			responsePII = scanResult
 			status := capture.statusCode
 			if scanResult != nil && scanResult.Blocked {
@@ -1081,7 +1081,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		capture := &responseCapture{ResponseWriter: w}
 		failoverOut, forwardErr = g.forwardWithFailover(ctx, capture, fwdParams, route, caller, extracted.Model, originalAuthorization, recordAttempt, checkCandidate)
 		if forwardErr == nil {
-			responsePII = handleStreamingPIIScan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), w, capture, responsePIIAction, g.classifier)
+			responsePII = handleStreamingPIIScan(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), w, capture, wire, responsePIIAction, g.classifier)
 		} else {
 			capture.flushTo(w)
 		}
@@ -1830,11 +1830,28 @@ func (g *Gateway) emitMetrics(ctx context.Context, caller *CallerConfig, provide
 	}
 }
 
-// writeCachedCompletion writes a minimal OpenAI-compatible chat completion JSON with the cached content.
-func writeCachedCompletion(w http.ResponseWriter, provider, model string, content string) {
+// writeCachedCompletion writes a minimal provider-native completion body with
+// the cached content: an Anthropic Messages object on anthropic-family routes,
+// an OpenAI chat completion otherwise (#195 — previously always OpenAI shape).
+func writeCachedCompletion(w http.ResponseWriter, apiFamily, model string, content string) {
 	w.Header().Set("Content-Type", "application/json")
+	id := "cache-" + fmt.Sprintf("%d", time.Now().UnixNano())
+	if apiFamily == "anthropic" {
+		resp := map[string]interface{}{
+			"id":            id,
+			"type":          "message",
+			"role":          "assistant",
+			"model":         model,
+			"content":       []map[string]interface{}{{"type": "text", "text": content}},
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+			"usage":         map[string]interface{}{"input_tokens": 0, "output_tokens": 0},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
 	resp := map[string]interface{}{
-		"id":     "cache-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		"id":     id,
 		"object": "chat.completion",
 		"model":  model,
 		"choices": []map[string]interface{}{

--- a/internal/gateway/response_pii.go
+++ b/internal/gateway/response_pii.go
@@ -90,10 +90,11 @@ func resolveResponsePIIAction(defaultPolicy *ServerDefaults, callerOverrides *Ca
 // scanResponseForPII scans only the LLM-generated content fields in a non-streaming
 // response body for PII and applies the action. API envelope fields (id, created,
 // usage, model, etc.) are never scanned, preventing false positives on timestamps
-// and token counts.
+// and token counts. apiFamily selects the provider-native error envelope for
+// any block body it returns (#195) — "anthropic" or "openai".
 //
 //nolint:gocyclo // action dispatch + fail-closed scanner-error branches are kept together
-func scanResponseForPII(ctx context.Context, body []byte, action string, scanner classifier.Facade) ([]byte, *ResponsePIIScanResult) {
+func scanResponseForPII(ctx context.Context, apiFamily string, body []byte, action string, scanner classifier.Facade) ([]byte, *ResponsePIIScanResult) {
 	result := &ResponsePIIScanResult{}
 	if scanner == nil || action == "allow" || action == "" {
 		return body, result
@@ -113,7 +114,7 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 			result.ScannerFailure = scannerFailureKind(scanErr)
 			result.BlockReason = "output_scanner_unavailable"
 			log.Warn().Err(scanErr).Msg("response_pii_scanner_unavailable_blocked")
-			return scannerUnavailableBody(), result
+			return scannerUnavailableBody(apiFamily), result
 		}
 		log.Warn().Err(scanErr).Msg("response_pii_scanner_unavailable_warn")
 		return body, result
@@ -143,17 +144,13 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 			result.ScannerFailure = scannerFailureKind(redactErr)
 			result.BlockReason = "output_scanner_unavailable"
 			log.Warn().Err(redactErr).Msg("response_pii_redaction_failed_blocked")
-			return scannerUnavailableBody(), result
+			return scannerUnavailableBody(apiFamily), result
 		}
 		redactedText := extractResponseContentText(modified)
 		if err := scanner.VerifyEgress(ctx, redactedText); err != nil {
-			safeErr := map[string]interface{}{
-				"error": map[string]interface{}{
-					"message": residualPIIBlockMessage("Response blocked: recognized PII remains after redaction", classifier.ResidualTypes(err)),
-					"type":    "pii_policy_violation",
-				},
-			}
-			blocked, _ := json.Marshal(safeErr)
+			blocked := providerErrorBody(apiFamily, http.StatusUnavailableForLegalReasons,
+				residualPIIBlockMessage("Response blocked: recognized PII remains after redaction", classifier.ResidualTypes(err)),
+				"pii_policy_violation")
 			result.Redacted = true
 			result.Blocked = true
 			result.BlockReason = "output_residual_pii_after_redaction"
@@ -169,13 +166,8 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 		return modified, result
 
 	case "block":
-		safeErr := map[string]interface{}{
-			"error": map[string]interface{}{
-				"message": "Response blocked: contains PII that violates policy",
-				"type":    "pii_policy_violation",
-			},
-		}
-		blocked, _ := json.Marshal(safeErr)
+		blocked := providerErrorBody(apiFamily, http.StatusUnavailableForLegalReasons,
+			"Response blocked: contains PII that violates policy", "pii_policy_violation")
 		result.Redacted = true
 		result.Blocked = true
 		result.BlockReason = "output_pii_blocked"
@@ -194,16 +186,11 @@ func scanResponseForPII(ctx context.Context, body []byte, action string, scanner
 	return body, result
 }
 
-// scannerUnavailableBody is the JSON error returned when the PII scan engine
-// failed and the response was blocked fail-closed.
-func scannerUnavailableBody() []byte {
-	blocked, _ := json.Marshal(map[string]interface{}{
-		"error": map[string]interface{}{
-			"message": "Response blocked: PII scanner unavailable (fail-closed)",
-			"type":    "scanner_unavailable",
-		},
-	})
-	return blocked
+// scannerUnavailableBody is the provider-native JSON error returned when the
+// PII scan engine failed and the response was blocked fail-closed (#195).
+func scannerUnavailableBody(apiFamily string) []byte {
+	return providerErrorBody(apiFamily, http.StatusBadGateway,
+		"Response blocked: PII scanner unavailable (fail-closed)", "scanner_unavailable")
 }
 
 // scannerFailureKind returns the typed adapter failure kind (timeout,
@@ -513,6 +500,7 @@ func handleStreamingPIIScan(
 	ctx context.Context,
 	w http.ResponseWriter,
 	capture *responseCapture,
+	apiFamily string,
 	action string,
 	scanner classifier.Facade,
 ) *ResponsePIIScanResult {
@@ -539,7 +527,7 @@ func handleStreamingPIIScan(
 	cls, scanErr := scanner.Analyze(ctx, contentText)
 	if scanErr != nil {
 		if action == "block" || action == "redact" {
-			forwardScannerUnavailableResponse(w)
+			forwardScannerUnavailableResponse(w, apiFamily)
 			log.Warn().Err(scanErr).Msg("response_pii_scanner_unavailable_blocked_stream")
 			return &ResponsePIIScanResult{Blocked: true, ScannerFailure: scannerFailureKind(scanErr), BlockReason: "output_scanner_unavailable"}
 		}
@@ -578,7 +566,7 @@ func handleStreamingPIIScan(
 		if completedJSON != nil {
 			redacted, redactErr := redactResponseContentFields(ctx, completedJSON, scanner)
 			if redactErr != nil {
-				forwardScannerUnavailableResponse(w)
+				forwardScannerUnavailableResponse(w, apiFamily)
 				result.Redacted = true
 				result.Blocked = true
 				result.ScannerFailure = scannerFailureKind(redactErr)
@@ -587,7 +575,7 @@ func handleStreamingPIIScan(
 				break
 			}
 			if err := scanner.VerifyEgress(ctx, extractResponseContentText(redacted)); err != nil {
-				forwardBlockedResponse(w)
+				forwardBlockedResponse(w, apiFamily)
 				result.Redacted = true
 				result.Blocked = true
 				result.BlockReason = "output_residual_pii_after_redaction"
@@ -600,7 +588,7 @@ func handleStreamingPIIScan(
 		} else {
 			redactedContent, redactErr := scanner.RedactText(ctx, contentText)
 			if redactErr != nil {
-				forwardScannerUnavailableResponse(w)
+				forwardScannerUnavailableResponse(w, apiFamily)
 				result.Redacted = true
 				result.Blocked = true
 				result.ScannerFailure = scannerFailureKind(redactErr)
@@ -609,7 +597,7 @@ func handleStreamingPIIScan(
 				break
 			}
 			if err := scanner.VerifyEgress(ctx, redactedContent); err != nil {
-				forwardBlockedResponse(w)
+				forwardBlockedResponse(w, apiFamily)
 				result.Redacted = true
 				result.Blocked = true
 				result.BlockReason = "output_residual_pii_after_redaction"
@@ -627,7 +615,7 @@ func handleStreamingPIIScan(
 			Msg("response_pii_redacted_stream")
 
 	case "block":
-		forwardBlockedResponse(w)
+		forwardBlockedResponse(w, apiFamily)
 		result.Redacted = true
 		result.Blocked = true
 		result.BlockReason = "output_pii_blocked"
@@ -707,29 +695,24 @@ func forwardRedactedAsSSE(w http.ResponseWriter, capture *responseCapture, origi
 	_, _ = w.Write(buf.Bytes())
 }
 
-// forwardBlockedResponse writes a JSON error for blocked streaming requests.
-// Since the SSE stream was buffered (never written to w), we can override
-// Content-Type and set an appropriate status code.
-func forwardBlockedResponse(w http.ResponseWriter) {
+// forwardBlockedResponse writes a provider-native JSON error for blocked
+// streaming requests (#195). Since the SSE stream was buffered (never written
+// to w), we can override Content-Type and set an appropriate status code.
+func forwardBlockedResponse(w http.ResponseWriter, apiFamily string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnavailableForLegalReasons)
-	safeErr, _ := json.Marshal(map[string]interface{}{
-		"error": map[string]interface{}{
-			"message": "Response blocked: contains PII that violates policy",
-			"type":    "pii_policy_violation",
-		},
-	})
 	//nolint:gosec // G705: error response body (JSON), not HTML
-	_, _ = w.Write(safeErr)
+	_, _ = w.Write(providerErrorBody(apiFamily, http.StatusUnavailableForLegalReasons,
+		"Response blocked: contains PII that violates policy", "pii_policy_violation"))
 }
 
-// forwardScannerUnavailableResponse writes a JSON error when the PII scan
-// engine failed and the buffered stream was discarded fail-closed.
-func forwardScannerUnavailableResponse(w http.ResponseWriter) {
+// forwardScannerUnavailableResponse writes a provider-native JSON error when
+// the PII scan engine failed and the buffered stream was discarded fail-closed.
+func forwardScannerUnavailableResponse(w http.ResponseWriter, apiFamily string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadGateway)
 	//nolint:gosec // G705: error response body (JSON), not HTML
-	_, _ = w.Write(scannerUnavailableBody())
+	_, _ = w.Write(scannerUnavailableBody(apiFamily))
 }
 
 // extractCompletedResponseFromSSE finds the response.completed event or the

--- a/internal/gateway/response_pii_test.go
+++ b/internal/gateway/response_pii_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -72,7 +73,7 @@ func TestScanResponseForPII_Unit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, result := scanResponseForPII(ctx, []byte(tt.body), tt.action, scanner)
+			out, result := scanResponseForPII(ctx, "openai", []byte(tt.body), tt.action, scanner)
 			assert.Equal(t, tt.wantPII, result.PIIDetected)
 			if tt.wantRedacted {
 				assert.True(t, result.Redacted)
@@ -161,7 +162,7 @@ func TestScanResponseForPII_FalsePositivePrevention(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, result := scanResponseForPII(ctx, []byte(tt.body), "redact", scanner)
+			out, result := scanResponseForPII(ctx, "openai", []byte(tt.body), "redact", scanner)
 			assert.False(t, result.PIIDetected,
 				"no PII in content → no detection (envelope must not trigger false positive)")
 			assert.False(t, result.Redacted, "nothing to redact when no PII in content")
@@ -231,7 +232,7 @@ func TestScanResponseForPII_ContentPII_EnvelopePreserved(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, result := scanResponseForPII(ctx, []byte(tt.body), "redact", scanner)
+			out, result := scanResponseForPII(ctx, "openai", []byte(tt.body), "redact", scanner)
 			assert.True(t, result.PIIDetected, "PII in content should be detected")
 			assert.True(t, result.Redacted, "PII in content should be redacted")
 			outStr := string(out)
@@ -645,4 +646,60 @@ func TestGateway_ChatCompletions_StreamingNoPII(t *testing.T) {
 		"clean streaming response must pass through")
 	assert.Contains(t, respBody, "world",
 		"all delta content must be forwarded")
+}
+
+// #195: block bodies must be provider-native — Anthropic envelope on
+// anthropic-family routes, OpenAI envelope (with code) on openai routes.
+func TestScanResponseForPII_BlockBodyPerFamily(t *testing.T) {
+	scanner := classifier.MustNewScanner()
+	ctx := context.Background()
+	anthBody := `{"content":[{"type":"text","text":"mail jane.doe@example.com"}]}`
+
+	blocked, result := scanResponseForPII(ctx, "anthropic", []byte(anthBody), "block", scanner)
+	if result == nil || !result.Blocked {
+		t.Fatalf("expected block, got %+v", result)
+	}
+	var anthEnv struct {
+		Type  string `json:"type"`
+		Error struct{ Type, Message string }
+	}
+	if err := json.Unmarshal(blocked, &anthEnv); err != nil {
+		t.Fatalf("anthropic block body not JSON: %v: %s", err, blocked)
+	}
+	if anthEnv.Type != "error" || anthEnv.Error.Type != "pii_policy_violation" {
+		t.Errorf("anthropic block body must use the Anthropic envelope: %s", blocked)
+	}
+
+	oaiBody := `{"choices":[{"message":{"role":"assistant","content":"mail jane.doe@example.com"}}]}`
+	blockedOAI, resultOAI := scanResponseForPII(ctx, "openai", []byte(oaiBody), "block", scanner)
+	if resultOAI == nil || !resultOAI.Blocked {
+		t.Fatalf("expected block, got %+v", resultOAI)
+	}
+	var oaiEnv struct {
+		Error struct{ Message, Type, Code string }
+	}
+	if err := json.Unmarshal(blockedOAI, &oaiEnv); err != nil {
+		t.Fatalf("openai block body not JSON: %v", err)
+	}
+	if oaiEnv.Error.Type != "pii_policy_violation" || oaiEnv.Error.Code != "pii_policy_violation" {
+		t.Errorf("openai block body must use the OpenAI envelope with code: %s", blockedOAI)
+	}
+}
+
+// #195: streaming block/scanner-failure writers render per-family too.
+func TestForwardBlockedResponse_PerFamily(t *testing.T) {
+	w := httptest.NewRecorder()
+	forwardBlockedResponse(w, "anthropic")
+	if w.Code != http.StatusUnavailableForLegalReasons {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"type":"error"`) || !strings.Contains(w.Body.String(), `"pii_policy_violation"`) {
+		t.Errorf("anthropic streaming block body: %s", w.Body.String())
+	}
+
+	w2 := httptest.NewRecorder()
+	forwardScannerUnavailableResponse(w2, "anthropic")
+	if !strings.Contains(w2.Body.String(), `"type":"error"`) {
+		t.Errorf("anthropic scanner-unavailable body must be Anthropic-shaped: %s", w2.Body.String())
+	}
 }


### PR DESCRIPTION
First residual-burndown PR for #195 (per CPO/CTO direction after closing epic #192): items 1, 2, 3, and the item-6 doc note. Item 4 (mid-stream terminal events) follows as its own PR; item 5 (machine codes for all denials) lands with #142's contract table.

## What

1. **Valid Anthropic error types** — `WriteAnthropicError` with an empty machine code emitted `"type": "error"`, which is not in Anthropic's enum, so typed SDK handling (`authentication_error`, `rate_limit_error`, …) fell through to generic paths. Empty types now map from the HTTP status (`400→invalid_request_error`, `401→authentication_error`, `403→permission_error`, `404→not_found_error`, `413→request_too_large`, `429→rate_limit_error`, `529→overloaded_error`, other `5xx→api_error`). Machine codes from the documented prefix convention are preserved in `error.type` (final enum/code contract is #142's table). `TestWriteAnthropicError_StatusMappedTypes` pins the full mapping and that the literal `"error"` can never reappear.
2. **Response-PII block shape** — the 451 block, residual-PII block, and 502 scanner-unavailable bodies (both streaming writers and the non-streaming return-path) were bare `{"error":{…}}` on both families. All now render via a new `providerErrorBody` that reuses the exact envelope structs from `errors.go` (reviewer bar: no second envelope implementation). Anthropic routes get `{"type":"error","error":{…}}`; OpenAI routes gain the `code` field. Pinned by `TestScanResponseForPII_BlockBodyPerFamily` + `TestForwardBlockedResponse_PerFamily`.
3. **Semantic-cache hit shape** — `writeCachedCompletion` emitted OpenAI chat-completion JSON on anthropic routes; now returns a proper Messages object (`type: message`, content block, `stop_reason: end_turn`). Pinned by `TestWriteCachedCompletion_AnthropicShape`.
4. **Item-6 doc** — pre-route errors (unknown provider prefix) intentionally keep the OpenAI shape; documented in the governing guide with the rationale (no wire family resolved yet).

## Not in this PR (per checklist scoping)
- Mid-stream terminal events (Anthropic `event: error`; Responses `response.failed`) — next PR; needs careful streaming work.
- Machine codes for the remaining denial reasons — with #142.

Full gateway/server/cmd + integration suites green; repo-config lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-visible JSON on denials, PII blocks, and cache hits across both wire families; behavior is contract-aligned and heavily tested, but any mistake could break Claude-family SDK parsing or cache consumers.
> 
> **Overview**
> Gateway responses on Anthropic-family routes now match what clients and SDKs expect instead of generic or wrong-wire JSON.
> 
> **Anthropic denials:** When no machine code is present, `WriteAnthropicError` no longer sets `error.type` to the invalid literal `"error"`; it maps from HTTP status to Anthropic’s enum (e.g. 403 → `permission_error`). Documented machine codes such as `session_budget_exceeded` are unchanged.
> 
> **Response-PII and scanner failures:** Block (451), residual-PII, and scanner-unavailable (502) bodies—non-streaming and buffered streaming—used a bare `{"error":{…}}` on every route. They now go through shared `providerErrorBody` (same structs as `Write*Error`): Anthropic gets `{"type":"error","error":{…}}`; OpenAI gets the usual envelope including `code`. The handler passes `wire` / `apiFamily` into `scanResponseForPII` and the streaming helpers.
> 
> **Semantic cache:** Cache hits on anthropic routes return an Anthropic Messages object (`type: message`, text block, `stop_reason: end_turn`) instead of an OpenAI chat completion.
> 
> **Docs:** `governing-coding-agents.md` notes that errors before routing (unknown provider) intentionally stay OpenAI-shaped; CHANGELOG records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4bda0b27f75ae15856529786834fcfc2066e3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->