### PR TITLE
fix(init): scaffold no longer ships bedrock_only with non-Bedrock models (#207)

### DIFF
--- a/internal/cmd/init_pack_test.go
+++ b/internal/cmd/init_pack_test.go
@@ -456,3 +456,54 @@ func TestInitPack_OpenClaw_CredentialRecognizersPresent(t *testing.T) {
 	assert.Contains(t, string(agentContent), "GITHUB_TOKEN")
 	assert.Contains(t, string(agentContent), "LLM_API_KEY", "same recognizer set as the coding-agents pack")
 }
+
+// #207: no shipped init template — scaffold, pack, or compliance overlay — may
+// produce model-routing warnings on first load. The regression shipped tier_2
+// with bedrock_only: true alongside non-Bedrock model naming, which warned on
+// every serve (twice, via a redundant policy re-load) and would force Bedrock
+// routing for models Bedrock cannot serve. This guards the whole generation and
+// overlay-merge surface so a brand-new user's first `serve` is warning-free.
+func TestInit_GeneratedPolicyHasNoRoutingWarnings(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"scaffold-default", []string{"init", "--scaffold"}},
+		{"scaffold-minimal", []string{"init", "--scaffold", "--minimal"}},
+		{"pack-generic", []string{"init", "--pack", "generic"}},
+		{"pack-langchain", []string{"init", "--pack", "langchain"}},
+		{"pack-crewai", []string{"init", "--pack", "crewai"}},
+		{"pack-fintech-eu", []string{"init", "--pack", "fintech-eu"}},
+		{"pack-ecommerce-eu", []string{"init", "--pack", "ecommerce-eu"}},
+		{"pack-saas-eu", []string{"init", "--pack", "saas-eu"}},
+		{"pack-telecom-eu", []string{"init", "--pack", "telecom-eu"}},
+		{"scaffold-gdpr", []string{"init", "--scaffold", "--compliance", "gdpr"}},
+		{"scaffold-dora", []string{"init", "--scaffold", "--compliance", "dora"}},
+		{"pack-langchain-gdpr", []string{"init", "--pack", "langchain", "--compliance", "gdpr"}},
+		{"pack-fintech-dora", []string{"init", "--pack", "fintech-eu", "--compliance", "dora"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetInitFlags()
+			t.Cleanup(resetInitFlags)
+			dir := t.TempDir()
+			prevWd, err := os.Getwd()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.Chdir(prevWd) })
+			require.NoError(t, os.Chdir(dir))
+
+			args := append([]string{}, tc.args...)
+			args = append(args, "--name", "warn-guard", "--skip-verify")
+			rootCmd.SetArgs(args)
+			require.NoError(t, rootCmd.Execute())
+
+			pol, err := policy.LoadPolicy(context.Background(), "agent.talon.yaml", false, ".")
+			require.NoError(t, err)
+			require.NotNil(t, pol.Policies.ModelRouting, "generated policy should define model_routing")
+
+			warnings, err := policy.ValidateRouting(pol.Policies.ModelRouting)
+			require.NoError(t, err)
+			assert.Empty(t, warnings, "generated policy must not produce routing warnings; got: %+v", warnings)
+		})
+	}
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -143,7 +143,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	pricingTable := loadPricingTable(cfg, policyBaseDir)
 	injectPricingInProviders(providers, pricingTable)
 	gatewayEstimator := gatewayCostEstimator(pricingTable)
-	routing, costLimits := loadRoutingAndCostLimits(ctx, policyPath, policyBaseDir)
+	// Reuse the policy already loaded above; re-loading here would parse and
+	// re-validate the same file a second time, double-logging routing warnings.
+	routing, costLimits := pol.Policies.ModelRouting, pol.Policies.CostLimits
 	router := llm.NewRouter(routing, providers, costLimits)
 
 	secretsStore, err := secrets.NewSecretStore(cfg.SecretsDBPath(), cfg.SecretsKey)

--- a/internal/cmd/templates/init/agent.talon.yaml.minimal.tmpl
+++ b/internal/cmd/templates/init/agent.talon.yaml.minimal.tmpl
@@ -25,7 +25,6 @@ policies:
     tier_2:
       primary: gpt-4o-mini
       location: eu-west-1
-      bedrock_only: true
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/agent.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/agent.talon.yaml.tmpl
@@ -68,12 +68,14 @@ policies:
       primary: gpt-4o
       fallback: gpt-4o-mini
       location: eu-west-1
-    # tier_2 is used for PII-bearing inputs. If you don't use AWS Bedrock, set bedrock_only: false
-    # and primary/fallback to OpenAI or Anthropic models (e.g. gpt-4o, gpt-4o-mini).
+    # tier_2 is used for PII-bearing inputs. It defaults to the same provider as the
+    # other tiers so the scaffold runs out of the box.
+    # To pin PII traffic to AWS Bedrock for data residency, set bedrock_only: true AND
+    # use Bedrock model naming (vendor.model, e.g. anthropic.claude-sonnet-4-20250514-v1:0).
     tier_2:
-      primary: claude-sonnet-4-20250514
+      primary: gpt-4o
+      fallback: gpt-4o-mini
       location: eu-west-1
-      bedrock_only: true
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/pack_ecommerce_eu.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/pack_ecommerce_eu.talon.yaml.tmpl
@@ -26,7 +26,9 @@ policies:
   model_routing:
     tier_0: { primary: gpt-4o-mini, location: any }
     tier_1: { primary: gpt-4o, fallback: gpt-4o-mini, location: eu-west-1 }
-    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1, bedrock_only: true }
+    # For EU data residency, pin tier_2 to AWS Bedrock: set bedrock_only: true and use
+    # Bedrock model naming (e.g. anthropic.claude-sonnet-4-20250514-v1:0) with a Bedrock provider.
+    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1 }
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/pack_fintech_eu.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/pack_fintech_eu.talon.yaml.tmpl
@@ -26,7 +26,9 @@ policies:
   model_routing:
     tier_0: { primary: gpt-4o-mini, location: any }
     tier_1: { primary: gpt-4o, fallback: gpt-4o-mini, location: eu-west-1 }
-    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1, bedrock_only: true }
+    # For EU data residency, pin tier_2 to AWS Bedrock: set bedrock_only: true and use
+    # Bedrock model naming (e.g. anthropic.claude-sonnet-4-20250514-v1:0) with a Bedrock provider.
+    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1 }
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/pack_generic.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/pack_generic.talon.yaml.tmpl
@@ -47,7 +47,6 @@ policies:
     tier_2:
       primary: gpt-4o
       location: eu
-      bedrock_only: true
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/pack_langchain.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/pack_langchain.talon.yaml.tmpl
@@ -49,7 +49,6 @@ policies:
     tier_2:
       primary: gpt-4o
       location: eu
-      bedrock_only: true
 
 audit:
   log_level: detailed

--- a/internal/cmd/templates/init/pack_saas_eu.talon.yaml.tmpl
+++ b/internal/cmd/templates/init/pack_saas_eu.talon.yaml.tmpl
@@ -26,7 +26,9 @@ policies:
   model_routing:
     tier_0: { primary: gpt-4o-mini, location: any }
     tier_1: { primary: gpt-4o, fallback: gpt-4o-mini, location: eu-west-1 }
-    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1, bedrock_only: true }
+    # For EU data residency, pin tier_2 to AWS Bedrock: set bedrock_only: true and use
+    # Bedrock model naming (e.g. anthropic.claude-sonnet-4-20250514-v1:0) with a Bedrock provider.
+    tier_2: { primary: claude-sonnet-4-20250514, location: eu-west-1 }
 
 audit:
   log_level: detailed

--- a/internal/pack/templates/compliance/dora.talon.yaml
+++ b/internal/pack/templates/compliance/dora.talon.yaml
@@ -25,10 +25,10 @@ policies:
       location: eu       # Even non-sensitive financial data stays in EU
     tier_1:
       location: eu
-      bedrock_only: true
     tier_2:
       location: eu
-      bedrock_only: true
+      # To route data only via AWS Bedrock, set bedrock_only: true on these tiers and use
+      # Bedrock model naming (e.g. anthropic.*) with a Bedrock provider configured.
 
 audit:
   # supports: dora Art. 11 — internal/evidence/store.go (ICT incident traceability with signed audit trail)

--- a/internal/pack/templates/compliance/gdpr.talon.yaml
+++ b/internal/pack/templates/compliance/gdpr.talon.yaml
@@ -19,8 +19,9 @@ policies:
     tier_1:
       location: eu       # Data stays in EU
     tier_2:
-      location: eu
-      bedrock_only: true # Sensitive data only via EU Bedrock
+      location: eu       # Sensitive data stays in EU (enforced via routing.rego)
+      # To route sensitive data only via AWS Bedrock, set bedrock_only: true and use
+      # Bedrock model naming (e.g. anthropic.*) with a Bedrock provider configured.
 
 audit:
   # supports: gdpr Art. 30 — internal/evidence/store.go (Processing records via signed evidence export)

--- a/internal/pack/templates/crewai/agent.talon.yaml
+++ b/internal/pack/templates/crewai/agent.talon.yaml
@@ -48,7 +48,6 @@ policies:
     tier_2:
       primary: gpt-4o
       location: eu
-      bedrock_only: true
 
 compliance:
   frameworks: [gdpr]


### PR DESCRIPTION
Fixes #207.

## Problem
Every `talon serve` on a freshly scaffolded policy logged a routing warning — **twice** — because tier_2 shipped `bedrock_only: true` alongside a non-Bedrock model id (`claude-sonnet-4-20250514`, `gpt-4o`, …). Per the warning text, the router then **forces the Bedrock provider for a model Bedrock cannot serve**, so scaffolded tier_2 (PII) routing was broken, not merely noisy. A brand-new user's first `serve` starts with a warning they didn't cause and can't interpret — squarely on the onboarding-trust path.

The self-contradiction was **systemic across 10 shipped templates**, not just the default scaffold.

## Fix
**Templates** — remove the broken `bedrock_only: true`:
- **Default + minimal scaffold**, and the **generic / langchain / crewai** packs. The default scaffold's tier_2 now uses the same OpenAI provider the scaffold actually configures (`gpt-4o` / `gpt-4o-mini`), so first `serve` works out of the box. Comment flipped to explain how to *enable* Bedrock correctly (`anthropic.*` naming + a Bedrock provider).
- **EU packs** (fintech / saas / ecommerce) and the **gdpr / dora compliance overlays**. EU data residency is carried by `location: eu` + sovereignty mode (`routing.rego`) — the telecom pack already shipped `bedrock_only: false` as precedent. Dropping the broken directive also fixes the **compliance-overlay merge**, which previously forced Bedrock onto OpenAI models via the `||` merge.

**Serve path** — dedup the double policy load ([`serve.go`](../blob/fix/scaffold-bedrock-only-warning/internal/cmd/serve.go#L146)): `serve` re-loaded and re-validated the same policy file via `loadRoutingAndCostLimits` purely to read routing/cost config already present on the loaded policy, which double-logged every routing warning. It now reuses the already-loaded policy — one load, one validation. (`loadRoutingAndCostLimits` stays in use by `run.go`/`plan.go`.)

**Guard test** — `TestInit_GeneratedPolicyHasNoRoutingWarnings` (13 subtests) asserts `ValidateRouting` yields zero warnings for scaffold, minimal, every routing pack, and pack+compliance merges.

## Verification
- **Repro (before):** untouched `talon init --scaffold` → `talon serve --log-level debug` logged the `bedrock_only is true …` warning **2×**.
- **After:** same repro → **0 warnings**; a genuine misconfig (manually re-added) warns **exactly once** (dedup confirmed).
- Tests: guard test 13/13; `internal/cmd`, `internal/policy`, `internal/pack`; `internal/server` (`-race`, incl. SSOT gate); `tests/integration` (`-tags=integration -race`) — all pass. `go build ./...` + `go vet` clean.

## Notes
- No behavior change to actual Bedrock users: `bedrock_only: true` with correct `vendor.model` naming is unaffected — the validator only warned on the mismatch, which no shipped template now produces.
- `tests/pii_enrichment_quality_test.sh` had a `sed 's/bedrock_only: true/false/'` workaround for this exact bug; it's now a harmless no-op and left untouched.