### PR TITLE
docs: add a manual governed-session proof path

### DIFF
--- a/docs/tutorials/manual-governed-session.md
+++ b/docs/tutorials/manual-governed-session.md
@@ -1,0 +1,455 @@
+# Reproduce the Governed Session Manually
+
+Rebuild the recorded Talon proof with raw requests and Talon commands.
+
+No `demo.sh`. No hidden orchestration. You will send the requests yourself, inspect the signed records yourself, tamper with an export yourself, and watch verification fail.
+
+This tutorial uses the same real-provider stack as the recorded governed-session demo:
+
+- OpenAI for normal gateway traffic,
+- a local Ollama model for the sovereignty-routing proof,
+- one visible `X-Talon-Session-ID`,
+- one signed evidence trail,
+- a real session budget.
+
+A full run uses cheap models and is capped at about USD 0.03. Actual cost varies slightly with model output length.
+
+## What you will prove
+
+By the end you will have reproduced these controls manually:
+
+1. clean traffic flows and verifies,
+2. a dangerous tool is removed before the model,
+3. PII is blocked before provider access,
+4. a disallowed model is denied,
+5. confidential data changes execution placement from US to LOCAL,
+6. accumulated session spend closes the next request,
+7. modifying signed evidence breaks verification,
+8. the whole session verifies and produces a RoPA artifact with a runtime-consistency check.
+
+## Prerequisites
+
+- Docker with Compose v2
+- `curl`
+- `jq`
+- a real Anthropic API key
+- a real OpenAI API key
+
+Clone Talon and export the provider keys:
+
+```bash
+git clone https://github.com/dativo-io/talon.git
+cd talon
+
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+```
+
+The keys are loaded into Talon's encrypted secret vault inside the container. They are used for upstream authentication and are not written into evidence.
+
+## 1. Start Talon and local Ollama
+
+Start the real-provider stack and the opt-in local-routing sidecar:
+
+```bash
+cd examples/governed-session
+
+docker compose --profile routing-demo up --build -d
+
+docker compose exec ollama ollama pull llama3.2:1b
+```
+
+Wait for Talon:
+
+```bash
+until curl -fsS http://localhost:8080/health >/dev/null; do sleep 2; done
+```
+
+Create one session identifier for every request in this tutorial:
+
+```bash
+export SESSION_ID="manual-proof-$(date +%s)"
+```
+
+You will also use the two configured Talon caller keys:
+
+```bash
+export TALON_KEY="talon-session-demo"
+export TALON_MODEL_KEY="talon-session-eu"
+```
+
+For CLI inspection, run Talon inside the container:
+
+```bash
+docker compose exec talon /usr/local/bin/talon audit list --session "$SESSION_ID"
+```
+
+## 2. Clean traffic flows and the record verifies
+
+Send a normal request through the OpenAI-compatible gateway:
+
+```bash
+curl -sS -X POST \
+  http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+  -H "Authorization: Bearer $TALON_KEY" \
+  -H "X-Talon-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "max_tokens": 120,
+    "messages": [
+      {"role": "user", "content": "Summarize GDPR Article 30 in one sentence."}
+    ]
+  }' | jq
+```
+
+List the session evidence:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  audit list --session "$SESSION_ID"
+```
+
+Copy the newest evidence ID and verify it:
+
+```bash
+docker compose exec talon /usr/local/bin/talon audit verify <evidence-id>
+```
+
+Expected result:
+
+```text
+signature VALID
+```
+
+This proves that normal traffic still works through the governed path and leaves a cryptographically verifiable record.
+
+## 3. A dangerous tool is removed before the model
+
+The `session-demo` caller forbids tool names matching `admin_*`.
+
+Send one allowed and one forbidden tool definition:
+
+```bash
+curl -sS -X POST \
+  http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+  -H "Authorization: Bearer $TALON_KEY" \
+  -H "X-Talon-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "max_tokens": 120,
+    "messages": [
+      {"role": "user", "content": "Write one paragraph on evidence retention duties. Use search_kb if useful."}
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "admin_purge_records",
+          "description": "Delete all evidence records",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "search_kb",
+          "description": "Search the internal knowledge base",
+          "parameters": {
+            "type": "object",
+            "properties": {"q": {"type": "string"}}
+          }
+        }
+      }
+    ]
+  }' | jq
+```
+
+List the session again, copy the newest evidence ID, then inspect it:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  audit list --session "$SESSION_ID"
+
+docker compose exec talon /usr/local/bin/talon audit show <evidence-id>
+```
+
+Look for the tool-governance section. It should show that `admin_purge_records` was requested and filtered while `search_kb` was forwarded.
+
+The important fact is not that Talon noticed the tool afterward. The forbidden schema was removed before the provider received the request.
+
+## 4. PII is blocked before provider access
+
+Send an IBAN through the same gateway caller:
+
+```bash
+curl -i -sS -X POST \
+  http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+  -H "Authorization: Bearer $TALON_KEY" \
+  -H "X-Talon-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "Refund the customer with IBAN DE89370400440532013000."}
+    ]
+  }'
+```
+
+Expected result:
+
+```text
+HTTP 400
+POLICY_DENIED_PII_INPUT
+```
+
+Inspect the newest record:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  audit list --session "$SESSION_ID"
+
+docker compose exec talon /usr/local/bin/talon audit show <evidence-id>
+```
+
+The record should show the PII denial with zero upstream cost and zero provider tokens.
+
+## 5. Model policy denies a disallowed model
+
+The `session-demo-eu` caller is allowed to use `gpt-4o-mini`, not `gpt-4o`.
+
+Send the disallowed model:
+
+```bash
+curl -i -sS -X POST \
+  http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+  -H "Authorization: Bearer $TALON_MODEL_KEY" \
+  -H "X-Talon-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Summarize the control objective."}
+    ]
+  }'
+```
+
+Expected result:
+
+```text
+HTTP 403
+POLICY_DENIED_ROUTING
+model not in caller allowlist
+```
+
+This is a policy denial, not a silent model substitution.
+
+## 6. Confidential data changes execution placement
+
+Now send sensitive data through Talon's policy-aware runner endpoint instead of the gateway proxy.
+
+Use the same session ID:
+
+```bash
+curl -sS -X POST \
+  http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer $TALON_KEY" \
+  -H "X-Talon-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {
+        "role": "user",
+        "content": "In one short sentence, name the top EU AI Act evidence duty for account DE89370400440532013000."
+      }
+    ]
+  }' | jq
+```
+
+List the session, copy the newest `req_...` evidence ID, then inspect it:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  audit list --session "$SESSION_ID"
+
+docker compose exec talon /usr/local/bin/talon audit show <req-evidence-id>
+```
+
+Look for:
+
+```text
+Routing Decision (sovereignty-aware)
+Selected:   ollama / llama3.2:1b
+Rejected:   openai
+  • confidential tier blocks cloud providers
+  • confidential tier requires LOCAL provider only
+```
+
+This is the central proof:
+
+- the IBAN classifies the input as confidential,
+- OpenAI remains in the candidate pool under `eu_preferred`,
+- policy rejects the US candidate before dispatch,
+- Talon selects the local Ollama candidate for the same request,
+- the signed `RoutingDecision` records both outcomes.
+
+The same type of data was blocked in the previous gateway act. Here policy permits the work but constrains where it may execute.
+
+## 7. Accumulated session spend closes the next request
+
+Check current session cost:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  costs --session "$SESSION_ID" --json | jq
+```
+
+The configured session cap is USD 0.03. Add real `gpt-4o` requests to the same session until Talon refuses the next estimated request:
+
+```bash
+for i in $(seq 1 20); do
+  status=$(curl -sS -o /tmp/talon-budget.json -w '%{http_code}' -X POST \
+    http://localhost:8080/v1/proxy/openai/v1/chat/completions \
+    -H "Authorization: Bearer $TALON_KEY" \
+    -H "X-Talon-Session-ID: $SESSION_ID" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"gpt-4o\",\"max_tokens\":120,\"messages\":[{\"role\":\"user\",\"content\":\"Budget probe $i: summarize evidence retention in one sentence.\"}]}" )
+
+  echo "request $i -> HTTP $status"
+  cat /tmp/talon-budget.json | jq
+
+  [ "$status" = "403" ] && break
+done
+```
+
+The final response should contain:
+
+```text
+session_budget_exceeded
+```
+
+Inspect the session total and the denied record:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  costs --session "$SESSION_ID" --json | jq
+
+docker compose exec talon /usr/local/bin/talon \
+  audit list --session "$SESSION_ID"
+```
+
+Talon denies before sending the next request when accumulated session spend plus the pre-request estimate exceeds the configured cap.
+
+Session budgets are soft caps: concurrent in-flight requests can still overshoot before the next request is evaluated.
+
+## 8. Export signed evidence, tamper with it, and fail verification
+
+Export the whole session as signed JSON:
+
+```bash
+docker compose exec -T talon /usr/local/bin/talon \
+  audit export --session "$SESSION_ID" --format signed-json \
+  > session-evidence.json
+```
+
+Verify the clean export:
+
+```bash
+cat session-evidence.json | docker compose exec -T talon sh -c \
+  'cat > /tmp/session-evidence.json && /usr/local/bin/talon audit verify --file /tmp/session-evidence.json'
+```
+
+Now flip one signed field:
+
+```bash
+jq '.records[0].policy_decision.allowed |= not' \
+  session-evidence.json > tampered.json
+```
+
+Verify the modified file:
+
+```bash
+cat tampered.json | docker compose exec -T talon sh -c \
+  'cat > /tmp/tampered.json && /usr/local/bin/talon audit verify --file /tmp/tampered.json'
+```
+
+Expected result:
+
+```text
+Invalid records: 1
+signature INVALID
+```
+
+Talon evidence is tamper-evident and cryptographically verifiable. The signature does not prevent someone from editing a file; it makes that modification detectable during verification.
+
+## 9. Verify the whole session and generate RoPA
+
+Verify every signed record belonging to the session:
+
+```bash
+docker compose exec talon /usr/local/bin/talon \
+  audit verify --session "$SESSION_ID"
+```
+
+Expected shape:
+
+```text
+Session manual-proof-...: N record(s), N valid, 0 invalid
+```
+
+Generate a GDPR Article 30 RoPA artifact from policy plus runtime evidence:
+
+```bash
+docker compose exec -T talon /usr/local/bin/talon \
+  compliance ropa \
+  --policy /home/talon/agent.talon.yaml \
+  --format html \
+  > ropa.html
+```
+
+The command may also report a runtime-consistency finding because the declared residency is EU while this tutorial intentionally used real US providers for some allowed acts:
+
+```text
+CONSISTENCY  destinations outside EU/LOCAL found in evidence
+ACTION       enforce eu_strict, or document the transfer mechanism
+```
+
+That is the useful final proof: Talon does not merely generate a compliance artifact. It can compare declared posture with observed runtime destinations and surface the inconsistency for resolution.
+
+## What you proved
+
+You manually demonstrated that one Talon boundary can:
+
+- allow normal provider traffic,
+- remove forbidden tools before the model,
+- stop PII before provider access,
+- deny disallowed models,
+- route confidential data away from a US candidate to a local model,
+- stop the next request when session spend crosses policy,
+- produce signed evidence whose modification is detectable,
+- verify the entire session,
+- generate a RoPA artifact and compare declared residency with observed destinations.
+
+The recorded GIF is only a compressed view of these same operations. This page is the reproducible proof path.
+
+## Optional: inspect cache-aware cross-provider cost
+
+The longer recorded demo also shows Anthropic prompt-cache write/read economics and an OpenAI executor consuming the planner's returned output.
+
+Those details are real, but the payload is intentionally large and distracts from the core governance proof above. For the exact cache fields and pricing behavior, see [the governed-session example](../../examples/governed-session/README.md) and [cost governance by caller](../guides/cost-governance-by-caller.md).
+
+## Clean up
+
+```bash
+docker compose --profile routing-demo down -v
+rm -f session-evidence.json tampered.json ropa.html /tmp/talon-budget.json
+```
+
+## Next step
+
+Put one real workload behind Talon rather than recreating another demo:
+
+- [Add Talon to an existing app](../guides/add-talon-to-existing-app.md)
+- [Choose an integration path](../guides/choosing-integration-path.md)
+- [Govern coding agents](../guides/governing-coding-agents.md)

--- a/docs/tutorials/quickstart-demo.md
+++ b/docs/tutorials/quickstart-demo.md
@@ -1,8 +1,8 @@
 # Quick Start: 60-Second Demo (No API Key)
 
-See Talon's controls in action without any API keys or configuration. The mock
-provider handles all LLM calls, so evidence generation, PII scanning, and cost
-tracking work exactly as they would with a real provider.
+See Talon's request path and signed evidence without any API keys or configuration. The mock provider handles the LLM call, so PII scanning, policy evaluation, cost tracking, and evidence generation run without spending money.
+
+This page intentionally proves one small path. For tools, enforcement, sovereignty routing, session budgets, tamper detection, and RoPA, continue to [Reproduce the governed session manually](manual-governed-session.md).
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ tracking work exactly as they would with a real provider.
 
 ## Steps
 
-### 1. Clone and Start (30 seconds)
+### 1. Clone and start (30 seconds)
 
 ```bash
 git clone https://github.com/dativo-io/talon
@@ -21,7 +21,7 @@ docker compose up
 
 Wait for both services to show as healthy (about 15-30 seconds).
 
-### 2. Send a Request with PII (10 seconds)
+### 2. Send a request with PII (10 seconds)
 
 In another terminal:
 
@@ -39,8 +39,9 @@ curl -X POST http://localhost:8080/v1/proxy/openai/v1/chat/completions \
   }'
 ```
 
-You'll get back a standard OpenAI-compatible JSON response. The mock provider
-returned a canned answer, but Talon's full pipeline ran on the request.
+You'll get back a standard OpenAI-compatible JSON response. The mock provider returned a canned answer, but Talon's request pipeline still inspected and classified the request.
+
+The demo configuration is deliberately in **shadow mode**. Talon records what policy observed without changing the request or response. This is the low-risk adoption path: observe real traffic first, then enable enforcement.
 
 ### 3. List the evidence (10 seconds)
 
@@ -48,11 +49,10 @@ returned a canned answer, but Talon's full pipeline ran on the request.
 docker compose exec talon /usr/local/bin/talon audit list
 ```
 
-Expected output:
+Expected shape:
 
 ```text
-# Expected output:
-✓ [req_a1b2c3d4] | 2026-03-15T10:23:45Z | demo/demo-user | gpt-4o-mini | €0.001 | 45ms
+✓ [req_a1b2c3d4] | ... | demo/demo-user | gpt-4o-mini | ...
 ```
 
 ### 4. Inspect the evidence
@@ -61,51 +61,59 @@ Expected output:
 docker compose exec talon /usr/local/bin/talon audit show req_a1b2c3d4
 ```
 
-This shows the full evidence record:
-- **Policy Decision:** Allowed (shadow mode)
-- **Classification:** PII detected (email, IBAN), input tier 2
-- **Execution:** Model used, cost, token counts, duration
-- **Integrity:** Input/output hashes, HMAC signature status
+The record shows:
 
-### 5. Verify Signature Integrity
+- **Policy decision:** allowed in shadow mode
+- **Classification:** email + IBAN detected; input tier 2
+- **Execution:** model, cost, token counts, duration
+- **Integrity:** hashes and HMAC signature
+
+### 5. Verify signature integrity
 
 ```bash
 docker compose exec talon /usr/local/bin/talon audit verify req_a1b2c3d4
 ```
 
-```
+Expected result:
+
+```text
 ✓ Evidence req_a1b2c3d4: signature VALID
 ```
 
-The HMAC-SHA256 signature proves no field has been modified since creation.
+The HMAC-SHA256 signature makes later modification detectable during verification.
 
 ### 6. Open the dashboard
 
-Visit [http://localhost:8080/dashboard](http://localhost:8080/dashboard) to see
-evidence records, costs, and PII findings in the browser.
+Visit [http://localhost:8080/dashboard](http://localhost:8080/dashboard) to see evidence records, costs, and PII findings in the browser.
 
 Use the Evidence tab to:
 
 - check the per-row integrity state (`Not checked`, `Verified`, `Invalid`, `Unable to verify`),
 - open the persistent signature block from **Detail**,
-- verify that governance decision and spend attribution are visible beside signature status.
+- verify that the governance decision and spend attribution are visible beside signature status.
 
 ## What you just proved
 
-The demo showed three things a PII-only proxy cannot:
+You executed and inspected this exact path:
 
-1. **Tool calls are visible and blockable.** Talon sees MCP tool calls and LLM requests. A proxy that only inspects HTTP bodies for PII never sees which tools the agent is calling; Talon can block forbidden tools before they run.
-2. **Policy runs before the LLM call.** Cost and policy are evaluated before the request is forwarded. You are not notified after you have already spent; the call is denied or allowed up front.
-3. **Every record is tamper-proof.** The evidence store is HMAC-signed. You can verify with `talon audit verify`; no one can quietly edit the log.
+1. **Talon accepted an OpenAI-compatible request without changing the client protocol.**
+2. **PII was detected and classified before forwarding.** The email and IBAN produced a tier-2 finding.
+3. **Shadow mode recorded the governance signal without breaking the application.** The request still reached the mock provider.
+4. **The resulting evidence is tamper-evident and cryptographically verifiable.** `talon audit verify` checks the HMAC signature.
+
+This page did **not** yet execute tool filtering, PII blocking, model denial, sovereignty routing, a session budget, or tamper failure. Reproduce those manually next:
+
+**[Reproduce the governed session manually →](manual-governed-session.md)**
 
 ## Now wire this to your app
 
-Point your existing app at Talon by changing only the base URL and using a Talon caller key. Examples:
+Point your existing app at Talon by changing only the base URL and using a Talon caller key.
 
-**Python (openai package):**
+**Python (`openai` package):**
 
 ```python
 import openai
+
 client = openai.OpenAI(
     base_url="http://localhost:8080/v1/proxy/openai/v1",
     api_key="<your-caller-key-from-talon-config>",
@@ -113,10 +121,11 @@ client = openai.OpenAI(
 # Then use client.chat.completions.create(...) as usual.
 ```
 
-**Node.js (openai package):**
+**Node.js (`openai` package):**
 
 ```javascript
 const OpenAI = require("openai");
+
 const client = new OpenAI({
   baseURL: "http://localhost:8080/v1/proxy/openai/v1",
   apiKey: "<your-caller-key-from-talon-config>",
@@ -133,49 +142,36 @@ curl -X POST http://localhost:8080/v1/proxy/openai/v1/chat/completions \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
-For a full step-by-step (vault key, gateway config, first real request), see [Add Talon to your existing app](../guides/add-talon-to-existing-app.md).
+For a full step-by-step with vault key, gateway config, first real request, and evidence, see [Add Talon to your existing app](../guides/add-talon-to-existing-app.md).
+
+## What's happening under the hood
+
+When your curl request hits Talon, the gateway path runs:
+
+1. **Route** — the URL path determines the provider.
+2. **Identify** — Talon resolves the caller.
+3. **Rate limit** — the token-bucket check runs.
+4. **Extract** — Talon parses model and message text.
+5. **PII scan** — recognizers find the email and IBAN.
+6. **Classify** — the IBAN raises the input to confidential tier 2.
+7. **Policy** — OPA evaluates the request; shadow mode records rather than blocks.
+8. **Tool policy** — there are no tools in this request.
+9. **Forward** — the request goes to the mock provider.
+10. **Evidence** — Talon writes an HMAC-signed record to SQLite.
+
+See [What Talon does to your request](../explanation/what-talon-does-to-your-request.md) for the full technical breakdown.
 
 ## You're done
 
-You ran the 60-second demo. Talon intercepted a request, scanned for PII, logged cost, and wrote a signed evidence record. The mock provider stood in for OpenAI; with a real key and gateway config, the same flow applies to your app.
+You ran the fastest Talon proof loop: one request, one governance decision, one signed record, one verification.
 
-**Next steps:**
-
-| I want to… | Doc |
-|------------|-----|
+| I want to… | Next doc |
+|------------|----------|
+| Reproduce the hero/deep controls manually | [Reproduce the governed session manually](manual-governed-session.md) |
+| Attack the evidence integrity directly | [Evidence integrity: 5-minute proof](evidence-integrity-demo.md) |
 | Put Talon in front of my real app | [Add Talon to your existing app](../guides/add-talon-to-existing-app.md) |
-| Build a new agent with Talon from scratch | [Your first agent with Talon](first-governed-agent.md) |
-| See how the request is processed step-by-step | [What Talon does to your request](../explanation/what-talon-does-to-your-request.md) |
-| Run more demo requests | Use `bash demo-client/demo.sh` in the docker-compose example dir |
-
-## What's Happening Under the Hood
-
-When your curl request hits Talon, a 10-step pipeline runs:
-
-1. **Route** — URL path determines provider (OpenAI)
-2. **Identify** — Caller lookup (default in demo)
-3. **Rate limit** — Token bucket check
-4. **Extract** — Parse model name and message text from JSON
-5. **PII scan** — Regex recognizers find email + IBAN
-6. **Classify** — Data tier set to 2 (confidential, due to IBAN)
-7. **Policy** — OPA evaluates: allowed in shadow mode
-8. **Tool policy** — No tools in this request
-9. **Forward** — Request sent to mock provider
-10. **Evidence** — HMAC-signed record written to SQLite
-
-Total overhead: <15ms. See
-[What Talon Does to Your Request](../explanation/what-talon-does-to-your-request.md)
-for the full technical breakdown.
-
-## Run More Requests
-
-Use the demo client to generate a richer evidence trail:
-
-```bash
-bash demo-client/demo.sh
-```
-
-This sends 5 requests with varied PII patterns and models.
+| Choose the right integration path | [Choose an integration path](../guides/choosing-integration-path.md) |
+| Build a new agent with Talon | [Your first governed agent](first-governed-agent.md) |
 
 ## Clean up
 


### PR DESCRIPTION
## What

Adds a new evaluator tutorial that reconstructs the recorded Talon proof manually with raw requests and Talon commands — no `demo.sh` and no hidden orchestration.

The tutorial walks a skeptical evaluator through one visible session and proves, step by step:

- clean traffic flows and the signed record verifies;
- a forbidden `admin_*` tool is removed before the model;
- PII is blocked before provider access;
- a disallowed model is denied;
- confidential data causes OpenAI/US to be policy-rejected and local Ollama to be selected;
- accumulated session spend closes the next request;
- a signed export verifies, a modified field makes verification fail;
- the whole session verifies and RoPA generation surfaces runtime-vs-declared residency consistency.

## Also fixes the 60-second quickstart

The current page executed one shadow-mode PII request but then claimed it had also proved tool blocking and pre-spend enforcement. This PR makes the claims match the steps actually run.

It also replaces `tamper-proof` language with the accurate boundary: **tamper-evident and cryptographically verifiable**.

The 60-second path remains intentionally small and now links directly to the manual full proof.

## Philosophy

The homepage recording should create interest. The docs should let an engineer rebuild the proof line by line:

`see it → reproduce it → tamper with the evidence → integrate one workload`

No production code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or data-path code changes.
> 
> **Overview**
> Adds **`docs/tutorials/manual-governed-session.md`**, a step-by-step evaluator tutorial that rebuilds the recorded governed-session demo with raw `curl`, Talon CLI, and `examples/governed-session` (OpenAI + Ollama, one `X-Talon-Session-ID`, ~USD 0.03 cap). It walks through eight proofs: clean traffic and signature verify, `admin_*` tool stripping, PII block, model allowlist denial, confidential-tier routing to local Ollama, session budget denial, tampered export failing verify, and session verify plus RoPA with residency consistency findings.
> 
> **Updates `quickstart-demo.md`** so the 60-second mock path only claims what it actually runs (shadow-mode PII observe + signed evidence), replaces **tamper-proof** with **tamper-evident / cryptographically verifiable**, and links forward to the manual full proof (and related next-step docs) instead of implying tool blocking and pre-spend enforcement were demonstrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a0dae04a1ed0abefade16e922b0102fc3d0893. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->