### PR TITLE
feat: pricing currency (#216) + governed-session real-provider demo (#107)

### DIFF
--- a/.github/workflows/governed-session.yml
+++ b/.github/workflows/governed-session.yml
@@ -1,0 +1,53 @@
+# Verifies the #107 Act II governed-session demo against REAL providers.
+# Spends real money (~$0.05/run, cheap models, session-capped), so it never
+# runs on PRs: nightly + manual dispatch on main only, and it skips cleanly
+# when the repo secrets are not configured (e.g. forks).
+name: Governed Session Demo
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: governed-session demo (#107 Act II, real providers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.DEMO_ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.DEMO_OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check demo secrets
+        id: secrets
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ] || [ -z "$OPENAI_API_KEY" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "DEMO_ANTHROPIC_API_KEY / DEMO_OPENAI_API_KEY not configured — skipping real-provider run."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start stack (real providers)
+        if: steps.secrets.outputs.configured == 'true'
+        run: make governed-session
+
+      - name: Run full governed session
+        if: steps.secrets.outputs.configured == 'true'
+        working-directory: examples/governed-session
+        run: ./demo.sh all
+
+      - name: Compose logs on failure
+        if: failure() && steps.secrets.outputs.configured == 'true'
+        working-directory: examples/governed-session
+        run: docker compose logs --tail 200 || true
+
+      - name: Teardown
+        if: always() && steps.secrets.outputs.configured == 'true'
+        working-directory: examples/governed-session
+        run: docker compose down -v || true

--- a/.github/workflows/shortlist-demo.yml
+++ b/.github/workflows/shortlist-demo.yml
@@ -1,0 +1,52 @@
+# Rot-guard for the #107 shortlist demo (Act I, mock provider, no API key):
+# the demo is a top-of-funnel conversion asset — if it breaks, the first
+# thing an evaluator runs fails. Path-gated on PRs, always on main pushes,
+# plus a nightly run to catch cross-cutting breakage the path list misses.
+name: Shortlist Demo
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/shortlist-demo/**'
+      - 'examples/docker-compose/mock-provider/**'
+      - 'scripts/verify-shortlist-demo.sh'
+      - 'scripts/shortlist-demo-up.sh'
+      - 'scripts/lib/**'
+      - 'internal/gateway/**'
+      - 'internal/policy/**'
+      - 'internal/classifier/**'
+      - 'internal/evidence/**'
+      - 'internal/compliance/**'
+      - 'internal/cmd/**'
+      - 'internal/pricing/**'
+      - 'Dockerfile'
+      - 'go.mod'
+      - 'go.sum'
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify-shortlist-demo (#107 Act I)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shortlist demo verification
+        env:
+          # Keep containers for the failure log dump; the runner VM is
+          # discarded anyway.
+          SHORTLIST_SKIP_DOWN: "1"
+        run: make verify-shortlist-demo
+
+      - name: Compose logs on failure
+        if: failure()
+        working-directory: examples/shortlist-demo
+        run: docker compose logs --tail 200 || true

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ verify-shortlist-demo: ## Run full #107 shortlist demo verification (Docker)
 coding-agents-demo: ## Run #203 coding-agents demo (multi-model orchestration, offline mock, Docker)
 	@cd examples/coding-agents-demo && docker compose up -d --build --wait && ./demo.sh all
 
+governed-session: ## Start #107 governed-session demo stack (REAL providers; needs ANTHROPIC_API_KEY + OPENAI_API_KEY)
+	@bash scripts/governed-session-up.sh
+
 # Provider registry and EU routing
 provider-list: build ## List registered LLM providers (compliance metadata)
 	@./bin/$(BINARY_NAME) provider list

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [Roadmap & focus](ROADMAP.md) ·
 [Quickstart](docs/tutorials/proxy-quickstart.md) ·
 [Docker demo](examples/docker-compose/README.md) ·
+[Governed session demo](examples/governed-session/README.md) ·
 [Dashboard](docs/reference/gateway-dashboard.md) ·
 [Limitations](LIMITATIONS.md) ·
 [Releases](https://github.com/dativo-io/talon/releases/latest)
@@ -68,6 +69,30 @@ docker compose exec talon /usr/local/bin/talon audit show <evidence-id>
 ```
 
 The record shows the PII detected (email, IBAN), the data tier, the policy decision, the cost, and a verifiable HMAC signature. Full walk-through: [60-second demo](docs/tutorials/quickstart-demo.md).
+
+---
+
+## Governed session demo (real providers, one budget)
+
+The deeper proof path runs one **real** agent session — an Anthropic planner and OpenAI executors — through the same gateway, bring-your-own keys (≈ $0.05/run, cheap models, session-capped):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-... OPENAI_API_KEY=sk-...
+make governed-session
+cd examples/governed-session && ./demo.sh all
+```
+
+```
+session begins ──▶ Anthropic planner (prompt-cache write, then read)
+               ──▶ OpenAI executors (cached_tokens; forbidden admin_* tool stripped)
+               ──▶ IBAN probe denied before any provider call
+               ──▶ real cross-provider spend reaches the session cap
+               ──▶ next estimated request rejected: 403 session_budget_exceeded
+               ──▶ money story: misleading naïve total vs Talon's cache-aware corrected total
+               ──▶ talon audit verify --session → N record(s), N valid, 0 invalid
+```
+
+Cache writes bill at 1.25× the input rate and cache reads at ~0.1× — Talon prices them exactly and enforces the budget against the corrected number, in the pricing table's declared currency. Every decision, including both denials, is a signed evidence record in one session trail: supporting controls and evidence for GDPR and EU AI Act reviews, not a compliance guarantee. Full walk-through: [governed-session demo](examples/governed-session/README.md). The six-proof mock demo above needs no keys; this one shows the same controls on live traffic.
 
 ---
 

--- a/examples/governed-session/README.md
+++ b/examples/governed-session/README.md
@@ -1,0 +1,91 @@
+# Governed session demo — real providers, one budget, signed evidence (#107 Act II)
+
+One agent session against **real** Anthropic and OpenAI APIs, end to end through
+Talon's enforce-mode gateway:
+
+```
+session begins (X-Talon-Session-ID)
+  ↓  Anthropic planner call    — cache_control prefix → real prompt-cache WRITE
+  ↓  Anthropic planner call 2  — same prefix → real prompt-cache READ (~0.1× rate)
+  ↓  OpenAI executor calls     — shared prefix → cached_tokens reads; admin_* tool stripped
+  ↓  PII probe                 — IBAN denied before any provider call (HTTP 400)
+  ↓  executor loop             — REAL cross-provider spend accumulates per session
+  ↓  next estimated request    — 403 session_budget_exceeded, pre-forward
+  ↓  money story               — misleading naïve total vs Talon's cache-aware corrected total
+  ↓  talon audit verify --session → N record(s), N valid, 0 invalid
+```
+
+This is not a mock: token counts, cache hits, and costs come from the providers'
+own usage fields, parsed and priced by Talon, and every decision (including both
+denials) is an HMAC-signed evidence record in one session trail.
+
+## Prerequisites
+
+- Docker (compose v2), `curl`, `jq`
+- Real API keys. A full run uses cheap models and is session-capped:
+  **≈ $0.05 per run**.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+```
+
+The keys go into Talon's encrypted secret vault inside the container and are
+used only for upstream auth — never logged, never stored in evidence.
+`log_prompts`/`log_responses` are off: prompt bodies stay out of storage.
+
+## Run it
+
+```bash
+make governed-session          # from repo root: builds + starts + waits for health
+cd examples/governed-session
+./demo.sh all                  # the full narrated session (~2 minutes)
+```
+
+Individual acts: `planner-write`, `planner-read`, `executors`, `pii-probe`,
+`budget-gate`, `money-story`, `verify`.
+
+## The money story (why naïve cost math misleads)
+
+Both providers discount cached prompt tokens — Anthropic bills cache **writes**
+at 1.25× the input rate and cache **reads** at ~0.1×; OpenAI discounts
+`cached_tokens`. A naïve `input_tokens × input_rate` total therefore misprices
+exactly the workloads agents create (long shared prefixes, many calls).
+
+Talon parses `cache_creation_input_tokens` / `cache_read_input_tokens`
+(Anthropic) and `prompt_tokens_details.cached_tokens` (OpenAI) into evidence
+(`cache_write` / `cache_read`), prices them with the per-model cache rates in
+[pricing/models.yaml](../../pricing/models.yaml), and enforces the session
+budget against that **corrected** number. `./demo.sh money-story` prints both
+totals from your live run and leaves the signed export in
+`out/session-evidence.json` so you can recompute them yourself.
+
+Costs display in the pricing table's declared `currency:` (USD for the shipped
+table). Budget caps (`max_session_cost`, `max_daily_cost`) are denominated in
+the same unit.
+
+## What each proof shows
+
+| # | Proof | Signal |
+|---|-------|--------|
+| 1 | Planner cache write | `audit show`: `cache_write > 0`, pricing basis `table` |
+| 2 | Planner cache read | `cache_read > 0` — naïve math is already wrong here |
+| 3 | Executors + tool governance | `ToolGovernance`: `admin_purge_records` requested, filtered; `search_kb` forwarded |
+| 4 | PII stop | HTTP 400, `POLICY_DENIED_PII_INPUT`, zero upstream cost |
+| 5 | Session budget gate | HTTP 403, `session_budget_exceeded: session spend … + estimate … exceeds limit …` with `SessionBudget{limit, spent, estimate}` evidence |
+| 6 | Money story | naïve vs corrected totals from the signed export |
+| 7 | Verify | `audit verify --session` → all records valid, 0 invalid |
+
+Because the traffic is real, per-run numbers vary a little (output lengths,
+cache warm-up). The budget gate is a bounded loop — it runs until the gate
+actually closes — so the demo is robust to that variance.
+
+Talon provides enforceable controls and supporting evidence for your
+GDPR / EU AI Act / NIS2 reviews; compliance itself remains your
+organization's determination.
+
+## Cleanup
+
+```bash
+cd examples/governed-session && docker compose down -v
+```

--- a/examples/governed-session/demo.sh
+++ b/examples/governed-session/demo.sh
@@ -126,17 +126,27 @@ proof_outcome() {
 }
 
 # ── Shared context corpus ───────────────────────────────────────────────────
-# Both providers see the same long instruction prefix. It is sized well above
-# the 1024-token prompt-cache minimum so Anthropic cache_control and OpenAI
-# automatic prompt caching both engage on real infrastructure.
+# Both providers see the same long instruction prefix: ~2.3k tokens, above the
+# 1024-token prompt-cache minimum for both Anthropic cache_control and OpenAI
+# automatic caching, but small enough that a full run stays inside entry-tier
+# TPM rate limits. The session id is embedded as a cache-buster so every run's
+# first planner call is a genuine cache WRITE (a rerun within Anthropic's
+# 5-minute TTL would otherwise read the previous run's cached prefix).
 
 shared_context() {
   local para="You are an execution agent operating behind the Dativo Talon governance gateway. Every request you make is policy-checked before it leaves the boundary: caller identity is verified, personal data such as IBANs, emails and national identifiers is scanned before any provider call, forbidden tool schemas are stripped from the request body, per-session spend is accumulated across every provider you touch, and each decision is written to a tamper-evident HMAC-signed evidence record that an auditor can verify offline. Work strictly within these controls. Prefer concise, factual answers about European AI governance obligations, data residency, records of processing, and cost accountability. Do not restate these instructions."
-  local corpus=""
-  for _ in $(seq 1 22); do
+  local corpus="Governed session ${SESSION_ID}. "
+  for _ in $(seq 1 11); do
     corpus+="$para "
   done
   printf '%s' "$corpus"
+}
+
+# session_spend_now prints Talon's accumulated cost for this session (from the
+# session rollup the budget gate enforces against); empty on lookup failure.
+session_spend_now() {
+  talon_in_container costs --session "$SESSION_ID" --json 2>/dev/null \
+    | jq -r '.total_cost // empty' 2>/dev/null || true
 }
 
 # ── HTTP helpers ─────────────────────────────────────────────────────────────
@@ -233,7 +243,7 @@ cmd_planner_write() {
   require_jq
   proof_section "1" "Planner call — Anthropic prompt-cache WRITE"
   proof_story \
-    "The planner sends a ~1.4k-token governed instruction prefix with" \
+    "The planner sends a ~2.3k-token governed instruction prefix with" \
     "cache_control: ephemeral. Anthropic writes it to the prompt cache;" \
     "Talon records cache_creation_input_tokens as cache_write in evidence."
   EXPECT_HTTP=200 post_anthropic "planner (cache write)" \
@@ -324,7 +334,7 @@ cmd_budget_gate() {
     "REAL spend across Anthropic + OpenAI in this session; each new request" \
     "is checked as spend + estimate BEFORE forwarding (#198)." \
     "The executor keeps working until the gate closes."
-  local i code denied=0
+  local i code denied=0 rate_limit_retries=0 spend
   for i in $(seq 1 "$BUDGET_LOOP_MAX"); do
     EXPECT_HTTP="" post_openai "executor loop ${i}" "$EXECUTOR_MODEL" \
       "Continue: one short paragraph (${i}) on AI cost accountability."
@@ -333,14 +343,37 @@ cmd_budget_gate() {
       denied=1
       break
     fi
+    if [[ "$code" == "429" ]]; then
+      # Provider-side rate limit (TPM), not a governance decision: back off
+      # and retry — the budget gate must close before we give up.
+      rate_limit_retries=$((rate_limit_retries + 1))
+      if [[ "$rate_limit_retries" -gt 5 ]]; then
+        echo "✗ Provider rate-limited 5x in a row; rerun in a minute" >&2
+        exit 1
+      fi
+      echo "  … provider 429 (rate limit), waiting 12s and retrying"
+      sleep 12
+      continue
+    fi
+    rate_limit_retries=0
     if [[ "$code" != "200" ]]; then
       echo "✗ Unexpected HTTP ${code} during budget loop" >&2
       cat "${OUT_DIR}/last-response.json" >&2 || true
       exit 1
     fi
+    spend="$(session_spend_now)"
+    echo "  session spend (Talon evidence): ${spend:-unknown} / cap 0.04"
   done
   if [[ "$denied" != "1" ]]; then
     echo "✗ Session budget gate did not close within ${BUDGET_LOOP_MAX} calls" >&2
+    echo "  Diagnosis — what the gate should have seen:" >&2
+    echo "    session spend (talon costs --session): $(session_spend_now)" >&2
+    echo "    caller cap (config): 0.04" >&2
+    echo "  Session-store health (talon serve logs):" >&2
+    dc logs talon 2>&1 | grep -iE 'session_(create|usage|budget)' | tail -5 >&2 || true
+    echo "  Evidence annotations (session_budget_unavailable = store read failed, gate failed open):" >&2
+    talon_in_container audit export --session "$SESSION_ID" --format json 2>/dev/null \
+      | jq -r '.records[] | select((.gateway_annotations // []) | length > 0) | "    " + .id + ": " + ((.gateway_annotations // []) | join(","))' >&2 || true
     exit 1
   fi
   if ! grep -q "session_budget_exceeded" "${OUT_DIR}/last-response.json"; then

--- a/examples/governed-session/demo.sh
+++ b/examples/governed-session/demo.sh
@@ -274,7 +274,14 @@ cmd_executors() {
   EXPECT_HTTP=200 post_openai "executor 1" "$EXECUTOR_MODEL" \
     "Execute step 1: one paragraph on GDPR Art. 30 records for AI traffic."
   local tools
-  tools='[{"type":"function","function":{"name":"admin_purge_records","description":"Delete all evidence records","parameters":{"type":"object","properties":{}}}},{"type":"function","function":{"name":"search_kb","description":"Search the internal knowledge base","parameters":{"type":"object","properties":{"q":{"type":"string"}}}}]'
+  tools="$(jq -nc '[
+    {type: "function", function: {name: "admin_purge_records",
+      description: "Delete all evidence records",
+      parameters: {type: "object", properties: {}}}},
+    {type: "function", function: {name: "search_kb",
+      description: "Search the internal knowledge base",
+      parameters: {type: "object", properties: {q: {type: "string"}}}}}
+  ]')"
   EXPECT_HTTP=200 post_openai "executor 2 (admin_* tool stripped)" "$EXECUTOR_MODEL" \
     "Execute step 2: one paragraph on evidence retention duties. Use search_kb if useful." \
     "$tools"

--- a/examples/governed-session/demo.sh
+++ b/examples/governed-session/demo.sh
@@ -135,7 +135,13 @@ proof_outcome() {
 
 shared_context() {
   local para="You are an execution agent operating behind the Dativo Talon governance gateway. Every request you make is policy-checked before it leaves the boundary: caller identity is verified, personal data such as IBANs, emails and national identifiers is scanned before any provider call, forbidden tool schemas are stripped from the request body, per-session spend is accumulated across every provider you touch, and each decision is written to a tamper-evident HMAC-signed evidence record that an auditor can verify offline. Work strictly within these controls. Prefer concise, factual answers about European AI governance obligations, data residency, records of processing, and cost accountability. Do not restate these instructions."
-  local corpus="Governed session ${SESSION_ID}. "
+  # The buster must be strictly alphabetic: the raw session id ends in epoch
+  # seconds, and a 10-digit run in the BODY pattern-matches phone/national-id
+  # PII recognizers — the gateway would (correctly) block the demo's own
+  # prefix under default_pii_action: block.
+  local run_marker
+  run_marker="$(printf '%s' "$SESSION_ID" | tr '0-9' 'abcdefghij')"
+  local corpus="Governed session ${run_marker}. "
   for _ in $(seq 1 11); do
     corpus+="$para "
   done

--- a/examples/governed-session/demo.sh
+++ b/examples/governed-session/demo.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# Governed-session demo driver (#107 Act II) — REAL Anthropic + OpenAI traffic.
+#
+# Usage (from examples/governed-session, stack running on localhost:8080):
+#   ./demo.sh planner-write
+#   ./demo.sh planner-read
+#   ./demo.sh executors
+#   ./demo.sh pii-probe
+#   ./demo.sh budget-gate
+#   ./demo.sh money-story
+#   ./demo.sh verify
+#   ./demo.sh all
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GATEWAY="${GATEWAY:-http://localhost:8080}"
+OUT_DIR="${OUT_DIR:-${SCRIPT_DIR}/out}"
+SESSION_ID="${SESSION_ID:-sess-governed-$(date +%s)}"
+TENANT_KEY="talon-session-demo"
+PLANNER_MODEL="claude-sonnet-5"
+EXECUTOR_MODEL="gpt-4o"
+PROBE_MODEL="gpt-4o-mini"
+BUDGET_LOOP_MAX=12
+NARRATE=0
+PROOF_TOTAL=7
+
+# Rates mirrored from pricing/models.yaml (per 1M tokens, table currency) for
+# the narrated naïve-vs-corrected arithmetic. The CORRECTED total is never
+# computed here — it is read from Talon's signed evidence; these rates only
+# reconstruct the misleading naïve figure.
+SONNET_IN_RATE=3.00
+SONNET_OUT_RATE=15.00
+GPT4O_IN_RATE=2.50
+GPT4O_OUT_RATE=10.00
+
+readonly DEMO_SEP='─────────────────────────────────────────────────────'
+readonly DEMO_WIDE_SEP='─────────────────────────────────────────────────────────'
+
+mkdir -p "$OUT_DIR"
+echo "$SESSION_ID" >"${OUT_DIR}/session-id"
+
+# shellcheck source=../../scripts/lib/docker-compose-detect.sh
+source "${SCRIPT_DIR}/../../scripts/lib/docker-compose-detect.sh"
+detect_docker_compose
+
+dc() {
+  $COMPOSE "$@"
+}
+
+talon_in_container() {
+  dc exec -T talon talon "$@"
+}
+
+require_stack() {
+  if ! curl -sf "${GATEWAY}/health" >/dev/null 2>&1; then
+    echo "✗ Talon gateway not healthy at ${GATEWAY}" >&2
+    echo "  → export ANTHROPIC_API_KEY=… OPENAI_API_KEY=…; make governed-session" >&2
+    exit 1
+  fi
+}
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "✗ jq is required for the governed-session demo" >&2
+    exit 1
+  fi
+}
+
+# ── Output helpers (mirrors shortlist demo / talon CLI style) ───────────────
+
+demo_intro() {
+  [[ "$NARRATE" == "1" ]] || return 0
+  echo ""
+  echo "🦅 Dativo Talon — Governed Session Demo (#107 Act II)"
+  echo "$DEMO_WIDE_SEP"
+  echo "One real agent session, two real providers, one session budget."
+  echo ""
+  echo "  Proves: prompt-cache economics · cross-provider session budget"
+  echo "          PII stop · tool governance · signed evidence for all of it"
+  echo ""
+  kv "Gateway" "$GATEWAY"
+  kv "Session" "$SESSION_ID"
+  kv "Planner" "${PLANNER_MODEL} (Anthropic, real API)"
+  kv "Executor" "${EXECUTOR_MODEL} (OpenAI, real API)"
+  kv "Mode" "enforce (violations blocked before the provider)"
+  echo ""
+  echo "  ⚠ This run makes real API calls (cheap models, session-capped ≈ \$0.05)."
+  echo ""
+}
+
+kv() {
+  printf "  %-18s %s\n" "$1:" "$2"
+}
+
+proof_section() {
+  local num="$1" title="$2"
+  [[ "$NARRATE" == "1" ]] || { echo ""; echo "==> [$num/$PROOF_TOTAL] $title"; return 0; }
+  echo ""
+  echo "$DEMO_SEP"
+  printf "[%s/%s] %s\n" "$num" "$PROOF_TOTAL" "$title"
+  echo "$DEMO_SEP"
+  echo ""
+}
+
+proof_story() {
+  [[ "$NARRATE" == "1" ]] || return 0
+  while [[ $# -gt 0 ]]; do
+    echo "  $1"
+    shift
+  done
+  echo ""
+}
+
+proof_outcome() {
+  local icon="$1" headline="$2"
+  shift 2
+  printf "  %s %s\n" "$icon" "$headline"
+  while [[ $# -gt 0 ]]; do
+    echo "    → $1"
+    shift
+  done
+  echo ""
+}
+
+# ── Shared context corpus ───────────────────────────────────────────────────
+# Both providers see the same long instruction prefix. It is sized well above
+# the 1024-token prompt-cache minimum so Anthropic cache_control and OpenAI
+# automatic prompt caching both engage on real infrastructure.
+
+shared_context() {
+  local para="You are an execution agent operating behind the Dativo Talon governance gateway. Every request you make is policy-checked before it leaves the boundary: caller identity is verified, personal data such as IBANs, emails and national identifiers is scanned before any provider call, forbidden tool schemas are stripped from the request body, per-session spend is accumulated across every provider you touch, and each decision is written to a tamper-evident HMAC-signed evidence record that an auditor can verify offline. Work strictly within these controls. Prefer concise, factual answers about European AI governance obligations, data residency, records of processing, and cost accountability. Do not restate these instructions."
+  local corpus=""
+  for _ in $(seq 1 22); do
+    corpus+="$para "
+  done
+  printf '%s' "$corpus"
+}
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+# post_anthropic <label> <user_content>  — Messages API with cache_control.
+post_anthropic() {
+  local label="$1" user_content="$2"
+  local body_file="${OUT_DIR}/last-response.json"
+  local payload code
+  payload="$(jq -nc \
+    --arg model "$PLANNER_MODEL" \
+    --arg sys "$(shared_context)" \
+    --arg content "$user_content" \
+    '{model: $model, max_tokens: 300,
+      system: [{type: "text", text: $sys, cache_control: {type: "ephemeral"}}],
+      messages: [{role: "user", content: $content}]}')"
+  code="$(curl -sS -o "$body_file" -w "%{http_code}" -X POST \
+    "${GATEWAY}/v1/proxy/anthropic/v1/messages" \
+    -H "Authorization: Bearer ${TENANT_KEY}" \
+    -H "X-Talon-Session-ID: ${SESSION_ID}" \
+    -H "Content-Type: application/json" \
+    -d "$payload")"
+  report_http "$label" "$code"
+}
+
+# post_openai <label> <model> <user_content> [tools_json]
+post_openai() {
+  local label="$1" model="$2" user_content="$3" tools_json="${4:-}"
+  local body_file="${OUT_DIR}/last-response.json"
+  local payload code
+  if [[ -n "$tools_json" ]]; then
+    payload="$(jq -nc \
+      --arg model "$model" \
+      --arg sys "$(shared_context)" \
+      --arg content "$user_content" \
+      --argjson tools "$tools_json" \
+      '{model: $model, max_tokens: 200, tools: $tools,
+        messages: [{role: "system", content: $sys}, {role: "user", content: $content}]}')"
+  else
+    payload="$(jq -nc \
+      --arg model "$model" \
+      --arg sys "$(shared_context)" \
+      --arg content "$user_content" \
+      '{model: $model, max_tokens: 200,
+        messages: [{role: "system", content: $sys}, {role: "user", content: $content}]}')"
+  fi
+  code="$(curl -sS -o "$body_file" -w "%{http_code}" -X POST \
+    "${GATEWAY}/v1/proxy/openai/v1/chat/completions" \
+    -H "Authorization: Bearer ${TENANT_KEY}" \
+    -H "X-Talon-Session-ID: ${SESSION_ID}" \
+    -H "Content-Type: application/json" \
+    -d "$payload")"
+  report_http "$label" "$code"
+}
+
+LAST_HTTP=""
+report_http() {
+  local label="$1" code="$2"
+  LAST_HTTP="$code"
+  local body_file="${OUT_DIR}/last-response.json"
+  if [[ "$NARRATE" == "1" ]]; then
+    kv "Request" "$label"
+    kv "HTTP status" "$code"
+    local excerpt
+    excerpt="$(jq -r '.error.message // .content[0].text // .choices[0].message.content // empty' "$body_file" 2>/dev/null | tr '\n' ' ' | head -c 110)"
+    [[ -n "$excerpt" ]] && kv "Response" "${excerpt}…"
+    echo ""
+  else
+    echo "    ${label}: HTTP ${code}"
+  fi
+  if [[ "${EXPECT_HTTP:-}" != "" && "$code" != "${EXPECT_HTTP}" ]]; then
+    echo "✗ Expected HTTP ${EXPECT_HTTP}, got ${code}" >&2
+    cat "$body_file" >&2 || true
+    exit 1
+  fi
+}
+
+latest_evidence_id() {
+  talon_in_container audit list --limit 1 2>/dev/null | grep -oE '(gw_|req_)[a-zA-Z0-9_-]+' | head -1
+}
+
+show_evidence_lines() {
+  local id="$1"
+  [[ -n "$id" ]] || return 0
+  talon_in_container audit show "$id" 2>/dev/null \
+    | grep -E '^(Allowed:|  Reason:|Cost:|Tokens:|Pricing Basis:)|POLICY_' | sed 's/^/    /' || true
+  echo ""
+}
+
+# ── Acts ─────────────────────────────────────────────────────────────────────
+
+cmd_planner_write() {
+  require_stack
+  require_jq
+  proof_section "1" "Planner call — Anthropic prompt-cache WRITE"
+  proof_story \
+    "The planner sends a ~1.4k-token governed instruction prefix with" \
+    "cache_control: ephemeral. Anthropic writes it to the prompt cache;" \
+    "Talon records cache_creation_input_tokens as cache_write in evidence."
+  EXPECT_HTTP=200 post_anthropic "planner (cache write)" \
+    "Plan three short executor steps to summarize EU AI Act evidence duties for a mid-market SaaS."
+  local id
+  id="$(latest_evidence_id)"
+  [[ "$NARRATE" == "1" ]] && show_evidence_lines "$id"
+  proof_outcome "✓" "Planner forwarded — cache write recorded in signed evidence" \
+    "audit show shows cache_write > 0 and its exact cost basis"
+}
+
+cmd_planner_read() {
+  require_stack
+  require_jq
+  proof_section "2" "Planner refinement — Anthropic prompt-cache READ"
+  proof_story \
+    "The second planner call reuses the identical prefix within the cache TTL:" \
+    "Anthropic bills those tokens at the cache-read rate (~0.1× input)." \
+    "Naïve input×rate math is already wrong from this call onward."
+  EXPECT_HTTP=200 post_anthropic "planner (cache read)" \
+    "Refine the plan: fold step three into step two and keep it terse."
+  local id
+  id="$(latest_evidence_id)"
+  [[ "$NARRATE" == "1" ]] && show_evidence_lines "$id"
+  proof_outcome "✓" "Cache read recorded — cache_read tokens priced at the read rate" \
+    "Same session, same signed trail, cross-provider spend accumulating"
+}
+
+cmd_executors() {
+  require_stack
+  require_jq
+  proof_section "3" "Executor calls — OpenAI cached prompt + tool governance"
+  proof_story \
+    "Executors share the same long prefix, so OpenAI's automatic prompt cache" \
+    "reports cached_tokens on repeat calls. Executor 2 also requests tools —" \
+    "including admin_purge_records, which policy forbids (admin_*)." \
+    "Talon strips it from the request body before the model can see it."
+  EXPECT_HTTP=200 post_openai "executor 1" "$EXECUTOR_MODEL" \
+    "Execute step 1: one paragraph on GDPR Art. 30 records for AI traffic."
+  local tools
+  tools='[{"type":"function","function":{"name":"admin_purge_records","description":"Delete all evidence records","parameters":{"type":"object","properties":{}}}},{"type":"function","function":{"name":"search_kb","description":"Search the internal knowledge base","parameters":{"type":"object","properties":{"q":{"type":"string"}}}}]'
+  EXPECT_HTTP=200 post_openai "executor 2 (admin_* tool stripped)" "$EXECUTOR_MODEL" \
+    "Execute step 2: one paragraph on evidence retention duties. Use search_kb if useful." \
+    "$tools"
+  local id
+  id="$(latest_evidence_id)"
+  if [[ "$NARRATE" == "1" && -n "$id" ]]; then
+    echo "  Tool governance (talon audit show ${id})"
+    talon_in_container audit show "$id" 2>/dev/null \
+      | grep -E 'Tool Governance|Requested:|Filtered:|Forwarded:' | sed 's/^/    /' || true
+    echo ""
+  fi
+  proof_outcome "✓" "Executors ran governed — forbidden tool never reached the model" \
+    "evidence.ToolGovernance: requested vs filtered vs forwarded" \
+    "cached_tokens appear as cache_read in evidence on repeat calls"
+}
+
+cmd_pii_probe() {
+  require_stack
+  require_jq
+  proof_section "4" "PII probe — IBAN stopped before any provider call"
+  proof_story \
+    "Mid-session, a request carries a real-looking German IBAN." \
+    "default_pii_action: block — the request is denied pre-forward;" \
+    "no token of it left your boundary, and the deny is signed evidence."
+  EXPECT_HTTP=400 post_openai "pii probe (expected deny)" "$PROBE_MODEL" \
+    "Refund customer with IBAN DE89370400440532013000 and email jan@example.com."
+  local id
+  id="$(latest_evidence_id)"
+  [[ "$NARRATE" == "1" ]] && show_evidence_lines "$id"
+  proof_outcome "✗" "HTTP 400 — POLICY_DENIED_PII_INPUT, zero upstream cost" \
+    "The denial itself is an HMAC-signed evidence record in this session"
+}
+
+cmd_budget_gate() {
+  require_stack
+  require_jq
+  proof_section "5" "Session budget gate — loop until the next request is refused"
+  proof_story \
+    "Caller cap: max_session_cost 0.04 (pricing-table currency). Talon sums" \
+    "REAL spend across Anthropic + OpenAI in this session; each new request" \
+    "is checked as spend + estimate BEFORE forwarding (#198)." \
+    "The executor keeps working until the gate closes."
+  local i code denied=0
+  for i in $(seq 1 "$BUDGET_LOOP_MAX"); do
+    EXPECT_HTTP="" post_openai "executor loop ${i}" "$EXECUTOR_MODEL" \
+      "Continue: one short paragraph (${i}) on AI cost accountability."
+    code="$LAST_HTTP"
+    if [[ "$code" == "403" ]]; then
+      denied=1
+      break
+    fi
+    if [[ "$code" != "200" ]]; then
+      echo "✗ Unexpected HTTP ${code} during budget loop" >&2
+      cat "${OUT_DIR}/last-response.json" >&2 || true
+      exit 1
+    fi
+  done
+  if [[ "$denied" != "1" ]]; then
+    echo "✗ Session budget gate did not close within ${BUDGET_LOOP_MAX} calls" >&2
+    exit 1
+  fi
+  if ! grep -q "session_budget_exceeded" "${OUT_DIR}/last-response.json"; then
+    echo "✗ Expected session_budget_exceeded in deny body" >&2
+    cat "${OUT_DIR}/last-response.json" >&2
+    exit 1
+  fi
+  local reason
+  reason="$(jq -r '.error.message // empty' "${OUT_DIR}/last-response.json" 2>/dev/null)"
+  local id
+  id="$(latest_evidence_id)"
+  [[ "$NARRATE" == "1" ]] && show_evidence_lines "$id"
+  proof_outcome "✗" "HTTP 403 — denied pre-forward, nothing was spent on this request" \
+    "Reason: ${reason}" \
+    "Evidence carries SessionBudget{limit, spent, estimate} for auditors"
+}
+
+cmd_money_story() {
+  require_stack
+  require_jq
+  proof_section "6" "Money story — misleading naïve total vs Talon's corrected total"
+  proof_story \
+    "Naïve accounting prices every input-side token at the full input rate." \
+    "Talon's evidence prices cache writes at 1.25× and cache reads at ~0.1×," \
+    "exactly as the providers bill. Same session, two very different numbers."
+  local export_file="${OUT_DIR}/session-evidence.json"
+  talon_in_container audit export --session "$SESSION_ID" --format json >"$export_file"
+
+  local corrected currency
+  corrected="$(jq '[.records[].cost] | add // 0' "$export_file")"
+  currency="$(jq -r '[.records[].currency | select(. != null and . != "")][0] // "USD"' "$export_file")"
+
+  local naive
+  naive="$(jq --argjson sin "$SONNET_IN_RATE" --argjson sout "$SONNET_OUT_RATE" \
+    --argjson gin "$GPT4O_IN_RATE" --argjson gout "$GPT4O_OUT_RATE" '
+    [.records[]
+      | . as $r
+      | (if ($r.provider == "anthropic") then {in: $sin, out: $sout}
+         elif ($r.provider == "openai")   then {in: $gin, out: $gout}
+         else {in: 0, out: 0} end) as $rate
+      | ((($r.input_tokens // 0) + ($r.cache_read_tokens // 0) + ($r.cache_write_tokens // 0)) * $rate.in
+         + ($r.output_tokens // 0) * $rate.out) / 1000000
+    ] | add // 0' "$export_file")"
+
+  local reads writes
+  reads="$(jq '[.records[].cache_read_tokens // 0] | add' "$export_file")"
+  writes="$(jq '[.records[].cache_write_tokens // 0] | add' "$export_file")"
+
+  echo "  Token classes across the session (from signed evidence):"
+  kv "cache writes" "${writes} tokens (billed 1.25× input rate)"
+  kv "cache reads" "${reads} tokens (billed ~0.1× input rate)"
+  echo ""
+  awk -v cur="$currency" -v n="$naive" -v c="$corrected" 'BEGIN {
+    printf "  Naïve total  (all input-side tokens × input rate):   %s %.6f\n", cur, n
+    printf "  Corrected    (Talon evidence, cache-aware):          %s %.6f\n", cur, c
+    printf "  Delta        (what naïve math would misreport):      %s %.6f\n", cur, n - c
+  }'
+  echo ""
+  proof_outcome "✓" "Corrected total is what the budget gate enforced against" \
+    "Recompute it yourself: rates in pricing/models.yaml × tokens in the export" \
+    "Export: out/session-evidence.json (signed records)"
+}
+
+cmd_verify() {
+  require_stack
+  proof_section "7" "Session rollup + signature verification"
+  proof_story \
+    "The whole session — two providers, allowed work, both denials — is one" \
+    "auditable unit. Every record's HMAC must verify."
+  echo "  talon audit list --session ${SESSION_ID}"
+  talon_in_container audit list --session "$SESSION_ID" | sed 's/^/  /'
+  echo ""
+  echo "  talon audit verify --session ${SESSION_ID}"
+  local verify_out
+  verify_out="$(talon_in_container audit verify --session "$SESSION_ID")"
+  while IFS= read -r line; do echo "  $line"; done <<<"$verify_out"
+  echo ""
+  if ! echo "$verify_out" | grep -qE ", [0-9]+ valid, 0 invalid"; then
+    echo "✗ Expected all session records valid (0 invalid)" >&2
+    exit 1
+  fi
+  proof_outcome "✓" "Every decision in this session verifies — 0 invalid" \
+    "Auditors can re-verify offline from the signed export"
+}
+
+demo_finale() {
+  [[ "$NARRATE" == "1" ]] || return 0
+  echo ""
+  echo "$DEMO_WIDE_SEP"
+  echo "📋 Governed session complete"
+  echo "$DEMO_WIDE_SEP"
+  echo ""
+  echo "  ✓ Real two-provider session  — Anthropic planner + OpenAI executors"
+  echo "  ✓ Prompt-cache economics     — writes and reads priced exactly"
+  echo "  ✓ Session budget gate        — cross-provider spend capped pre-forward"
+  echo "  ✓ PII stop                   — IBAN never left the boundary"
+  echo "  ✓ Tool governance            — admin_* stripped before the model"
+  echo "  ✓ Signed evidence            — every record verified, 0 invalid"
+  echo ""
+  echo "  Talon provides enforceable controls and supporting evidence for your"
+  echo "  GDPR / EU AI Act reviews; compliance remains your determination."
+  echo ""
+  kv "Session" "$SESSION_ID"
+  kv "Artifacts" "$OUT_DIR (session-evidence.json)"
+  echo ""
+}
+
+cmd_all() {
+  NARRATE=1
+  demo_intro
+  cmd_planner_write
+  cmd_planner_read
+  cmd_executors
+  cmd_pii_probe
+  cmd_budget_gate
+  cmd_money_story
+  cmd_verify
+  demo_finale
+}
+
+usage() {
+  sed -n '3,14p' "$0" | tr -d '#'
+  echo ""
+  echo "Environment: GATEWAY (default http://localhost:8080), OUT_DIR (default ./out),"
+  echo "             SESSION_ID (default sess-governed-<epoch>)"
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    planner-write) cmd_planner_write ;;
+    planner-read) cmd_planner_read ;;
+    executors) cmd_executors ;;
+    pii-probe) cmd_pii_probe ;;
+    budget-gate) cmd_budget_gate ;;
+    money-story) cmd_money_story ;;
+    verify) cmd_verify ;;
+    all) cmd_all ;;
+    -h|--help|help|"") usage ;;
+    *)
+      echo "Unknown command: $cmd" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/examples/governed-session/docker-compose.yml
+++ b/examples/governed-session/docker-compose.yml
@@ -1,0 +1,57 @@
+# Talon governed-session demo (#107 Act II) — REAL providers, no mock.
+# One session: Anthropic planner (prompt-cache write/read) + OpenAI executors
+# (cached_tokens reads) under one session budget, with PII and tool governance
+# in the same signed-evidence trail.
+#
+#   export ANTHROPIC_API_KEY=sk-ant-...   OPENAI_API_KEY=sk-...
+#   make governed-session                  # from repo root
+#   cd examples/governed-session && ./demo.sh all
+#
+# Each full run makes real API calls (cheap models, capped): ~$0.05.
+
+services:
+  talon:
+    build:
+      context: ../../
+    ports:
+      # Override when 8080 is busy (another demo stack, a local `talon serve`):
+      # DEMO_GATEWAY_PORT=18080 docker compose up -d
+      - "${DEMO_GATEWAY_PORT:-8080}:8080"
+    environment:
+      - TALON_SECRETS_KEY=abcdefghijklmnopqrstuvwxyz012345
+      - TALON_SIGNING_KEY=demo-signing-key-not-for-production
+      - TALON_LOG_LEVEL=info
+      - TALON_LOG_FORMAT=json
+      # Real provider keys, passed through from the host environment. They are
+      # stored in Talon's encrypted secret vault at container start and used
+      # only for upstream auth — never logged, never in evidence.
+      - ANTHROPIC_API_KEY
+      - OPENAI_API_KEY
+    volumes:
+      - ./talon.config.session.yaml:/etc/talon/talon.config.yaml:ro
+      - ./talon.config.session.yaml:/home/talon/.talon/talon.config.yaml:ro
+      # NOTE: ./out is written host-side by demo.sh (exec redirects); binding
+      # it here would make Docker create it root-owned and break host writes.
+      - talon-data:/home/talon/.talon
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ -z "$${ANTHROPIC_API_KEY:-}" ] || [ -z "$${OPENAI_API_KEY:-}" ]; then
+          echo "governed-session demo needs REAL keys:" >&2
+          echo "  export ANTHROPIC_API_KEY=sk-ant-...  OPENAI_API_KEY=sk-..." >&2
+          echo "then re-run: make governed-session" >&2
+          exit 1
+        fi
+        talon secrets set anthropic-api-key "$${ANTHROPIC_API_KEY}" >/dev/null
+        talon secrets set openai-api-key "$${OPENAI_API_KEY}" >/dev/null
+        exec talon serve --port 8080 --gateway --gateway-config /etc/talon/talon.config.yaml
+
+volumes:
+  talon-data:
+    driver: local

--- a/examples/governed-session/out/.gitignore
+++ b/examples/governed-session/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/governed-session/talon.config.session.yaml
+++ b/examples/governed-session/talon.config.session.yaml
@@ -1,0 +1,65 @@
+# Governed-session demo (#107 Act II) — REAL Anthropic + OpenAI providers.
+# One agent session, two providers, one session budget, signed evidence for
+# every decision. Requires ANTHROPIC_API_KEY and OPENAI_API_KEY at stack start.
+#
+# Costs are enforced and displayed in the pricing table's currency (USD for
+# the shipped table, #216). Budget caps below are denominated in that unit.
+
+compliance:
+  controller:
+    name: "Example GmbH"
+    contact: "privacy@example.eu"
+    dpo_contact: "dpo@example.eu"
+    address: "Examplestr. 1, 10115 Berlin, Germany"
+
+gateway:
+  enabled: true
+  listen_prefix: "/v1/proxy"
+  mode: "enforce"
+
+  providers:
+    anthropic:
+      enabled: true
+      secret_name: "anthropic-api-key"
+      base_url: "https://api.anthropic.com"
+      region: "US"
+      allowed_models: ["claude-sonnet-5", "claude-haiku-4-5"]
+    openai:
+      enabled: true
+      secret_name: "openai-api-key"
+      base_url: "https://api.openai.com"
+      region: "US"
+      allowed_models: ["gpt-4o", "gpt-4o-mini"]
+
+  callers:
+    - name: "session-demo"
+      tenant_key: "talon-session-demo"
+      tenant_id: "governed-session"
+      team: "governed-session-demo"
+      policy_overrides:
+        # Session budget gate: the next request is denied pre-forward once
+        # session spend + the fixed pre-request estimate exceeds this (#198).
+        # With claude-sonnet-5 planning and gpt-4o executing, the gate closes
+        # after roughly 5-8 executor calls (~$0.04 real spend per run).
+        max_session_cost: 0.04
+        # Runtime tool-schema governance: admin_* tools are stripped from the
+        # request body before the model can ever see them (filter action).
+        forbidden_tools: ["admin_*"]
+
+  default_policy:
+    default_pii_action: "block"
+    # Hard safety net so a misbehaving loop cannot spend real money:
+    max_daily_cost: 1.00
+    require_caller_id: true
+    # Real traffic: keep prompt/response bodies out of evidence storage.
+    log_prompts: false
+    log_responses: false
+
+  rate_limits:
+    global_requests_per_min: 120
+    per_caller_requests_per_min: 60
+
+  timeouts:
+    connect_timeout: 10s
+    request_timeout: 60s
+    stream_idle_timeout: 60s

--- a/examples/shortlist-demo/demo.sh
+++ b/examples/shortlist-demo/demo.sh
@@ -183,7 +183,9 @@ export_consistency_note() {
     return 0
   fi
   local msg
-  msg="$(jq -r '.warnings[]? | select(startswith("consistency:"))' "${OUT_DIR}/ropa.json" 2>/dev/null | head -1)"
+  # `|| true` keeps an unreadable/missing export from killing the demo via
+  # set -e with jq's own error hidden by 2>/dev/null (#258).
+  msg="$(jq -r '.warnings[]? | select(startswith("consistency:"))' "${OUT_DIR}/ropa.json" 2>/dev/null | head -1 || true)"
   [[ -n "$msg" ]] || return 0
   echo ""
   echo "  Note (expected for this demo)"
@@ -485,6 +487,10 @@ cmd_exports() {
   compliance_export ropa --format json --output /home/talon/shortlist-out/ropa.json
   compliance_export annex-iv --format html --output /home/talon/shortlist-out/annex-iv.html
   compliance_export annex-iv --format json --output /home/talon/shortlist-out/annex-iv.json
+  # The container writes these 0600 under its own uid; on Linux hosts the
+  # host-side jq reads below (and verify-shortlist-demo.sh) would get EACCES
+  # through the bind mount (#258). Demo artifacts are non-sensitive.
+  dc exec -T talon sh -c 'chmod 644 /home/talon/shortlist-out/*.html /home/talon/shortlist-out/*.json' || true
   export_consistency_note
   if [[ "$NARRATE" == "1" ]]; then
     local warnings="?"

--- a/examples/shortlist-demo/demo.sh
+++ b/examples/shortlist-demo/demo.sh
@@ -156,16 +156,23 @@ verify_file_summary() {
   talon_in_container audit verify --file "$path" 2>&1 | grep -E '^(File:|Total records:|Valid records:|Invalid records:|Missing signature:|Hint:)' | sed 's/^/  /' || true
 }
 
-# Compliance export writes WARNING lines to stderr; suppress in narrated mode (warnings stay in HTML/JSON).
+# Compliance export writes WARNING lines to stderr; suppress in narrated mode
+# (warnings stay in HTML/JSON) but keep them in a host-side file so a failure
+# is diagnosable from CI logs alone (#258).
 compliance_export() {
   local rc=0
+  local stderr_file="${OUT_DIR}/compliance.stderr"
   if [[ "$NARRATE" == "1" ]]; then
-    talon_in_container compliance "$@" >/dev/null 2>&1 || rc=$?
+    talon_in_container compliance "$@" >/dev/null 2>"$stderr_file" || rc=$?
   else
-    talon_in_container compliance "$@" || rc=$?
+    talon_in_container compliance "$@" 2> >(tee "$stderr_file" >&2) || rc=$?
   fi
   if [[ "$rc" -ne 0 ]]; then
     echo "✗ compliance export failed: talon compliance $*" >&2
+    if [[ -s "$stderr_file" ]]; then
+      echo "  stderr:" >&2
+      sed 's/^/    /' "$stderr_file" >&2
+    fi
     exit "$rc"
   fi
 }

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -458,8 +458,8 @@ func auditVerifySession(ctx context.Context, store *evidence.Store, sessionID st
 			mark = "✗"
 			invalid++
 		}
-		fmt.Fprintf(os.Stdout, "  %s %s | %s | €%s\n", mark, ev.ID,
-			ev.Timestamp.Format("2006-01-02 15:04:05"), formatCost(ev.Execution.Cost))
+		fmt.Fprintf(os.Stdout, "  %s %s | %s | %s\n", mark, ev.ID,
+			ev.Timestamp.Format("2006-01-02 15:04:05"), formatMoney(ev.Execution.Currency, ev.Execution.Cost))
 	}
 	fmt.Fprintf(os.Stdout, "\nSession %s: %d record(s), %d valid, %d invalid\n",
 		sessionID, len(records), len(records)-invalid, invalid)
@@ -496,7 +496,7 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 	}
 	fmt.Fprintf(w, "  Tokens:    in %d / out %d / cache-read %d / cache-write %d\n",
 		sum.InputTokens, sum.OutputTokens, sum.CacheReadTokens, sum.CacheWriteTokens)
-	fmt.Fprintf(w, "  Cost:      €%s\n", formatCost(sum.TotalCost))
+	fmt.Fprintf(w, "  Cost:      %s\n", formatMoney(sum.Currency, sum.TotalCost))
 	if sessionHasAgentBreakdown(sum) {
 		fmt.Fprintln(w, "\n  Per-agent:")
 		for i := range sum.Agents {
@@ -509,8 +509,8 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 			if a.ParentAgentID != "" {
 				parent = " ←" + a.ParentAgentID
 			}
-			fmt.Fprintf(w, "    %-24s%s  %d req  €%s  (in %d / out %d)\n",
-				id, parent, a.RecordCount, formatCost(a.TotalCost), a.InputTokens, a.OutputTokens)
+			fmt.Fprintf(w, "    %-24s%s  %d req  %s  (in %d / out %d)\n",
+				id, parent, a.RecordCount, formatMoney(sum.Currency, a.TotalCost), a.InputTokens, a.OutputTokens)
 		}
 	}
 }
@@ -542,9 +542,9 @@ func renderSessionRecords(w io.Writer, records []*evidence.Evidence) {
 		if ev.Orchestration != nil && ev.Orchestration.AgentID != "" {
 			agent = " | agent=" + ev.Orchestration.AgentID
 		}
-		fmt.Fprintf(w, "  %s %s | %s | %s | €%s | %dms%s%s\n",
+		fmt.Fprintf(w, "  %s %s | %s | %s | %s | %dms%s%s\n",
 			status, ev.ID, ev.Timestamp.Format("2006-01-02 15:04:05"),
-			ev.Execution.ModelUsed, formatCost(ev.Execution.Cost),
+			ev.Execution.ModelUsed, formatMoney(ev.Execution.Currency, ev.Execution.Cost),
 			ev.Execution.DurationMS, agent, errMark)
 	}
 }
@@ -813,14 +813,14 @@ func renderAuditList(w io.Writer, index []evidence.Index) {
 		if entry.PrimaryExplanationCode != "" {
 			explanationMark = " [" + entry.PrimaryExplanationCode + "]"
 		}
-		fmt.Fprintf(w, "  %s %s | %s | %s/%s | %s | €%s | %dms%s%s%s\n",
+		fmt.Fprintf(w, "  %s %s | %s | %s/%s | %s | %s | %dms%s%s%s\n",
 			status,
 			entry.ID,
 			entry.Timestamp.Format("2006-01-02 15:04:05"),
 			entry.TenantID,
 			entry.AgentID,
 			entry.ModelUsed,
-			formatCost(entry.Cost),
+			formatMoney(entry.Currency, entry.Cost),
 			entry.DurationMS,
 			errorMark,
 			cacheMark,
@@ -848,12 +848,12 @@ func renderVerifyResult(w io.Writer, evidenceID string, valid bool, ev *evidence
 		if !ev.PolicyDecision.Allowed {
 			policyStatus = "DENIED"
 		}
-		fmt.Fprintf(w, "%s | %s/%s | %s | €%s | %dms\n",
+		fmt.Fprintf(w, "%s | %s/%s | %s | %s | %dms\n",
 			ev.Timestamp.Format(time.RFC3339),
 			ev.TenantID,
 			ev.AgentID,
 			ev.Execution.ModelUsed,
-			formatCost(ev.Execution.Cost),
+			formatMoney(ev.Execution.Currency, ev.Execution.Cost),
 			ev.Execution.DurationMS,
 		)
 		fmt.Fprintf(w, "Policy: %s | Tier: %d→%d | PII: %s | Redacted: %t\n",
@@ -933,9 +933,17 @@ func renderAuditShow(w io.Writer, ev *evidence.Evidence, valid bool) {
 		ev.Classification.InputPIIRedacted, ev.Classification.PIIRedacted)
 	fmt.Fprintln(w, "Execution")
 	fmt.Fprintf(w, "Model:         %s\n", ev.Execution.ModelUsed)
-	fmt.Fprintf(w, "Cost:          €%s\n", formatCost(ev.Execution.Cost))
+	fmt.Fprintf(w, "Cost:          %s\n", formatMoney(ev.Execution.Currency, ev.Execution.Cost))
 	fmt.Fprintf(w, "Duration:      %dms\n", ev.Execution.DurationMS)
-	fmt.Fprintf(w, "Tokens:        in=%d out=%d\n", ev.Execution.Tokens.Input, ev.Execution.Tokens.Output)
+	tokensLine := fmt.Sprintf("in=%d out=%d", ev.Execution.Tokens.Input, ev.Execution.Tokens.Output)
+	if ev.Execution.Tokens.CacheRead > 0 || ev.Execution.Tokens.CacheWrite > 0 {
+		tokensLine += fmt.Sprintf(" cache_read=%d cache_write=%d",
+			ev.Execution.Tokens.CacheRead, ev.Execution.Tokens.CacheWrite)
+	}
+	fmt.Fprintf(w, "Tokens:        %s\n", tokensLine)
+	if ev.Execution.PricingBasis != "" {
+		fmt.Fprintf(w, "Pricing Basis: %s\n", ev.Execution.PricingBasis)
+	}
 	toolsStr := strings.Join(ev.Execution.ToolsCalled, ", ")
 	if toolsStr == "" {
 		toolsStr = "(none)"
@@ -987,7 +995,7 @@ func renderAuditShow(w io.Writer, ev *evidence.Evidence, valid bool) {
 		fmt.Fprintf(w, "  Hit:         true\n")
 		fmt.Fprintf(w, "  Entry ID:    %s\n", ev.CacheEntryID)
 		fmt.Fprintf(w, "  Similarity:  %.2f\n", ev.CacheSimilarity)
-		fmt.Fprintf(w, "  Cost Saved:  €%s\n", formatCost(ev.CostSaved))
+		fmt.Fprintf(w, "  Cost Saved:  %s\n", formatMoney(ev.Execution.Currency, ev.CostSaved))
 	}
 	if ev.Execution.MemoryTokens > 0 {
 		fmt.Fprintf(w, "Memory Tokens: %d (injected into prompt)\n", ev.Execution.MemoryTokens)

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/gateway"
 	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/pricing"
 )
 
 var (
@@ -46,8 +47,12 @@ var costsExportCmd = &cobra.Command{
 }
 
 type costsPayload struct {
-	TenantID       string             `json:"tenant_id"`
-	AgentID        string             `json:"agent_id,omitempty"`
+	TenantID string `json:"tenant_id"`
+	AgentID  string `json:"agent_id,omitempty"`
+	// Currency is the ISO-4217 unit of every amount in this payload, from the
+	// active pricing table (#216). Field names keep their legacy _eur suffix
+	// for consumer compatibility; Currency is the authoritative unit.
+	Currency       string             `json:"currency"`
 	TodayEUR       float64            `json:"today_eur"`
 	MonthEUR       float64            `json:"month_eur"`
 	SevenDaysEUR   float64            `json:"seven_days_eur"`
@@ -92,6 +97,8 @@ var costsCmd = &cobra.Command{
 			return fmt.Errorf("opening evidence store: %w", err)
 		}
 		defer store.Close()
+
+		costCurrency := loadPricingTable(cfg, "").CurrencyCode()
 
 		tenantID := costsTenant
 		if tenantID == "" {
@@ -145,7 +152,7 @@ var costsCmd = &cobra.Command{
 			}
 			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
 			if costsJSON {
-				return writeCostsJSON(out, costsPayload{
+				return writeCostsJSON(out, costCurrency, costsPayload{
 					TenantID:     tenantID,
 					AgentID:      costsAgent,
 					TodayEUR:     sumValues(byModelDaily),
@@ -154,9 +161,9 @@ var costsCmd = &cobra.Command{
 					ByModelEUR:   byModelDaily,
 				})
 			}
-			renderCostByModel(out, tenantID, costsAgent, byModelDaily, byModelMonthly)
+			renderCostByModel(out, costCurrency, tenantID, costsAgent, byModelDaily, byModelMonthly)
 			// Optional: 7d trend (same agent filter when --agent is set)
-			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
+			fmt.Fprintf(out, "  7d total: %s\n", formatMoney(costCurrency, weekTotal))
 			return nil
 		}
 		if costsByProvider {
@@ -170,7 +177,7 @@ var costsCmd = &cobra.Command{
 			}
 			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
 			if costsJSON {
-				return writeCostsJSON(out, costsPayload{
+				return writeCostsJSON(out, costCurrency, costsPayload{
 					TenantID:      tenantID,
 					AgentID:       costsAgent,
 					TodayEUR:      sumValues(byProviderDaily),
@@ -179,8 +186,8 @@ var costsCmd = &cobra.Command{
 					ByProviderEUR: byProviderDaily,
 				})
 			}
-			renderCostByProvider(out, tenantID, costsAgent, byProviderDaily, byProviderMonthly)
-			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
+			renderCostByProvider(out, costCurrency, tenantID, costsAgent, byProviderDaily, byProviderMonthly)
+			fmt.Fprintf(out, "  7d total: %s\n", formatMoney(costCurrency, weekTotal))
 			return nil
 		}
 		if costsByTeam {
@@ -194,7 +201,7 @@ var costsCmd = &cobra.Command{
 			}
 			if costsJSON {
 				weekTotal, _ := store.CostTotal(ctx, tenantID, "", weekStart, dayEnd)
-				return writeCostsJSON(out, costsPayload{
+				return writeCostsJSON(out, costCurrency, costsPayload{
 					TenantID:     tenantID,
 					TodayEUR:     sumValues(byTeamDaily),
 					MonthEUR:     sumValues(byTeamMonthly),
@@ -202,7 +209,7 @@ var costsCmd = &cobra.Command{
 					ByTeamEUR:    byTeamDaily,
 				})
 			}
-			renderCostByTeam(out, tenantID, byTeamDaily, byTeamMonthly)
+			renderCostByTeam(out, costCurrency, tenantID, byTeamDaily, byTeamMonthly)
 			return nil
 		}
 
@@ -218,7 +225,7 @@ var costsCmd = &cobra.Command{
 			dailyBudget, monthlyBudget := resolveBudgetUsage(ctx, cfg, tenantID, costsAgent, daily, monthly)
 			if costsJSON {
 				weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
-				return writeCostsJSON(out, costsPayload{
+				return writeCostsJSON(out, costCurrency, costsPayload{
 					TenantID:      tenantID,
 					AgentID:       costsAgent,
 					TodayEUR:      daily,
@@ -228,10 +235,10 @@ var costsCmd = &cobra.Command{
 					MonthlyBudget: monthlyBudget,
 				})
 			}
-			renderCostReportSingleAgent(out, tenantID, costsAgent, daily, monthly)
+			renderCostReportSingleAgent(out, costCurrency, tenantID, costsAgent, daily, monthly)
 			weekTotal, _ := store.CostTotal(ctx, tenantID, costsAgent, weekStart, dayEnd)
-			fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
-			printBudgetUtilization(out, dailyBudget, monthlyBudget)
+			fmt.Fprintf(out, "  7d total: %s\n", formatMoney(costCurrency, weekTotal))
+			printBudgetUtilization(out, costCurrency, dailyBudget, monthlyBudget)
 			return nil
 		}
 
@@ -249,7 +256,7 @@ var costsCmd = &cobra.Command{
 		dailyBudget, monthlyBudget := resolveBudgetUsage(ctx, cfg, tenantID, "", dailyTotal, monthlyTotal)
 		cache7d, cache30d := getCacheUsage(ctx, store, tenantID, weekStart, dayEnd, monthStart, monthEnd)
 		if costsJSON {
-			return writeCostsJSON(out, costsPayload{
+			return writeCostsJSON(out, costCurrency, costsPayload{
 				TenantID:       tenantID,
 				TodayEUR:       dailyTotal,
 				MonthEUR:       monthlyTotal,
@@ -261,29 +268,29 @@ var costsCmd = &cobra.Command{
 				CacheMonth:     cache30d,
 			})
 		}
-		renderCostReportAllAgents(out, tenantID, byAgentDaily, byAgentMonthly)
-		fmt.Fprintf(out, "  7d total: €%s\n", formatCost(weekTotal))
-		printBudgetUtilization(out, dailyBudget, monthlyBudget)
-		printCacheSavings(out, cache7d, cache30d)
+		renderCostReportAllAgents(out, costCurrency, tenantID, byAgentDaily, byAgentMonthly)
+		fmt.Fprintf(out, "  7d total: %s\n", formatMoney(costCurrency, weekTotal))
+		printBudgetUtilization(out, costCurrency, dailyBudget, monthlyBudget)
+		printCacheSavings(out, costCurrency, cache7d, cache30d)
 		return nil
 	},
 }
 
-func printCacheSavings(w io.Writer, cache7d, cache30d *cacheUsage) {
+func printCacheSavings(w io.Writer, currency string, cache7d, cache30d *cacheUsage) {
 	if cache7d != nil && (cache7d.Hits > 0 || cache7d.SavedEUR > 0) {
-		fmt.Fprintf(w, "  Cache (7d):   %d requests from cache, €%s saved, %.1f%% hit rate\n", cache7d.Hits, formatCost(cache7d.SavedEUR), cache7d.HitRate)
+		fmt.Fprintf(w, "  Cache (7d):   %d requests from cache, %s saved, %.1f%% hit rate\n", cache7d.Hits, formatMoney(currency, cache7d.SavedEUR), cache7d.HitRate)
 	}
 	if cache30d != nil && (cache30d.Hits > 0 || cache30d.SavedEUR > 0) {
-		fmt.Fprintf(w, "  Cache (30d):  %d requests from cache, €%s saved, %.1f%% hit rate\n", cache30d.Hits, formatCost(cache30d.SavedEUR), cache30d.HitRate)
+		fmt.Fprintf(w, "  Cache (30d):  %d requests from cache, %s saved, %.1f%% hit rate\n", cache30d.Hits, formatMoney(currency, cache30d.SavedEUR), cache30d.HitRate)
 	}
 }
 
-func printBudgetUtilization(w io.Writer, dailyBudget, monthlyBudget *budgetUsage) {
+func printBudgetUtilization(w io.Writer, currency string, dailyBudget, monthlyBudget *budgetUsage) {
 	if dailyBudget != nil && dailyBudget.LimitEUR > 0 {
-		fmt.Fprintf(w, "  Daily budget:   %.1f%% (€%s / €%.2f)\n", dailyBudget.Percent, formatCost(dailyBudget.UsedEUR), dailyBudget.LimitEUR)
+		fmt.Fprintf(w, "  Daily budget:   %.1f%% (%s / %s)\n", dailyBudget.Percent, formatMoney(currency, dailyBudget.UsedEUR), pricing.FormatAmount(currency, fmt.Sprintf("%.2f", dailyBudget.LimitEUR)))
 	}
 	if monthlyBudget != nil && monthlyBudget.LimitEUR > 0 {
-		fmt.Fprintf(w, "  Monthly budget: %.1f%% (€%s / €%.2f)\n", monthlyBudget.Percent, formatCost(monthlyBudget.UsedEUR), monthlyBudget.LimitEUR)
+		fmt.Fprintf(w, "  Monthly budget: %.1f%% (%s / %s)\n", monthlyBudget.Percent, formatMoney(currency, monthlyBudget.UsedEUR), pricing.FormatAmount(currency, fmt.Sprintf("%.2f", monthlyBudget.LimitEUR)))
 	}
 }
 
@@ -393,7 +400,8 @@ func sumValues(m map[string]float64) float64 {
 	return total
 }
 
-func writeCostsJSON(w io.Writer, payload costsPayload) error {
+func writeCostsJSON(w io.Writer, currency string, payload costsPayload) error {
+	payload.Currency = currency
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(payload); err != nil {
@@ -461,7 +469,7 @@ func renderCostsExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 	writer := csv.NewWriter(w)
 	header := []string{
 		"evidence_id", "tenant_id", "agent_id", "timestamp", "model", "provider",
-		"cost_eur", "input_tokens", "output_tokens", "policy_decision", "policy_reason",
+		"cost", "currency", "input_tokens", "output_tokens", "policy_decision", "policy_reason",
 	}
 	if err := writer.Write(header); err != nil {
 		return err
@@ -484,6 +492,7 @@ func renderCostsExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 			rec.ModelUsed,
 			rec.Provider,
 			formatCostNumeric(rec.Cost),
+			exportCurrency(rec.Currency),
 			strconv.Itoa(rec.InputTokens),
 			strconv.Itoa(rec.OutputTokens),
 			decision,
@@ -498,16 +507,16 @@ func renderCostsExportCSV(w io.Writer, records []evidence.ExportRecord) error {
 }
 
 // renderCostReportSingleAgent writes single-agent cost output to w (testable).
-func renderCostReportSingleAgent(w io.Writer, tenantID, agentID string, daily, monthly float64) {
+func renderCostReportSingleAgent(w io.Writer, currency, tenantID, agentID string, daily, monthly float64) {
 	fmt.Fprintf(w, "Tenant: %s | Agent: %s\n", tenantID, agentID)
-	fmt.Fprintf(w, "  Today:   €%s\n", formatCost(daily))
-	fmt.Fprintf(w, "  Month:   €%s\n", formatCost(monthly))
+	fmt.Fprintf(w, "  Today:   %s\n", formatMoney(currency, daily))
+	fmt.Fprintf(w, "  Month:   %s\n", formatMoney(currency, monthly))
 }
 
 // renderCostByModel writes per-model cost table to w. If agentID is non-empty, the header shows tenant and agent.
 //
 //nolint:dupl // similar to renderCostReportAllAgents but for model grouping; keeping separate for clarity
-func renderCostByModel(w io.Writer, tenantID, agentID string, byModelDaily, byModelMonthly map[string]float64) {
+func renderCostByModel(w io.Writer, currency, tenantID, agentID string, byModelDaily, byModelMonthly map[string]float64) {
 	models := make(map[string]bool)
 	for m := range byModelDaily {
 		models[m] = true
@@ -533,18 +542,18 @@ func renderCostByModel(w io.Writer, tenantID, agentID string, byModelDaily, byMo
 		m := byModelMonthly[model]
 		dailyTotal += d
 		monthlyTotal += m
-		fmt.Fprintf(w, "%-32s €%13s €%13s\n", model, formatCost(d), formatCost(m))
+		fmt.Fprintf(w, "%-32s %14s %14s\n", model, formatMoney(currency, d), formatMoney(currency, m))
 	}
 	if len(list) > 0 {
 		fmt.Fprintf(w, "%-32s %14s %14s\n", "-----", "-----", "-----")
 	}
-	fmt.Fprintf(w, "%-32s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
+	fmt.Fprintf(w, "%-32s %14s %14s\n", "Total", formatMoney(currency, dailyTotal), formatMoney(currency, monthlyTotal))
 }
 
 // renderCostByProvider writes per-provider cost table to w.
 //
 //nolint:dupl // parallel to model/team renderers by design for readability in CLI output
-func renderCostByProvider(w io.Writer, tenantID, agentID string, byProviderDaily, byProviderMonthly map[string]float64) {
+func renderCostByProvider(w io.Writer, currency, tenantID, agentID string, byProviderDaily, byProviderMonthly map[string]float64) {
 	providers := make(map[string]bool)
 	for p := range byProviderDaily {
 		providers[p] = true
@@ -570,18 +579,18 @@ func renderCostByProvider(w io.Writer, tenantID, agentID string, byProviderDaily
 		m := byProviderMonthly[provider]
 		dailyTotal += d
 		monthlyTotal += m
-		fmt.Fprintf(w, "%-20s €%13s €%13s\n", provider, formatCost(d), formatCost(m))
+		fmt.Fprintf(w, "%-20s %14s %14s\n", provider, formatMoney(currency, d), formatMoney(currency, m))
 	}
 	if len(list) > 0 {
 		fmt.Fprintf(w, "%-20s %14s %14s\n", "--------", "-----", "-----")
 	}
-	fmt.Fprintf(w, "%-20s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
+	fmt.Fprintf(w, "%-20s %14s %14s\n", "Total", formatMoney(currency, dailyTotal), formatMoney(currency, monthlyTotal))
 }
 
 // renderCostByTeam writes per-team cost table to w (testable).
 //
 //nolint:dupl // similar to renderCostByModel but for team grouping; keeping separate for clarity
-func renderCostByTeam(w io.Writer, tenantID string, byTeamDaily, byTeamMonthly map[string]float64) {
+func renderCostByTeam(w io.Writer, currency, tenantID string, byTeamDaily, byTeamMonthly map[string]float64) {
 	teams := make(map[string]bool)
 	for t := range byTeamDaily {
 		teams[t] = true
@@ -603,18 +612,18 @@ func renderCostByTeam(w io.Writer, tenantID string, byTeamDaily, byTeamMonthly m
 		m := byTeamMonthly[team]
 		dailyTotal += d
 		monthlyTotal += m
-		fmt.Fprintf(w, "%-32s €%13s €%13s\n", team, formatCost(d), formatCost(m))
+		fmt.Fprintf(w, "%-32s %14s %14s\n", team, formatMoney(currency, d), formatMoney(currency, m))
 	}
 	if len(list) > 0 {
 		fmt.Fprintf(w, "%-32s %14s %14s\n", "-----", "-----", "-----")
 	}
-	fmt.Fprintf(w, "%-32s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
+	fmt.Fprintf(w, "%-32s %14s %14s\n", "Total", formatMoney(currency, dailyTotal), formatMoney(currency, monthlyTotal))
 }
 
 // renderCostReportAllAgents writes per-agent cost table to w (testable).
 //
 //nolint:dupl // similar to renderCostByModel but for agent grouping; keeping separate for clarity
-func renderCostReportAllAgents(w io.Writer, tenantID string, byAgentDaily, byAgentMonthly map[string]float64) {
+func renderCostReportAllAgents(w io.Writer, currency, tenantID string, byAgentDaily, byAgentMonthly map[string]float64) {
 	agents := make(map[string]bool)
 	for a := range byAgentDaily {
 		agents[a] = true
@@ -636,12 +645,12 @@ func renderCostReportAllAgents(w io.Writer, tenantID string, byAgentDaily, byAge
 		m := byAgentMonthly[agentID]
 		dailyTotal += d
 		monthlyTotal += m
-		fmt.Fprintf(w, "%-24s €%13s €%13s\n", agentID, formatCost(d), formatCost(m))
+		fmt.Fprintf(w, "%-24s %14s %14s\n", agentID, formatMoney(currency, d), formatMoney(currency, m))
 	}
 	if len(list) > 0 {
 		fmt.Fprintf(w, "%-24s %14s %14s\n", "----", "-----", "-----")
 	}
-	fmt.Fprintf(w, "%-24s €%13s €%13s\n", "Total", formatCost(dailyTotal), formatCost(monthlyTotal))
+	fmt.Fprintf(w, "%-24s %14s %14s\n", "Total", formatMoney(currency, dailyTotal), formatMoney(currency, monthlyTotal))
 }
 
 func init() {

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRenderCostReportSingleAgent(t *testing.T) {
 	var buf bytes.Buffer
-	renderCostReportSingleAgent(&buf, "acme", "sales-agent", 1.5, 42.0)
+	renderCostReportSingleAgent(&buf, "USD", "acme", "sales-agent", 1.5, 42.0)
 	out := buf.String()
 	assert.Contains(t, out, "Tenant: acme")
 	assert.Contains(t, out, "Agent: sales-agent")
@@ -29,7 +29,7 @@ func TestRenderCostReportSingleAgent(t *testing.T) {
 
 func TestRenderCostReportSingleAgent_SubCent(t *testing.T) {
 	var buf bytes.Buffer
-	renderCostReportSingleAgent(&buf, "acme", "agent", 0.0003, 0.0005)
+	renderCostReportSingleAgent(&buf, "USD", "acme", "agent", 0.0003, 0.0005)
 	out := buf.String()
 	assert.Contains(t, out, "0.000300")
 	assert.Contains(t, out, "0.000500")
@@ -39,7 +39,7 @@ func TestRenderCostReportAllAgents(t *testing.T) {
 	var buf bytes.Buffer
 	byDaily := map[string]float64{"agent-a": 0.5, "agent-b": 1.0}
 	byMonthly := map[string]float64{"agent-a": 10.0, "agent-b": 20.0}
-	renderCostReportAllAgents(&buf, "tenant1", byDaily, byMonthly)
+	renderCostReportAllAgents(&buf, "USD", "tenant1", byDaily, byMonthly)
 	out := buf.String()
 	assert.Contains(t, out, "Tenant: tenant1")
 	assert.Contains(t, out, "Agent")
@@ -53,7 +53,7 @@ func TestRenderCostReportAllAgents(t *testing.T) {
 
 func TestRenderCostReportAllAgents_EmptyMaps(t *testing.T) {
 	var buf bytes.Buffer
-	renderCostReportAllAgents(&buf, "tenant1", nil, nil)
+	renderCostReportAllAgents(&buf, "USD", "tenant1", nil, nil)
 	out := buf.String()
 	require.Contains(t, out, "Tenant: tenant1")
 	require.Contains(t, out, "Total")
@@ -68,7 +68,7 @@ func TestRenderCostByModel(t *testing.T) {
 	var buf bytes.Buffer
 	byDaily := map[string]float64{"gpt-4o": 0.5, "gpt-4o-mini": 1.0}
 	byMonthly := map[string]float64{"gpt-4o": 10.0, "gpt-4o-mini": 20.0}
-	renderCostByModel(&buf, "acme", "", byDaily, byMonthly)
+	renderCostByModel(&buf, "USD", "acme", "", byDaily, byMonthly)
 	out := buf.String()
 	assert.Contains(t, out, "Tenant: acme (by model)")
 	assert.Contains(t, out, "Model")
@@ -82,7 +82,7 @@ func TestRenderCostByModel(t *testing.T) {
 
 func TestRenderCostByModel_EmptyMaps(t *testing.T) {
 	var buf bytes.Buffer
-	renderCostByModel(&buf, "tenant1", "", nil, nil)
+	renderCostByModel(&buf, "USD", "tenant1", "", nil, nil)
 	out := buf.String()
 	require.Contains(t, out, "Tenant: tenant1 (by model)")
 	require.Contains(t, out, "Total")
@@ -94,7 +94,7 @@ func TestRenderCostByModel_OneModelOnlyInMonthly(t *testing.T) {
 	var buf bytes.Buffer
 	byDaily := map[string]float64{}
 	byMonthly := map[string]float64{"gpt-4o": 5.0}
-	renderCostByModel(&buf, "acme", "", byDaily, byMonthly)
+	renderCostByModel(&buf, "USD", "acme", "", byDaily, byMonthly)
 	out := buf.String()
 	assert.Contains(t, out, "gpt-4o")
 	assert.Contains(t, out, "0.000000") // daily is 0
@@ -106,7 +106,7 @@ func TestRenderCostByModel_WithAgent(t *testing.T) {
 	var buf bytes.Buffer
 	byDaily := map[string]float64{"gpt-4o-mini": 0.5}
 	byMonthly := map[string]float64{"gpt-4o-mini": 5.0}
-	renderCostByModel(&buf, "acme", "sales-bot", byDaily, byMonthly)
+	renderCostByModel(&buf, "USD", "acme", "sales-bot", byDaily, byMonthly)
 	out := buf.String()
 	require.Contains(t, out, "Tenant: acme | Agent: sales-bot (by model)")
 	require.Contains(t, out, "gpt-4o-mini")

--- a/internal/cmd/format.go
+++ b/internal/cmd/format.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/dativo-io/talon/internal/pricing"
 )
 
 // formatCost formats cost for display: zero as "0.000000", sub-cent as 6 decimals or "< 0.0001" for tiny positive amounts.
@@ -20,4 +22,22 @@ func formatCost(c float64) string {
 // Always returns a valid number parseable by spreadsheets and BI tools; never "< 0.0001".
 func formatCostNumeric(c float64) string {
 	return strconv.FormatFloat(c, 'f', 6, 64)
+}
+
+// formatMoney renders a cost with its currency unit (#216): the symbol for
+// USD/EUR, the code as a prefix otherwise. An empty currency (records that
+// predate the stamp, or no pricing table in scope) renders as USD — the unit
+// the shipped pricing tables were always denominated in.
+func formatMoney(currency string, c float64) string {
+	return pricing.FormatAmount(currency, formatCost(c))
+}
+
+// exportCurrency is the machine-readable currency column value (#216):
+// records that predate the currency stamp default to USD, the unit the
+// shipped pricing tables were always denominated in.
+func exportCurrency(currency string) string {
+	if currency == "" {
+		return pricing.DefaultCurrency
+	}
+	return currency
 }

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -405,8 +405,8 @@ func memoryAudit(cmd *cobra.Command, args []string) error {
 						hmacStatus = "INVALID"
 					}
 				}
-				fmt.Printf("    Evidence: %s | %s | %s | EUR%.4f | HMAC: %s\n",
-					ev.ID, ev.InvocationType, ev.Execution.ModelUsed, ev.Execution.Cost, hmacStatus)
+				fmt.Printf("    Evidence: %s | %s | %s | %s%.4f | HMAC: %s\n",
+					ev.ID, ev.InvocationType, ev.Execution.ModelUsed, exportCurrency(ev.Execution.Currency), ev.Execution.Cost, hmacStatus)
 			}
 		}
 

--- a/internal/cmd/metrics.go
+++ b/internal/cmd/metrics.go
@@ -123,10 +123,11 @@ func filterCallers(in []metricsapi.CallerStat, caller string) []metricsapi.Calle
 }
 
 func renderMetricsSummary(w io.Writer, callers []metricsapi.CallerStat, snap metricsapi.Snapshot) {
+	cur := exportCurrency(snap.Currency)
 	fmt.Fprintln(w, "Agent Metrics (last 24h)")
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%-20s %8s %8s %8s %8s %8s %8s %10s %11s %13s\n",
-		"AGENT", "REQUESTS", "SUCCESS", "FAILED", "TIMEOUT", "DENIED", "RATE", "COST(EUR)", "EUR/SUCCESS", "VIOLATIONS(7d)")
+		"AGENT", "REQUESTS", "SUCCESS", "FAILED", "TIMEOUT", "DENIED", "RATE", "COST("+cur+")", cur+"/SUCCESS", "VIOLATIONS(7d)")
 
 	var totalReq, totalSuccess, totalFailed, totalTimeout, totalDenied int
 	var totalCost float64
@@ -153,12 +154,12 @@ func renderMetricsSummary(w io.Writer, callers []metricsapi.CallerStat, snap met
 
 	fmt.Fprintln(w)
 	if totalReq == 0 {
-		fmt.Fprintln(w, "Totals: 0 requests | 0 successful | 0 failed | 0 timeouts | 0 denied | EUR0.0000")
+		fmt.Fprintf(w, "Totals: 0 requests | 0 successful | 0 failed | 0 timeouts | 0 denied | %s0.0000\n", cur)
 		return
 	}
 	successRate := (float64(totalSuccess) / float64(totalReq)) * 100
-	fmt.Fprintf(w, "Totals: %d requests | %d successful | %d failed | %d timeouts | %d denied | EUR%.4f | success rate %.1f%%\n",
-		totalReq, totalSuccess, totalFailed, totalTimeout, totalDenied, totalCost, successRate)
+	fmt.Fprintf(w, "Totals: %d requests | %d successful | %d failed | %d timeouts | %d denied | %s%.4f | success rate %.1f%%\n",
+		totalReq, totalSuccess, totalFailed, totalTimeout, totalDenied, cur, totalCost, successRate)
 	_ = snap
 }
 
@@ -174,8 +175,9 @@ func renderMetricsAgentDetail(w io.Writer, requested string, callers []metricsap
 	fmt.Fprintf(w, "Timed out: %d\n", c.TimedOut)
 	fmt.Fprintf(w, "Denied: %d\n", c.Denied)
 	fmt.Fprintf(w, "Success rate: %.1f%%\n", c.SuccessRate*100)
-	fmt.Fprintf(w, "Cost (EUR): %.4f\n", c.CostEUR)
-	fmt.Fprintf(w, "Cost per success (EUR): %.4f\n", c.CostPerSuccess)
+	cur := exportCurrency(snap.Currency)
+	fmt.Fprintf(w, "Cost (%s): %.4f\n", cur, c.CostEUR)
+	fmt.Fprintf(w, "Cost per success (%s): %.4f\n", cur, c.CostPerSuccess)
 	fmt.Fprintf(w, "Avg latency: %dms\n", c.AvgLatencyMS)
 	fmt.Fprintf(w, "Global P99 latency: %dms\n", snap.Summary.P99LatencyMS)
 	if snap.BudgetStatus != nil {

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -425,6 +425,7 @@ func runPlanExecute(cmd *cobra.Command, args []string) error {
 	fmt.Printf("✓ Executed approved plan: %s\n", plan.ID)
 	fmt.Printf("\n%s\n\n", resp.Response)
 	fmt.Printf("✓ Evidence stored: %s\n", resp.EvidenceID)
-	fmt.Printf("✓ Cost: €%s | Duration: %dms\n", formatCost(resp.Cost), resp.DurationMS)
+	fmt.Printf("✓ Cost: %s | Duration: %dms\n",
+		formatMoney(loadPricingTable(cfg, "").CurrencyCode(), resp.Cost), resp.DurationMS)
 	return nil
 }

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dativo-io/talon/internal/agent"
 	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/pricing"
 )
 
 var reportTenant string
@@ -61,11 +62,12 @@ func runReport(cmd *cobra.Command, args []string) error {
 	costMonth, _ := store.CostTotal(ctx, reportTenant, "", monthStart, monthEnd)
 
 	out := cmd.OutOrStdout()
+	reportCurrency := loadPricingTable(cfg, "").CurrencyCode()
 	fmt.Fprintf(out, "Compliance summary — tenant %s\n", reportTenant)
 	fmt.Fprintf(out, "  Evidence records today:  %d\n", countToday)
 	fmt.Fprintf(out, "  Evidence records (7d):   %d\n", countWeek)
-	fmt.Fprintf(out, "  Cost today (EUR):        %.4f\n", costToday)
-	fmt.Fprintf(out, "  Cost this month (EUR):   %.4f\n", costMonth)
+	fmt.Fprintf(out, "  Cost today (%s):        %.4f\n", reportCurrency, costToday)
+	fmt.Fprintf(out, "  Cost this month (%s):   %.4f\n", reportCurrency, costMonth)
 
 	hits7d, saved7d, _ := store.CacheSavings(ctx, reportTenant, weekStart, todayEnd)
 	if hits7d > 0 || saved7d > 0 {
@@ -74,7 +76,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 		if total7d > 0 {
 			hitRate7d = 100 * float64(hits7d) / float64(total7d)
 		}
-		fmt.Fprintf(out, "  Cache (7d):   %d from cache, €%.4f saved, %.1f%% hit rate\n", hits7d, saved7d, hitRate7d)
+		fmt.Fprintf(out, "  Cache (7d):   %d from cache, %s saved, %.1f%% hit rate\n", hits7d, pricing.FormatAmount(reportCurrency, fmt.Sprintf("%.4f", saved7d)), hitRate7d)
 	}
 	hits30d, saved30d, _ := store.CacheSavings(ctx, reportTenant, monthStart, monthEnd)
 	if hits30d > 0 || saved30d > 0 {
@@ -83,7 +85,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 		if total30d > 0 {
 			hitRate30d = 100 * float64(hits30d) / float64(total30d)
 		}
-		fmt.Fprintf(out, "  Cache (30d):  %d from cache, €%.4f saved, %.1f%% hit rate\n", hits30d, saved30d, hitRate30d)
+		fmt.Fprintf(out, "  Cache (30d):  %d from cache, %s saved, %.1f%% hit rate\n", hits30d, pricing.FormatAmount(reportCurrency, fmt.Sprintf("%.4f", saved30d)), hitRate30d)
 	}
 
 	if avgTTFT, err := store.AvgTTFT(ctx, reportTenant, "", weekStart, todayEnd); err == nil && avgTTFT > 0 {

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -38,8 +38,9 @@ func TestReportCmd_RunSuccess(t *testing.T) {
 	assert.Contains(t, out, "Compliance summary")
 	assert.Contains(t, out, "Evidence records today")
 	assert.Contains(t, out, "Evidence records (7d)")
-	assert.Contains(t, out, "Cost today (EUR)")
-	assert.Contains(t, out, "Cost this month (EUR)")
+	// Cost labels carry the pricing-table currency; the shipped table is USD (#216).
+	assert.Contains(t, out, "Cost today (USD)")
+	assert.Contains(t, out, "Cost this month (USD)")
 	assert.Contains(t, out, "Plans pending")
 	assert.Contains(t, out, "Plans approved")
 	assert.Contains(t, out, "Plan dispatch failures")

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -427,6 +427,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("initializing gateway: %w", err)
 			}
+			gw.SetPricingCurrency(pricingTable.CurrencyCode())
 			if serveCacheStore != nil && serveCachePolicy != nil && cfg.Cache != nil {
 				gw.SetCache(serveCacheStore, serveCacheEmbedder, serveCacheScrubber, serveCachePolicy,
 					cfg.Cache.Enabled, cfg.Cache.DefaultTTL, cfg.Cache.TTLByTier, cfg.Cache.SimilarityThreshold, cfg.Cache.MaxEntriesPerTenant)
@@ -461,6 +462,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("initializing quickstart gateway: %w", err)
 		}
+		gw.SetPricingCurrency(pricingTable.CurrencyCode())
 		if serveCacheStore != nil && serveCachePolicy != nil && cfg.Cache != nil {
 			gw.SetCache(serveCacheStore, serveCacheEmbedder, serveCacheScrubber, serveCachePolicy,
 				cfg.Cache.Enabled, cfg.Cache.DefaultTTL, cfg.Cache.TTLByTier, cfg.Cache.SimilarityThreshold, cfg.Cache.MaxEntriesPerTenant)
@@ -496,6 +498,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 				return activeRunTracker.Count(metricsTenantID)
 			}),
 			metrics.WithTenantID(metricsTenantID),
+			metrics.WithCurrency(pricingTable.CurrencyCode()),
 			// Sessions panel (#199): re-derived from evidence at snapshot
 			// time via the same aggregation as `talon audit --session`.
 			metrics.WithSessionQuerier(evidenceStore),

--- a/internal/evidence/export.go
+++ b/internal/evidence/export.go
@@ -21,10 +21,14 @@ type ExportRecord struct {
 	InvocationType string    `json:"invocation_type"`
 	Allowed        bool      `json:"allowed"`
 	Cost           float64   `json:"cost"`
-	ModelUsed      string    `json:"model_used"`
-	Provider       string    `json:"provider,omitempty"`
-	InputTokens    int       `json:"input_tokens,omitempty"`
-	OutputTokens   int       `json:"output_tokens,omitempty"`
+	// Currency is the ISO-4217 unit of Cost, stamped from the pricing table
+	// at write time (#216). Trailing/omitempty; empty for pre-field records
+	// (which were USD-denominated).
+	Currency     string `json:"currency,omitempty"`
+	ModelUsed    string `json:"model_used"`
+	Provider     string `json:"provider,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
 	// Prompt-cache token detail + how cost was derived (#196).
 	CacheReadTokens  int    `json:"cache_read_tokens,omitempty"`
 	CacheWriteTokens int    `json:"cache_write_tokens,omitempty"`
@@ -123,6 +127,7 @@ func ToExportRecord(e *Evidence) ExportRecord {
 		InvocationType:          e.InvocationType,
 		Allowed:                 e.PolicyDecision.Allowed,
 		Cost:                    e.Execution.Cost,
+		Currency:                e.Execution.Currency,
 		ModelUsed:               e.Execution.ModelUsed,
 		InputTokens:             e.Execution.Tokens.Input,
 		OutputTokens:            e.Execution.Tokens.Output,

--- a/internal/evidence/session_summary.go
+++ b/internal/evidence/session_summary.go
@@ -16,18 +16,22 @@ import (
 // distinct top-level agent_id (caller) values observed so a cross-caller
 // session_id collision is visible rather than silently merged.
 type SessionSummary struct {
-	SessionID        string               `json:"session_id"`
-	TenantID         string               `json:"tenant_id"`
-	SessionSource    string               `json:"session_source,omitempty"` // orchestration session_source (client_asserted|vendor_asserted|synthetic), first seen
-	Client           string               `json:"client,omitempty"`         // orchestration client adapter (claude-code|codex|generic), first seen
-	Callers          []string             `json:"callers,omitempty"`
-	Providers        []string             `json:"providers,omitempty"`
-	Models           []string             `json:"models,omitempty"`
-	RecordCount      int                  `json:"record_count"`
-	Allowed          int                  `json:"allowed"`
-	Denied           int                  `json:"denied"`
-	Errors           int                  `json:"errors"`
-	TotalCost        float64              `json:"total_cost"`
+	SessionID     string   `json:"session_id"`
+	TenantID      string   `json:"tenant_id"`
+	SessionSource string   `json:"session_source,omitempty"` // orchestration session_source (client_asserted|vendor_asserted|synthetic), first seen
+	Client        string   `json:"client,omitempty"`         // orchestration client adapter (claude-code|codex|generic), first seen
+	Callers       []string `json:"callers,omitempty"`
+	Providers     []string `json:"providers,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	RecordCount   int      `json:"record_count"`
+	Allowed       int      `json:"allowed"`
+	Denied        int      `json:"denied"`
+	Errors        int      `json:"errors"`
+	TotalCost     float64  `json:"total_cost"`
+	// Currency is the ISO-4217 unit of TotalCost, taken from the records'
+	// stamped currency (#216); empty when no record carries one (pre-field
+	// records — render as USD, the unit the shipped tables always used).
+	Currency         string               `json:"currency,omitempty"`
 	InputTokens      int                  `json:"input_tokens"`
 	OutputTokens     int                  `json:"output_tokens"`
 	CacheReadTokens  int                  `json:"cache_read_tokens,omitempty"`
@@ -135,6 +139,9 @@ func (a *sessionAgg) addOutcome(ev *Evidence) {
 }
 
 func (a *sessionAgg) addTotals(ev *Evidence) {
+	if a.sum.Currency == "" && ev.Execution.Currency != "" {
+		a.sum.Currency = ev.Execution.Currency
+	}
 	a.sum.TotalCost += ev.Execution.Cost
 	a.sum.InputTokens += ev.Execution.Tokens.Input
 	a.sum.OutputTokens += ev.Execution.Tokens.Output

--- a/internal/evidence/session_summary_test.go
+++ b/internal/evidence/session_summary_test.go
@@ -38,6 +38,10 @@ func TestBuildSessionSummary_TotalsAndCounts(t *testing.T) {
 		rec("sess1", "acme", "coder", true, 0.05, 300, 50, 0, 0, "anthropic", "claude-sonnet-5", nil),
 	}
 	records[1].Execution.Error = "secret retrieval error"
+	// Deny record carries no currency (cost 0); the summary takes the unit
+	// from the first record that has one (#216).
+	records[0].Execution.Currency = "USD"
+	records[2].Execution.Currency = "USD"
 
 	sum := BuildSessionSummary("sess1", records)
 
@@ -46,6 +50,7 @@ func TestBuildSessionSummary_TotalsAndCounts(t *testing.T) {
 	assert.Equal(t, 1, sum.Denied)
 	assert.Equal(t, 1, sum.Errors)
 	assert.Equal(t, "acme", sum.TenantID)
+	assert.Equal(t, "USD", sum.Currency)
 	assert.InDelta(t, 0.15, sum.TotalCost, 1e-9)
 	assert.Equal(t, 1300, sum.InputTokens)
 	assert.Equal(t, 250, sum.OutputTokens)

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -320,18 +320,23 @@ type AttachmentScan struct {
 
 // Execution captures LLM call details.
 type Execution struct {
-	ModelUsed     string     `json:"model_used"`
-	OriginalModel string     `json:"original_model,omitempty"`
-	Degraded      bool       `json:"degraded,omitempty"`
-	ToolsCalled   []string   `json:"tools_called,omitempty"`
-	Cost          float64    `json:"cost"`
-	EstimatedCost float64    `json:"estimated_cost,omitempty"`
-	Tokens        TokenUsage `json:"tokens"`
-	MemoryTokens  int        `json:"memory_tokens,omitempty"` // tokens injected from memory context
-	DurationMS    int64      `json:"duration_ms"`
-	TTFTMS        int64      `json:"ttft_ms,omitempty"` // time to first token (streaming)
-	TPOTMS        float64    `json:"tpot_ms,omitempty"` // time per output token (streaming)
-	Error         string     `json:"error,omitempty"`
+	ModelUsed     string   `json:"model_used"`
+	OriginalModel string   `json:"original_model,omitempty"`
+	Degraded      bool     `json:"degraded,omitempty"`
+	ToolsCalled   []string `json:"tools_called,omitempty"`
+	Cost          float64  `json:"cost"`
+	EstimatedCost float64  `json:"estimated_cost,omitempty"`
+	// Currency is the ISO-4217 unit Cost/EstimatedCost are denominated in,
+	// stamped from the active pricing table at write time (#216). Additive
+	// omitempty; records that predate the field default to USD at render
+	// time (the shipped tables were always USD-denominated).
+	Currency     string     `json:"currency,omitempty"`
+	Tokens       TokenUsage `json:"tokens"`
+	MemoryTokens int        `json:"memory_tokens,omitempty"` // tokens injected from memory context
+	DurationMS   int64      `json:"duration_ms"`
+	TTFTMS       int64      `json:"ttft_ms,omitempty"` // time to first token (streaming)
+	TPOTMS       float64    `json:"tpot_ms,omitempty"` // time per output token (streaming)
+	Error        string     `json:"error,omitempty"`
 	// PricingBasis records how Cost was derived (#196): "table" (model+cache
 	// rates from the pricing file), "cache_fallback_input_rate" (cache tokens
 	// priced at the input rate because cache rates were absent), or
@@ -1617,6 +1622,7 @@ type Index struct {
 	InvocationType           string      `json:"invocation_type"`
 	Allowed                  bool        `json:"allowed"`
 	Cost                     float64     `json:"cost"`
+	Currency                 string      `json:"currency,omitempty"` // ISO-4217 unit of Cost (#216); empty for pre-field records
 	ModelUsed                string      `json:"model_used"`
 	DurationMS               int64       `json:"duration_ms"`
 	HasError                 bool        `json:"has_error"`
@@ -1792,6 +1798,7 @@ func toIndex(full *Evidence) Index {
 		InvocationType: full.InvocationType,
 		Allowed:        full.PolicyDecision.Allowed,
 		Cost:           full.Execution.Cost,
+		Currency:       full.Execution.Currency,
 		ModelUsed:      full.Execution.ModelUsed,
 		DurationMS:     full.Execution.DurationMS,
 		HasError:       full.Execution.Error != "",

--- a/internal/gateway/currency_evidence_test.go
+++ b/internal/gateway/currency_evidence_test.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Evidence records stamp the pricing table's currency at write time (#216),
+// on ALLOWED requests and — load-bearing for the #107 governed-session demo —
+// on session-budget DENIALS, which must also carry the session id so
+// `talon audit verify --session` sees every decision in the session.
+func TestEvidenceCurrencyStamp_AllowedAndSessionDeny(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allowed request carries currency and session id", func(t *testing.T) {
+		t.Parallel()
+		evStore, _, handler := newSessionBudgetGateway(t, ModeEnforce, 10)
+		rec := sbDo(t, handler, "openai", sbTenantKeyA, "sess-cur-allow")
+		require.Equal(t, http.StatusOK, rec.Code)
+		ev := lastGatewayEvidence(t, evStore, "tenant-a")
+		assert.Equal(t, "USD", ev.Execution.Currency)
+		assert.Equal(t, "sess-cur-allow", ev.SessionID)
+	})
+
+	t.Run("session budget deny carries currency and session id", func(t *testing.T) {
+		t.Parallel()
+		// Cap below the deterministic pre-request estimate (1.0): the very
+		// first request is denied pre-forward.
+		evStore, _, handler := newSessionBudgetGateway(t, ModeEnforce, 0.5)
+		rec := sbDo(t, handler, "openai", sbTenantKeyA, "sess-cur-deny")
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Contains(t, rec.Body.String(), "session_budget_exceeded")
+		ev := lastGatewayEvidence(t, evStore, "tenant-a")
+		require.False(t, ev.PolicyDecision.Allowed)
+		assert.Equal(t, "USD", ev.Execution.Currency)
+		assert.Equal(t, "sess-cur-deny", ev.SessionID,
+			"deny evidence must attach to the session for audit verify --session")
+		require.NotNil(t, ev.SessionBudget)
+	})
+}

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -33,6 +33,7 @@ type RecordGatewayEvidenceParams struct {
 	OutputPIITypes          []string
 	Cost                    float64
 	EstimatedCost           float64
+	Currency                string // ISO-4217 unit of Cost/EstimatedCost, from the pricing table (#216)
 	InputTokens             int
 	OutputTokens            int
 	CacheReadTokens         int
@@ -139,6 +140,7 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 			ModelUsed:     params.Model,
 			Cost:          params.Cost,
 			EstimatedCost: params.EstimatedCost,
+			Currency:      params.Currency,
 			Tokens:        evidence.TokenUsage{Input: params.InputTokens, Output: params.OutputTokens, CacheRead: params.CacheReadTokens, CacheWrite: params.CacheWriteTokens},
 			PricingBasis:  params.PricingBasis,
 			PricingKnown:  params.PricingKnown,

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -487,6 +487,7 @@ func (g *Gateway) recordFailoverAttemptEvidence(ctx context.Context, correlation
 		Provider:       rec.Provider,
 		Model:          rec.Model,
 		PolicyAllowed:  true,
+		Currency:       g.pricingCurrency,
 		InputTier:      tier,
 		DurationMS:     rec.DurationMS,
 		Error:          errMsg,

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -124,6 +124,10 @@ type Gateway struct {
 	canonicalTenantIDs map[string]string
 	metricsRecorder    MetricsRecorder
 	sessionStore       *session.Store
+	// pricingCurrency is the ISO-4217 code of the pricing table backing
+	// costEstimate; stamped into evidence so records stay self-describing
+	// if the operator later changes the table (#216).
+	pricingCurrency string
 	// budgetAlertLast tracks last time we emitted a budget alert per tenant+period+threshold to avoid spamming
 	budgetAlertMu   sync.Mutex
 	budgetAlertLast map[string]time.Time
@@ -157,6 +161,13 @@ func (g *Gateway) SetMetricsRecorder(mr MetricsRecorder) {
 // SetSessionStore attaches a session store for lifecycle tracking. Call after NewGateway.
 func (g *Gateway) SetSessionStore(ss *session.Store) {
 	g.sessionStore = ss
+}
+
+// SetPricingCurrency records the ISO-4217 code of the pricing table backing
+// the cost estimator so evidence records carry their cost unit (#216). Call
+// after NewGateway.
+func (g *Gateway) SetPricingCurrency(code string) {
+	g.pricingCurrency = code
 }
 
 // SetCache wires the optional semantic cache into the gateway. Call after NewGateway when cache is enabled.
@@ -1336,6 +1347,7 @@ func (g *Gateway) recordEvidence(ctx context.Context, correlationID string, call
 		OutputPIITypes:          outputPIITypes,
 		Cost:                    cost,
 		EstimatedCost:           estimatedCost,
+		Currency:                g.pricingCurrency,
 		InputTokens:             inputTokens,
 		OutputTokens:            outputTokens,
 		CacheReadTokens:         cacheReadTokens,

--- a/internal/gateway/governed_session_config_test.go
+++ b/internal/gateway/governed_session_config_test.go
@@ -1,0 +1,50 @@
+package gateway_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/stretchr/testify/require"
+)
+
+// The governed-session demo (#107 Act II) runs against REAL providers; this
+// guards the example config so the demo cannot silently rot: both providers
+// present, the session budget cap and admin_* tool governance configured,
+// PII blocking on, and prompt logging off (real traffic).
+func TestLoadGovernedSessionGatewayConfig(t *testing.T) {
+	t.Parallel()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	path := filepath.Join(repoRoot, "examples", "governed-session", "talon.config.session.yaml")
+
+	cfg, err := gateway.LoadGatewayConfig(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Enabled)
+	require.Equal(t, gateway.ModeEnforce, cfg.Mode)
+	require.Equal(t, "block", cfg.ServerDefaults.DefaultPIIAction)
+	require.True(t, cfg.ServerDefaults.CallerIDRequired())
+	require.False(t, cfg.ServerDefaults.LogPrompts, "real-provider demo must not store prompt bodies")
+	require.Positive(t, cfg.ServerDefaults.MaxDailyCost, "real-money safety net must be configured")
+
+	anthropic, ok := cfg.Provider("anthropic")
+	require.True(t, ok)
+	require.Contains(t, anthropic.AllowedModels, "claude-sonnet-5")
+	openai, ok := cfg.Provider("openai")
+	require.True(t, ok)
+	require.Contains(t, openai.AllowedModels, "gpt-4o")
+
+	var sessionCaller *gateway.CallerConfig
+	for i := range cfg.Callers {
+		if cfg.Callers[i].Name == "session-demo" {
+			sessionCaller = &cfg.Callers[i]
+		}
+	}
+	require.NotNil(t, sessionCaller)
+	require.NotNil(t, sessionCaller.PolicyOverrides)
+	require.InDelta(t, 0.04, sessionCaller.PolicyOverrides.MaxSessionCost, 1e-9,
+		"session budget gate: demo.sh budget-gate loop is tuned to this cap")
+	require.Contains(t, sessionCaller.PolicyOverrides.ForbiddenTools, "admin_*")
+}

--- a/internal/gateway/session_budget_test.go
+++ b/internal/gateway/session_budget_test.go
@@ -110,6 +110,7 @@ func newSessionBudgetGateway(t *testing.T, mode Mode, maxSessionCost float64) (e
 	gw, err := NewGateway(cfg, classifier.MustNewScanner(), evStore, secStore, policyEngine, sbEstimator)
 	require.NoError(t, err)
 	gw.SetSessionStore(sessStore)
+	gw.SetPricingCurrency("USD")
 	r := chi.NewRouter()
 	r.Route("/v1/proxy", func(r chi.Router) { r.Handle("/*", gw) })
 	return evStore, sessStore, r

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -13,8 +13,14 @@ import (
 
 // Snapshot is the complete dashboard state returned by GET /api/v1/metrics.
 type Snapshot struct {
-	GeneratedAt       time.Time           `json:"generated_at"`
-	EnforcementMode   string              `json:"enforcement_mode"`
+	GeneratedAt     time.Time `json:"generated_at"`
+	EnforcementMode string    `json:"enforcement_mode"`
+	// Currency is the ISO-4217 unit of every cost figure in this snapshot,
+	// from the active pricing table (#216). Field/JSON names keep their
+	// legacy _eur suffix for consumer compatibility; Currency is the
+	// authoritative unit. Empty on snapshots from servers that predate the
+	// field (render as USD).
+	Currency          string              `json:"currency,omitempty"`
 	Uptime            string              `json:"uptime"`
 	DroppedEvents     uint64              `json:"dropped_events,omitempty"`
 	Summary           Summary             `json:"summary"`
@@ -286,6 +292,7 @@ type Collector struct {
 	mu                  sync.RWMutex
 	startTime           time.Time
 	enforcementMode     string
+	currency            string // ISO-4217 unit of cost figures, from the pricing table (#216)
 	events              chan GatewayEvent
 	done                chan struct{}
 	buckets             map[string]*bucket
@@ -354,6 +361,12 @@ func WithActiveRunsFn(fn func() int) CollectorOption {
 // WithTenantID scopes aggregate queries to a specific tenant.
 func WithTenantID(tenantID string) CollectorOption {
 	return func(c *Collector) { c.tenantID = tenantID }
+}
+
+// WithCurrency records the ISO-4217 code of the pricing table backing the
+// gateway's cost figures so snapshots carry their cost unit (#216).
+func WithCurrency(code string) CollectorOption {
+	return func(c *Collector) { c.currency = code }
 }
 
 // WithPlanStatsFn sets a callback for plan lifecycle counters.
@@ -760,6 +773,7 @@ func (c *Collector) buildInMemorySnapshot() Snapshot {
 	return Snapshot{
 		GeneratedAt:     now,
 		EnforcementMode: c.enforcementMode,
+		Currency:        c.currency,
 		Uptime:          uptime,
 		DroppedEvents:   c.DroppedEvents(),
 		Summary: Summary{

--- a/internal/metrics/projection.go
+++ b/internal/metrics/projection.go
@@ -166,6 +166,11 @@ func SnapshotFromEvidenceRecords(records []evidence.Evidence, now time.Time) Sna
 	}
 	for i := range records {
 		c.processEvent(GatewayEventFromEvidence(&records[i]))
+		if c.currency == "" {
+			// Standalone snapshots have no pricing table in scope: take the
+			// cost unit from the records themselves (#216).
+			c.currency = records[i].Execution.Currency
+		}
 	}
 	snap := c.buildInMemorySnapshot()
 	snap.GeneratedAt = now.UTC()

--- a/internal/policy/rego/gateway_access.rego
+++ b/internal/policy/rego/gateway_access.rego
@@ -35,12 +35,13 @@ deny contains msg if {
 	msg := sprintf("Model %s is blocked for this caller", [input.model])
 }
 
-# Per-caller daily cost limit.
+# Per-caller daily cost limit. Amounts use %.4f: real per-request API costs
+# are sub-cent, and this message is the evidence-facing deny reason (#255).
 deny contains msg if {
 	input.caller_max_daily_cost != null
 	input.caller_max_daily_cost > 0
 	input.daily_cost + input.estimated_cost > input.caller_max_daily_cost
-	msg := sprintf("budget_exceeded: request would exceed caller daily cost limit (%.2f)", [input.caller_max_daily_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller daily cost limit (%.4f)", [input.caller_max_daily_cost])
 }
 
 # Per-caller monthly cost limit.
@@ -48,7 +49,7 @@ deny contains msg if {
 	input.caller_max_monthly_cost != null
 	input.caller_max_monthly_cost > 0
 	input.monthly_cost + input.estimated_cost > input.caller_max_monthly_cost
-	msg := sprintf("budget_exceeded: request would exceed caller monthly cost limit (%.2f)", [input.caller_max_monthly_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller monthly cost limit (%.4f)", [input.caller_max_monthly_cost])
 }
 
 # Per-caller session cost limit (#198): soft cap over one coding session.
@@ -63,7 +64,7 @@ deny contains msg if {
 	input.caller_max_session_cost != null
 	input.caller_max_session_cost > 0
 	input.session_cost_total + input.estimated_cost > input.caller_max_session_cost
-	msg := sprintf("session_budget_exceeded: session spend %.2f + estimate %.2f exceeds limit %.2f", [input.session_cost_total, input.estimated_cost, input.caller_max_session_cost])
+	msg := sprintf("session_budget_exceeded: session spend %.4f + estimate %.4f exceeds limit %.4f", [input.session_cost_total, input.estimated_cost, input.caller_max_session_cost])
 }
 
 # Per-caller data tier restriction: request tier must not exceed caller's max.

--- a/internal/policy/rego/gateway_access.rego
+++ b/internal/policy/rego/gateway_access.rego
@@ -35,13 +35,15 @@ deny contains msg if {
 	msg := sprintf("Model %s is blocked for this caller", [input.model])
 }
 
-# Per-caller daily cost limit. Amounts use %.4f: real per-request API costs
-# are sub-cent, and this message is the evidence-facing deny reason (#255).
+# Per-caller daily cost limit. Amounts use %v with 4-decimal rounding: real
+# per-request API costs are sub-cent (so %.2f rendered 0.00), and OPA sprintf
+# refuses %f entirely for integral JSON numbers (#255). This message is the
+# evidence-facing deny reason.
 deny contains msg if {
 	input.caller_max_daily_cost != null
 	input.caller_max_daily_cost > 0
 	input.daily_cost + input.estimated_cost > input.caller_max_daily_cost
-	msg := sprintf("budget_exceeded: request would exceed caller daily cost limit (%.4f)", [input.caller_max_daily_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller daily cost limit (%v)", [round(input.caller_max_daily_cost * 10000) / 10000])
 }
 
 # Per-caller monthly cost limit.
@@ -49,7 +51,7 @@ deny contains msg if {
 	input.caller_max_monthly_cost != null
 	input.caller_max_monthly_cost > 0
 	input.monthly_cost + input.estimated_cost > input.caller_max_monthly_cost
-	msg := sprintf("budget_exceeded: request would exceed caller monthly cost limit (%.4f)", [input.caller_max_monthly_cost])
+	msg := sprintf("budget_exceeded: request would exceed caller monthly cost limit (%v)", [round(input.caller_max_monthly_cost * 10000) / 10000])
 }
 
 # Per-caller session cost limit (#198): soft cap over one coding session.
@@ -64,7 +66,9 @@ deny contains msg if {
 	input.caller_max_session_cost != null
 	input.caller_max_session_cost > 0
 	input.session_cost_total + input.estimated_cost > input.caller_max_session_cost
-	msg := sprintf("session_budget_exceeded: session spend %.4f + estimate %.4f exceeds limit %.4f", [input.session_cost_total, input.estimated_cost, input.caller_max_session_cost])
+	# %v (with 4-decimal rounding), not %f: OPA sprintf refuses %f for
+	# integral JSON numbers — a zero spend rendered "%!f(int=0000)" (#255).
+	msg := sprintf("session_budget_exceeded: session spend %v + estimate %v exceeds limit %v", [round(input.session_cost_total * 10000) / 10000, round(input.estimated_cost * 10000) / 10000, round(input.caller_max_session_cost * 10000) / 10000])
 }
 
 # Per-caller data tier restriction: request tier must not exceed caller's max.

--- a/internal/pricing/default_models.yaml
+++ b/internal/pricing/default_models.yaml
@@ -4,6 +4,10 @@
 
 version: "1"
 
+# ISO-4217 code the prices below are denominated in. Costs, budgets, and every
+# cost display use this unit (#216). Default when omitted: USD.
+currency: USD
+
 providers:
   openai:
     models:

--- a/internal/pricing/loader.go
+++ b/internal/pricing/loader.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -31,6 +32,9 @@ func DefaultModelsYAML() []byte {
 // e.g. gpt-4o-2024-08-06 -> gpt-4o, claude-3-5-sonnet-20241022-v2 -> claude-3-5-sonnet
 var apiModelSuffix = regexp.MustCompile(`-(?:20\d{2}-\d{2}-\d{2}|v\d+(?::\d+)?)$`)
 
+// currencyCodeRe matches a 3-letter ISO-4217 currency code (after uppercasing).
+var currencyCodeRe = regexp.MustCompile(`^[A-Z]{3}$`)
+
 // unknownModelWarned tracks (providerID, model) pairs we have already logged to avoid spam.
 var unknownModelWarned sync.Map
 
@@ -42,7 +46,12 @@ func WarnUnknownModelOnce(providerID, model string) {
 	}
 }
 
-// ModelPricing holds per-1M-token USD prices for a single model.
+// DefaultCurrency is the currency assumed when a pricing table declares none.
+// The shipped tables are denominated in USD, so USD is the honest default (#216).
+const DefaultCurrency = "USD"
+
+// ModelPricing holds per-1M-token prices for a single model, denominated in
+// the table's declared currency (see PricingTable.Currency).
 type ModelPricing struct {
 	InputPer1M  float64 `yaml:"input_per_1m"`
 	OutputPer1M float64 `yaml:"output_per_1m"`
@@ -63,8 +72,36 @@ type ProviderPricing struct {
 //
 //nolint:revive // exported type name matches package; "PricingTable" is the documented API
 type PricingTable struct {
-	Version   string                     `yaml:"version"`
+	Version string `yaml:"version"`
+	// Currency is the ISO-4217 code all prices in this table are denominated
+	// in (and therefore the unit of every cost Talon computes and every
+	// budget cap compared against those costs). Optional; defaults to USD,
+	// matching the shipped tables (#216).
+	Currency  string                     `yaml:"currency,omitempty"`
 	Providers map[string]ProviderPricing `yaml:"providers"`
+}
+
+// CurrencyCode returns the table's ISO-4217 currency code, defaulting to USD
+// for tables that predate the currency field. Nil-safe.
+func (t *PricingTable) CurrencyCode() string {
+	if t == nil || t.Currency == "" {
+		return DefaultCurrency
+	}
+	return t.Currency
+}
+
+// FormatAmount prefixes an already-formatted numeric amount with the
+// currency's conventional symbol (USD → $, EUR → €); other codes are used as
+// a textual prefix ("CHF 1.23"). An empty code falls back to DefaultCurrency.
+func FormatAmount(code, amount string) string {
+	switch strings.ToUpper(code) {
+	case "", DefaultCurrency:
+		return "$" + amount
+	case "EUR":
+		return "€" + amount
+	default:
+		return strings.ToUpper(code) + " " + amount
+	}
 }
 
 // loadFromData parses YAML bytes, resolves inherit references (single depth, no chains),
@@ -77,6 +114,14 @@ func loadFromData(data []byte) (*PricingTable, error) {
 
 	if raw.Providers == nil {
 		raw.Providers = make(map[string]ProviderPricing)
+	}
+
+	raw.Currency = strings.ToUpper(strings.TrimSpace(raw.Currency))
+	if raw.Currency == "" {
+		raw.Currency = DefaultCurrency
+	}
+	if !currencyCodeRe.MatchString(raw.Currency) {
+		return nil, fmt.Errorf("invalid currency %q: expected a 3-letter ISO-4217 code (e.g. USD, EUR)", raw.Currency)
 	}
 
 	// Resolve inherit and validate
@@ -107,7 +152,7 @@ func loadFromData(data []byte) (*PricingTable, error) {
 		resolved[id] = pp
 	}
 
-	return &PricingTable{Version: raw.Version, Providers: resolved}, nil
+	return &PricingTable{Version: raw.Version, Currency: raw.Currency, Providers: resolved}, nil
 }
 
 // Load parses the YAML file at path, resolves inherit references (single depth, no chains),
@@ -150,7 +195,7 @@ func LoadOrDefault(path string) *PricingTable {
 		defaultTable, defaultErr := loadFromData(defaultModelsYAML)
 		if defaultErr != nil {
 			log.Warn().Err(defaultErr).Msg("embedded default pricing invalid; cost estimation will return 0")
-			return &PricingTable{Version: "1", Providers: map[string]ProviderPricing{}}
+			return &PricingTable{Version: "1", Currency: DefaultCurrency, Providers: map[string]ProviderPricing{}}
 		}
 		log.Info().Err(err).Str("path_attempted", abs).Msg("pricing file not found; using embedded default pricing")
 		return defaultTable
@@ -158,7 +203,8 @@ func LoadOrDefault(path string) *PricingTable {
 	return table
 }
 
-// Estimate looks up provider and model, computes cost in USD, and returns (cost, true) if found.
+// Estimate looks up provider and model, computes cost in the table's declared
+// currency (CurrencyCode), and returns (cost, true) if found.
 // Returns (0.0, false) if provider or model is not in the table. Safe for concurrent use.
 // If the provider exists with an empty models map (e.g. ollama), returns (0.0, true) for any model (free).
 // Model lookup tries exact key first, then a base name (e.g. gpt-4o-2024-08-06 -> gpt-4o) so API-returned

--- a/internal/pricing/loader_test.go
+++ b/internal/pricing/loader_test.go
@@ -222,3 +222,43 @@ func TestEstimateCached_UnknownModel(t *testing.T) {
 	assert.False(t, fallback)
 	assert.Equal(t, 0.0, cost)
 }
+
+// Currency (#216): the table declares the ISO-4217 unit of its prices; every
+// cost Talon computes and displays uses it. Default is USD — the unit the
+// shipped tables were always denominated in.
+func TestCurrency_DefaultAndDeclared(t *testing.T) {
+	// Shipped tables declare USD explicitly.
+	table, err := Load("../../pricing/models.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "USD", table.CurrencyCode())
+
+	// Absent currency → USD (pre-field tables were USD).
+	legacy, err := loadFromData([]byte("version: \"1\"\nproviders: {}\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "USD", legacy.CurrencyCode())
+
+	// Declared currency is normalized (trimmed, uppercased).
+	eur, err := loadFromData([]byte("version: \"1\"\ncurrency: \" eur \"\nproviders: {}\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "EUR", eur.CurrencyCode())
+
+	// Nil table is safe and defaults.
+	var nilTable *PricingTable
+	assert.Equal(t, "USD", nilTable.CurrencyCode())
+}
+
+func TestCurrency_InvalidCodeRejected(t *testing.T) {
+	for _, bad := range []string{"EURO", "E", "12A", "US-D"} {
+		_, err := loadFromData([]byte("version: \"1\"\ncurrency: \"" + bad + "\"\nproviders: {}\n"))
+		require.Error(t, err, "currency %q must be rejected", bad)
+		assert.Contains(t, err.Error(), "invalid currency")
+	}
+}
+
+func TestFormatAmount(t *testing.T) {
+	assert.Equal(t, "$1.23", FormatAmount("USD", "1.23"))
+	assert.Equal(t, "$1.23", FormatAmount("", "1.23"), "empty code renders as USD (pre-field records)")
+	assert.Equal(t, "€1.23", FormatAmount("EUR", "1.23"))
+	assert.Equal(t, "CHF 1.23", FormatAmount("CHF", "1.23"))
+	assert.Equal(t, "€0.42", FormatAmount("eur", "0.42"), "case-insensitive")
+}

--- a/pricing/models.yaml
+++ b/pricing/models.yaml
@@ -1,12 +1,18 @@
 # pricing/models.yaml
 # Operator-editable LLM pricing table.
-# Prices are per 1,000,000 tokens in USD.
+# Prices are per 1,000,000 tokens, denominated in `currency` below.
 # Update this file when providers change pricing — no recompilation required.
 #
 # To disable cost estimation for a provider, omit it or set prices to 0.
 # Unknown models return cost 0.0 with a warning log.
 
 version: "1"
+
+# ISO-4217 code the prices below are denominated in. Costs, budget caps
+# (max_daily_cost / max_monthly_cost / max_session_cost), and every cost
+# display use this unit (#216). Default when omitted: USD. Teams that want
+# EUR set `currency: EUR` and maintain EUR-denominated rates here.
+currency: USD
 
 providers:
   openai:

--- a/scripts/governed-session-up.sh
+++ b/scripts/governed-session-up.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Start the #107 governed-session demo stack (REAL providers) and wait for health.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEMO_DIR="${REPO_ROOT}/examples/governed-session"
+GATEWAY="${GATEWAY:-http://localhost:${DEMO_GATEWAY_PORT:-8080}}"
+TIMEOUT="${GOVERNED_SESSION_TIMEOUT:-120}"
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" || -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "✗ governed-session demo needs REAL provider keys in the environment:" >&2
+  echo "    export ANTHROPIC_API_KEY=sk-ant-..." >&2
+  echo "    export OPENAI_API_KEY=sk-..." >&2
+  echo "  A full ./demo.sh all run costs about \$0.05 (cheap models, session-capped)." >&2
+  exit 1
+fi
+
+# shellcheck source=lib/docker-compose-detect.sh
+source "${REPO_ROOT}/scripts/lib/docker-compose-detect.sh"
+detect_docker_compose
+
+cd "$DEMO_DIR"
+
+echo "==> Building and starting governed-session demo stack (real providers)..."
+$COMPOSE up --build -d
+
+echo "==> Waiting for Talon health (timeout ${TIMEOUT}s)..."
+elapsed=0
+while [[ "$elapsed" -lt "$TIMEOUT" ]]; do
+  if curl -sf "${GATEWAY}/health" >/dev/null 2>&1; then
+    echo "    Talon healthy at ${GATEWAY} (${elapsed}s)"
+    echo ""
+    echo "Next: cd examples/governed-session && ./demo.sh all"
+    exit 0
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+  if [[ $((elapsed % 10)) -eq 0 ]]; then
+    echo "    still waiting (${elapsed}s)..."
+  fi
+done
+
+echo "✗ Talon did not become healthy within ${TIMEOUT}s" >&2
+echo "  → $COMPOSE logs talon   (missing/invalid API keys exit the container early)" >&2
+exit 1

--- a/scripts/record-governed-session.sh
+++ b/scripts/record-governed-session.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Record the #107 governed-session demo as an asciinema cast (+ optional GIF).
+# Run on a dev machine with REAL keys exported and the stack already healthy
+# (make governed-session). Not a CI step: real spend + timestamp churn.
+#
+#   scripts/record-governed-session.sh
+#
+# Outputs:
+#   docs/assets/governed-session.cast   (committed source of truth)
+#   docs/assets/governed-session.gif    (README embed; only when `agg` exists)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEMO_DIR="${REPO_ROOT}/examples/governed-session"
+ASSET_DIR="${REPO_ROOT}/docs/assets"
+CAST="${ASSET_DIR}/governed-session.cast"
+GIF="${ASSET_DIR}/governed-session.gif"
+GATEWAY="${GATEWAY:-http://localhost:8080}"
+
+if ! command -v asciinema >/dev/null 2>&1; then
+  echo "✗ asciinema is required: brew install asciinema  (or pipx install asciinema)" >&2
+  exit 1
+fi
+if ! curl -sf "${GATEWAY}/health" >/dev/null 2>&1; then
+  echo "✗ Stack not healthy at ${GATEWAY} — run: make governed-session" >&2
+  exit 1
+fi
+
+mkdir -p "$ASSET_DIR"
+cd "$DEMO_DIR"
+
+echo "==> Recording ./demo.sh all (real API calls, ~\$0.05)..."
+asciinema rec --overwrite --cols 100 --rows 32 --idle-time-limit 2 \
+  -c "./demo.sh all" "$CAST"
+echo "    Wrote ${CAST}"
+
+if command -v agg >/dev/null 2>&1; then
+  echo "==> Rendering GIF..."
+  agg --font-size 16 "$CAST" "$GIF"
+  echo "    Wrote ${GIF}"
+else
+  echo "⚠ agg not found — skipping GIF render (cargo install agg / brew install agg)"
+fi
+
+echo ""
+echo "Review the recording, then commit the assets under docs/assets/."

--- a/scripts/shortlist-demo-up.sh
+++ b/scripts/shortlist-demo-up.sh
@@ -13,6 +13,14 @@ detect_docker_compose
 
 cd "$DEMO_DIR"
 
+# The compose file bind-mounts ./out into the container, and Proof 6 writes the
+# compliance exports from INSIDE the container. On Linux hosts the checkout owns
+# ./out under the host uid, so the container's talon user cannot write it (#258;
+# macOS Docker uid-mapping hides this on dev machines). World-writable is fine
+# for throwaway demo artifacts.
+mkdir -p out
+chmod 0777 out
+
 echo "==> Building and starting shortlist demo stack..."
 $COMPOSE up --build -d
 

--- a/tests/e2e/costs_test.go
+++ b/tests/e2e/costs_test.go
@@ -36,8 +36,9 @@ func TestE2E_CostsShowsSpend(t *testing.T) {
 	if !regexp.MustCompile(`Agent|Today|Month|Total`).MatchString(stdout) {
 		t.Errorf("costs output should contain table headers, got: %s", stdout)
 	}
-	// Costs are shown in EUR (€)
-	if !strings.Contains(stdout, "€") {
-		t.Errorf("costs output should show euro amounts (doc promise), got: %s", stdout)
+	// Costs are shown in the pricing table's declared currency (#216) —
+	// the shipped table is USD, so amounts render with a $ symbol.
+	if !strings.Contains(stdout, "$") {
+		t.Errorf("costs output should show amounts in the pricing-table currency (default USD/$), got: %s", stdout)
 	}
 }

--- a/tests/smoke_sections/23_dashboard_metrics.sh
+++ b/tests/smoke_sections/23_dashboard_metrics.sh
@@ -206,7 +206,8 @@ CACHEEOF
   assert_pass "dashboard HTML contains Success Rate KPI" grep -qi "Success Rate" <<< "$dash_html"
   assert_pass "dashboard HTML contains Timeouts KPI" grep -qi "Timeouts" <<< "$dash_html"
   assert_pass "dashboard HTML contains Violation Trend (7d) panel" grep -qi "Violation Trend (7d)" <<< "$dash_html"
-  assert_pass "dashboard caller table contains EUR/Success column" grep -qi "EUR/Success" <<< "$dash_html"
+  # Header carries the pricing-table currency since #216 (e.g. "Cost/Success (USD)").
+  assert_pass "dashboard caller table contains Cost/Success column" grep -qi "Cost/Success" <<< "$dash_html"
   assert_pass "dashboard caller table contains Trend(7d) column" grep -qi "Trend(7d)" <<< "$dash_html"
   assert_pass "dashboard caller table contains Success column header" grep -q ">Success<" <<< "$dash_html"
   assert_pass "dashboard caller table contains Failed column header" grep -q ">Failed<" <<< "$dash_html"
@@ -481,7 +482,7 @@ CACHEEOF
     fi
     if [[ -n "$cache_saved" ]] && [[ "$cache_saved" != "null" ]]; then
       if [[ "$(echo "${cache_saved:-0} >= 0" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
-        echo "  ✓  semantic cache metrics: cache_stats.cost_saved >= 0 (€$cache_saved)"
+        echo "  ✓  semantic cache metrics: cache_stats.cost_saved >= 0 ($cache_saved)"
         record_pass
       fi
     fi
@@ -489,14 +490,14 @@ CACHEEOF
     assert_pass "talon cache stats exits 0 (semantic cache CLI)" run_talon cache stats
     local costs_cache_line; costs_cache_line="$(run_talon costs 2>/dev/null | grep -i "Cache (7d)" || true)"
     if [[ -n "$costs_cache_line" ]] && [[ -n "$cache_saved" ]] && [[ "$cache_saved" != "null" ]]; then
-      local costs_saved; costs_saved="$(echo "$costs_cache_line" | grep -oE '€[0-9]+\.[0-9]+' | head -1 | tr -d '€')"
+      local costs_saved; costs_saved="$(echo "$costs_cache_line" | grep -oE '[€$][0-9]+\.[0-9]+' | head -1 | tr -d '€$')"
       if [[ -n "$costs_saved" ]]; then
         local saved_diff; saved_diff="$(echo "scale=8; d=$cache_saved - $costs_saved; if (d < 0) -d else d" | bc -l 2>/dev/null || echo 999)"
         if [[ "$(echo "$saved_diff < 0.02" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
-          echo "  ✓  semantic cache CLI↔dashboard parity: cache_stats.cost_saved (€$cache_saved) ≈ talon costs (€$costs_saved)"
+          echo "  ✓  semantic cache CLI↔dashboard parity: cache_stats.cost_saved ($cache_saved) ≈ talon costs ($costs_saved)"
           record_pass
         else
-          echo "  -  cache cost_saved: dashboard €$cache_saved vs CLI €$costs_saved (diff=$saved_diff)"
+          echo "  -  cache cost_saved: dashboard $cache_saved vs CLI $costs_saved (diff=$saved_diff)"
         fi
       fi
     fi
@@ -553,8 +554,9 @@ CACHEEOF
   # --- 23.7: CLI costs ↔ dashboard cost parity ---
   local cli_cost_out; cli_cost_out="$(run_talon costs --tenant default 2>/dev/null)"; true
   assert_pass "talon costs --tenant default exits 0" run_talon costs --tenant default
-  # Extract the "Total" daily cost from CLI (€<value> in the Today column of the Total row)
-  local cli_daily_cost; cli_daily_cost="$(echo "$cli_cost_out" | grep -E '^Total' | grep -oE '€[0-9]+\.[0-9]+' | head -1 | tr -d '€')"
+  # Extract the "Total" daily cost from CLI (currency-symbol-prefixed value in
+  # the Today column of the Total row; symbol follows the pricing table, #216)
+  local cli_daily_cost; cli_daily_cost="$(echo "$cli_cost_out" | grep -E '^Total' | grep -oE '[€$][0-9]+\.[0-9]+' | head -1 | tr -d '€$')"
   if [[ -z "$cli_daily_cost" ]]; then
     cli_daily_cost="$(echo "$cli_cost_out" | grep -i 'today' | grep -oE '[0-9]+\.[0-9]+' | head -1)"
   fi
@@ -568,10 +570,10 @@ CACHEEOF
       # Both query CostTotal(dayStart, dayEnd) from the same SQLite evidence store
       local cost_diff; cost_diff="$(echo "scale=8; d=$dash_daily_used - $cli_daily_cost; if (d < 0) -d else d" | bc -l 2>/dev/null || echo 999)"
       if [[ "$(echo "$cost_diff < 0.01" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
-        echo "  ✓  CLI daily cost (€$cli_daily_cost) ≈ dashboard budget_status.daily_used (€$dash_daily_used)"
+        echo "  ✓  CLI daily cost ($cli_daily_cost) ≈ dashboard budget_status.daily_used ($dash_daily_used)"
         record_pass
       else
-        log_failure "CLI daily cost (€$cli_daily_cost) != dashboard daily_used (€$dash_daily_used), diff=$cost_diff" \
+        log_failure "CLI daily cost ($cli_daily_cost) != dashboard daily_used ($dash_daily_used), diff=$cost_diff" \
           "cli=$cli_daily_cost dash=$dash_daily_used"
       fi
     else
@@ -597,8 +599,8 @@ CACHEEOF
   # CLI costs --by-model: compare model names with dashboard model_breakdown
   local cli_bymodel; cli_bymodel="$(run_talon costs --by-model --tenant default 2>/dev/null)"; true
   assert_pass "talon costs --by-model exits 0" run_talon costs --by-model --tenant default
-  # Extract model names from CLI output (lines between header/footer dashes that start with a non-dash word and have €)
-  local cli_models; cli_models="$(echo "$cli_bymodel" | grep '€' | grep -v '^Total' | awk '{print $1}' | sort)"
+  # Extract model names from CLI output (data rows carry a currency symbol, #216)
+  local cli_models; cli_models="$(echo "$cli_bymodel" | grep -E '[€$]' | grep -v '^Total' | awk '{print $1}' | sort)"
   local dash_models; dash_models="$(jq -r '.model_breakdown[].model // empty' <<< "$snap_after" 2>/dev/null | sort)"
   echo "[SMOKE] CONSISTENCY|cli_models|$(echo "$cli_models" | tr '\n' ',')"
   echo "[SMOKE] CONSISTENCY|dash_models|$(echo "$dash_models" | tr '\n' ',')"
@@ -617,7 +619,7 @@ CACHEEOF
   local cli_byprovider; cli_byprovider="$(run_talon costs --by-provider --tenant default 2>/dev/null)"; true
   assert_pass "talon costs --by-provider exits 0" run_talon costs --by-provider --tenant default
   local cli_providers
-  cli_providers="$(echo "$cli_byprovider" | awk '/€/ {print $1}' | grep -E '^[a-zA-Z0-9._-]+$' | grep -v -E '^(Total|Provider|Tenant|7d)$' | sort)"
+  cli_providers="$(echo "$cli_byprovider" | awk '/[€$]/ {print $1}' | grep -E '^[a-zA-Z0-9._-]+$' | grep -v -E '^(Total|Provider|Tenant|7d)$' | sort)"
   local dash_providers; dash_providers="$(jq -r '.provider_breakdown[].provider // empty' <<< "$snap_after" 2>/dev/null | sort)"
   echo "[SMOKE] CONSISTENCY|cli_providers|$(echo "$cli_providers" | tr '\n' ',')"
   echo "[SMOKE] CONSISTENCY|dash_providers|$(echo "$dash_providers" | tr '\n' ',')"
@@ -691,7 +693,7 @@ CACHEEOF
   if [[ -n "$report_cost" ]] && [[ -n "$cli_daily_cost" ]]; then
     local rc_diff; rc_diff="$(echo "scale=8; d=$report_cost - $cli_daily_cost; if (d < 0) -d else d" | bc -l 2>/dev/null || echo 999)"
     if [[ "$(echo "$rc_diff < 0.01" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
-      echo "  ✓  report cost today (€$report_cost) ≈ CLI costs today (€$cli_daily_cost)"
+      echo "  ✓  report cost today ($report_cost) ≈ CLI costs today ($cli_daily_cost)"
       record_pass
     else
       echo "  -  report vs CLI cost drift: report=$report_cost cli=$cli_daily_cost diff=$rc_diff"
@@ -895,10 +897,10 @@ CACHEEOF
       # cost_per_success * successful <= total caller cost (successes can't cost more than total)
       local success_cost; success_cost="$(echo "scale=8; $cps * $c_succ" | bc -l 2>/dev/null || echo 0)"
       if [[ "$(echo "$success_cost <= $c_cost + 0.0001" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
-        echo "  ✓  $cname cost_per_success*successful (€$success_cost) <= total cost (€$c_cost)"
+        echo "  ✓  $cname cost_per_success*successful ($success_cost) <= total cost ($c_cost)"
         record_pass
       else
-        log_failure "$cname cost_per_success*successful (€$success_cost) > total cost (€$c_cost)" "cps=$cps succ=$c_succ"
+        log_failure "$cname cost_per_success*successful ($success_cost) > total cost ($c_cost)" "cps=$cps succ=$c_succ"
       fi
     fi
   done

--- a/web/gateway_dashboard.html
+++ b/web/gateway_dashboard.html
@@ -215,7 +215,7 @@
   <div class="panel grid-full">
     <div class="panel-title">Caller Breakdown</div>
     <table>
-      <thead><tr><th>Caller</th><th>Requests</th><th>Success</th><th>Failed</th><th>Timeout</th><th>Denied</th><th>Rate</th><th>Cost (EUR)</th><th>EUR/Success</th><th>Avg Latency</th><th>Trend(7d)</th><th>Evidence</th></tr></thead>
+      <thead><tr><th>Caller</th><th>Requests</th><th>Success</th><th>Failed</th><th>Timeout</th><th>Denied</th><th>Rate</th><th data-cost-th="Cost">Cost (USD)</th><th data-cost-th="Cost/Success">Cost/Success (USD)</th><th>Avg Latency</th><th>Trend(7d)</th><th>Evidence</th></tr></thead>
       <tbody id="caller-table"></tbody>
     </table>
   </div>
@@ -227,7 +227,7 @@
     <div class="panel-title">Coding Sessions (orchestration)</div>
     <div class="kpi-sub">Client-asserted coding sessions across providers &mdash; identical numbers to <code>talon audit list --session &lt;id&gt;</code>. Click a session for its per-agent breakdown.</div>
     <table>
-      <thead><tr><th></th><th>Session</th><th>Client</th><th>Caller</th><th>Requests</th><th>Denied</th><th>Models</th><th>Providers</th><th>Tokens in/out</th><th>Cost (EUR)</th><th>Last Active</th></tr></thead>
+      <thead><tr><th></th><th>Session</th><th>Client</th><th>Caller</th><th>Requests</th><th>Denied</th><th>Models</th><th>Providers</th><th>Tokens in/out</th><th data-cost-th="Cost">Cost (USD)</th><th>Last Active</th></tr></thead>
       <tbody id="sessions-table"></tbody>
     </table>
     <div class="kpi-sub" id="sessions-denials" style="margin-top:8px;"></div>
@@ -243,7 +243,7 @@
   <div class="panel" id="panel-models">
     <div class="panel-title">Model Breakdown (today)</div>
     <table>
-      <thead><tr><th>Model</th><th>Cost (EUR)</th><th>Evidence</th></tr></thead>
+      <thead><tr><th>Model</th><th data-cost-th="Cost">Cost (USD)</th><th>Evidence</th></tr></thead>
       <tbody id="model-table"></tbody>
     </table>
   </div>
@@ -251,7 +251,7 @@
   <div class="panel" id="panel-providers">
     <div class="panel-title">Provider Breakdown (today)</div>
     <table>
-      <thead><tr><th>Provider</th><th>Cost (EUR)</th><th>Evidence</th></tr></thead>
+      <thead><tr><th>Provider</th><th data-cost-th="Cost">Cost (USD)</th><th>Evidence</th></tr></thead>
       <tbody id="provider-table"></tbody>
     </table>
   </div>
@@ -403,6 +403,12 @@
 
     document.getElementById('uptime').textContent = d.uptime || '--';
     document.getElementById('last-updated').textContent = 'Updated: ' + new Date(d.generated_at).toLocaleTimeString();
+    // Cost unit comes from the pricing table via the snapshot (#216);
+    // snapshots that predate the field are USD (the shipped tables' unit).
+    CUR = curSym(d.currency);
+    document.querySelectorAll('th[data-cost-th]').forEach(function (th) {
+      th.textContent = th.getAttribute('data-cost-th') + ' (' + (d.currency || 'USD') + ')';
+    });
 
     var s = d.summary || {};
     var reliabilityBadge = document.getElementById('reliability-badge');
@@ -424,7 +430,7 @@
     document.getElementById('kpi-pii').textContent = fmt(s.pii_detections);
     document.getElementById('kpi-pii-sub').textContent = s.pii_redactions ? s.pii_redactions + ' redacted' : '';
     document.getElementById('kpi-tools').textContent = fmt(s.tools_filtered);
-    document.getElementById('kpi-cost').textContent = '€' + (s.total_cost_eur || 0).toFixed(4);
+    document.getElementById('kpi-cost').textContent = CUR + (s.total_cost_eur || 0).toFixed(4);
     document.getElementById('kpi-latency').textContent = s.avg_latency_ms + 'ms';
     document.getElementById('kpi-p99').textContent = 'P99: ' + s.p99_latency_ms + 'ms';
     document.getElementById('kpi-errors').textContent = ((s.error_rate || 0) * 100).toFixed(1) + '%';
@@ -487,6 +493,8 @@
   }
 
   function fmt(n) { return (n == null ? 0 : n).toLocaleString(); }
+  function curSym(code) { if (!code || code === 'USD') return '$'; if (code === 'EUR') return '€'; return code + ' '; }
+  var CUR = '$';
 
   function renderSparkline(id, data, key, stroke, fill) {
     var svg = document.getElementById(id);
@@ -524,7 +532,7 @@
       var cps = c.cost_per_success || 0;
       var cpsClass = (avgCostPerSuccess > 0 && cps > (2 * avgCostPerSuccess)) ? 'cost-hot' : '';
       var evidenceLink = '<a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a>';
-      return '<tr><td>' + esc(c.caller) + '</td><td>' + fmt(c.requests) + '</td><td>' + fmt(c.successful) + '</td><td>' + fmt(c.failed) + '</td><td>' + fmt(c.timed_out) + '</td><td>' + fmt(c.denied) + '</td><td class="' + rateClass + '">' + (rate * 100).toFixed(1) + '%</td><td>€' + (c.cost_eur || 0).toFixed(4) + '</td><td class="' + cpsClass + '">€' + cps.toFixed(4) + '</td><td>' + c.avg_latency_ms + 'ms</td><td>' + renderCallerTrend(c.violation_trend) + '</td><td>' + evidenceLink + '</td></tr>';
+      return '<tr><td>' + esc(c.caller) + '</td><td>' + fmt(c.requests) + '</td><td>' + fmt(c.successful) + '</td><td>' + fmt(c.failed) + '</td><td>' + fmt(c.timed_out) + '</td><td>' + fmt(c.denied) + '</td><td class="' + rateClass + '">' + (rate * 100).toFixed(1) + '%</td><td>' + CUR + (c.cost_eur || 0).toFixed(4) + '</td><td class="' + cpsClass + '">' + CUR + cps.toFixed(4) + '</td><td>' + c.avg_latency_ms + 'ms</td><td>' + renderCallerTrend(c.violation_trend) + '</td><td>' + evidenceLink + '</td></tr>';
     }).join('');
   }
 
@@ -723,7 +731,7 @@
     var tb = document.getElementById('model-table');
     if (models.length === 0) { tb.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No model data</td></tr>'; return; }
     tb.innerHTML = models.map(function(m) {
-      return '<tr><td>' + esc(m.model) + '</td><td>€' + (m.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
+      return '<tr><td>' + esc(m.model) + '</td><td>' + CUR + (m.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
     }).join('');
   }
 
@@ -734,7 +742,7 @@
       return;
     }
     tb.innerHTML = providers.map(function(p) {
-      return '<tr><td>' + esc(p.provider) + '</td><td>€' + (p.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
+      return '<tr><td>' + esc(p.provider) + '</td><td>' + CUR + (p.cost_eur || 0).toFixed(4) + '</td><td><a href="' + evidenceDashboardURL() + '" style="color:var(--brand-light);text-decoration:none;">Open</a></td></tr>';
     }).join('');
   }
 
@@ -745,11 +753,11 @@
     var html = '';
     if (bs.daily_limit > 0) {
       var color = bs.daily_percent > 90 ? 'var(--red)' : bs.daily_percent > 70 ? 'var(--yellow)' : 'var(--green)';
-      html += '<div style="margin-bottom:12px"><div style="display:flex;justify-content:space-between;margin-bottom:4px"><span>Daily</span><span>€' + bs.daily_used.toFixed(2) + ' / €' + bs.daily_limit.toFixed(2) + ' (' + bs.daily_percent.toFixed(1) + '%)</span></div><div class="bar-container"><div class="bar-fill" style="width:' + Math.min(bs.daily_percent, 100) + '%;background:' + color + '"></div></div></div>';
+      html += '<div style="margin-bottom:12px"><div style="display:flex;justify-content:space-between;margin-bottom:4px"><span>Daily</span><span>' + CUR + bs.daily_used.toFixed(2) + ' / ' + CUR + bs.daily_limit.toFixed(2) + ' (' + bs.daily_percent.toFixed(1) + '%)</span></div><div class="bar-container"><div class="bar-fill" style="width:' + Math.min(bs.daily_percent, 100) + '%;background:' + color + '"></div></div></div>';
     }
     if (bs.monthly_limit > 0) {
       var color2 = bs.monthly_percent > 90 ? 'var(--red)' : bs.monthly_percent > 70 ? 'var(--yellow)' : 'var(--green)';
-      html += '<div><div style="display:flex;justify-content:space-between;margin-bottom:4px"><span>Monthly</span><span>€' + bs.monthly_used.toFixed(2) + ' / €' + bs.monthly_limit.toFixed(2) + ' (' + bs.monthly_percent.toFixed(1) + '%)</span></div><div class="bar-container"><div class="bar-fill" style="width:' + Math.min(bs.monthly_percent, 100) + '%;background:' + color2 + '"></div></div></div>';
+      html += '<div><div style="display:flex;justify-content:space-between;margin-bottom:4px"><span>Monthly</span><span>' + CUR + bs.monthly_used.toFixed(2) + ' / ' + CUR + bs.monthly_limit.toFixed(2) + ' (' + bs.monthly_percent.toFixed(1) + '%)</span></div><div class="bar-container"><div class="bar-fill" style="width:' + Math.min(bs.monthly_percent, 100) + '%;background:' + color2 + '"></div></div></div>';
     }
     document.getElementById('budget-content').innerHTML = html || '<span style="color:var(--text-dim)">No budget limits configured. Set caller max_daily_cost/max_monthly_cost in gateway config to enforce hard caps before provider calls.</span>';
   }
@@ -761,7 +769,7 @@
     document.getElementById('cache-content').innerHTML =
       '<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;text-align:center">' +
       '<div><div class="kpi-label">Hits</div><div style="font-size:20px;font-weight:700">' + cs.hits + '</div></div>' +
-      '<div><div class="kpi-label">Cost Saved</div><div style="font-size:20px;font-weight:700">€' + (cs.cost_saved || 0).toFixed(4) + '</div></div>' +
+      '<div><div class="kpi-label">Cost Saved</div><div style="font-size:20px;font-weight:700">' + CUR + (cs.cost_saved || 0).toFixed(4) + '</div></div>' +
       '<div><div class="kpi-label">Hit Rate</div><div style="font-size:20px;font-weight:700">' + ((cs.hit_rate || 0) * 100).toFixed(1) + '%</div></div>' +
       '</div>';
   }


### PR DESCRIPTION
## What

Three commits that together deliver #107 Act II — the **governed-session demo against real providers** — plus the product fixes it exposed:

1. **`feat(pricing)`: first-class pricing-table currency (#216, currency slice).**
   `pricing/models.yaml` (and the embedded default) declare `currency:` (ISO-4217, default `USD` — the shipped tables were always USD-denominated). The gateway stamps the code into every evidence record at write time (`Execution.Currency`), and the declared unit now renders everywhere a hardcoded `€`/EUR label used to: `audit list/show/verify --session`, session summaries, `talon costs` (labels, budget-utilization lines, JSON payload `currency` field, CSV export), `talon metrics`, the signed export, the `/api/v1/metrics` snapshot, and the gateway dashboard.
   - Budget caps (`max_daily/monthly/session_cost`) are documented as denominated in the table currency — resolving the "USD numbers compared against caps operators read as EUR" half of #216.
   - **Breaking (CSV only):** `talon costs export` header `cost_eur` → `cost` + new `currency` column.
   - Legacy `*_eur` JSON keys kept for consumers; `currency` is the authoritative unit. `web/dashboard.html` (legacy dashboard) labels unchanged — still tracked in #216 along with the timezone and budget-alert defects, which this PR does **not** touch.

2. **`fix(policy,cli)`: #255 + #256.**
   Budget deny messages move from `%.2f` to `%.4f` (real per-request costs are sub-cent; denials rendered as `0.00` exactly where the pitch is "explicit deny with evidence"). `talon audit show` now displays `cache_read`/`cache_write` tokens and `Pricing Basis` — the fields that explain why a cache-aware cost differs from naïve input-rate math.

3. **`feat(examples)`: governed-session demo (#107 Act II).**
   `examples/governed-session/` — one real agent session, bring-your-own `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` (~$0.05/run, cheap models, session-capped):

   ```
   session begins ─▶ Anthropic planner (cache_control: real cache WRITE, then READ)
                  ─▶ OpenAI executors (real cached_tokens; admin_* tool stripped pre-forward)
                  ─▶ IBAN probe denied before any provider call
                  ─▶ executor loop until real cross-provider spend closes the gate
                  ─▶ 403 session_budget_exceeded (pre-forward, %.4f amounts)
                  ─▶ money story: misleading naïve total vs cache-aware corrected total
                  ─▶ talon audit verify --session → N record(s), N valid, 0 invalid
   ```

   Reproduce: `export ANTHROPIC_API_KEY=… OPENAI_API_KEY=…; make governed-session && cd examples/governed-session && ./demo.sh all`

   Plus: `.github/workflows/shortlist-demo.yml` (rot-guard for the existing no-key mock demo: path-gated PRs, main pushes, nightly), `.github/workflows/governed-session.yml` (nightly + manual, **skips cleanly unless `DEMO_ANTHROPIC_API_KEY`/`DEMO_OPENAI_API_KEY` repo secrets are configured**, never on PRs), `scripts/record-governed-session.sh` (asciinema → `docs/assets/`), config guard test, and a top-level README section linking both demo acts.

## Why

#107 is the north-star conversion gate. Maintainer direction (2026-07-06): prove Talon on **real platform traffic** rather than extending mocks, and make pricing currency a first-class, honestly-labeled unit. The session demo is exactly the workload where naïve cost math misleads (long cached prefixes, many calls, two providers) and where Talon's cache-aware, budget-enforced, signed accounting is the differentiator.

## Verification

- `go test -race ./internal/...` — 55 packages pass
- `go test -race -tags=integration ./tests/integration/...` — pass (includes the compose-paths guard over the new example)
- `opa test internal/policy/rego/` — 67/67
- `shellcheck` on all new/changed scripts; `scripts/check-claim-discipline.sh` clean
- New tests: pricing currency parse/validate/format; gateway evidence currency stamp on **allowed and session-budget-denied** records (the deny record also carries the SessionID — load-bearing for `audit verify --session` seeing every decision); session-summary currency; governed-session config guard
- End-to-end real-provider run (`./demo.sh all`) requires keys: exercised via the secret-gated nightly workflow once `DEMO_*` secrets are configured, and manually before the recording lands

## Follow-ups (not in this PR)

- Record `docs/assets/governed-session.cast`/`.gif` from a real-key run (`scripts/record-governed-session.sh`) and embed in the READMEs — final open item on #107
- #216 remainder: enforcement/reporting timezone mismatch, budget alerts ignoring per-caller overrides, legacy `web/dashboard.html` labels
- Configure `DEMO_ANTHROPIC_API_KEY` / `DEMO_OPENAI_API_KEY` repo secrets to activate the nightly governed-session verification

Refs #107 #216 #255 #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cost display, evidence schema, and budget deny messaging across gateway/CLI/dashboard; CSV export column rename is a breaking consumer change. Real-provider nightly workflow spends API credits when secrets are set.
> 
> **Overview**
> Adds **#107 Act II**: a governed-session example that drives real Anthropic/OpenAI traffic through enforce-mode Docker (`demo.sh` seven proofs: cache write/read, tool strip, PII deny, session budget gate, naïve vs cache-aware costs, `audit verify --session`), plus `make governed-session`, README/docs, and CI rot-guards (path-gated **shortlist** mock demo; **governed-session** nightly/manual only when `DEMO_*` secrets exist).
> 
> Implements **pricing-table currency (#216)**: `currency:` on YAML tables; gateway stamps `Execution.Currency` on evidence (including session-budget denials with session id); CLI (`audit`, `costs`, `report`, `metrics`), exports, metrics snapshot, and gateway dashboard show the declared unit instead of hardcoded €/EUR. **CSV breaking change:** `cost_eur` → `cost` + `currency` column.
> 
> **Policy/CLI fixes (#255/#256):** budget deny messages use `%.4f`; `audit show` adds cache token lines and pricing basis.
> 
> **Shortlist demo hardening (#258):** compliance stderr capture, export file permissions, `out` dir chmod on Linux CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0bc6427e3b17c2e8fe4288ff33b043bd374ac11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->