### PR TITLE
fix: UTC-normalize plan review store timestamps (#292); identify Talon before trusting the costs probe (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+### Fixed
+
+- **Plan review store timestamps are UTC-normalized (#292), closing the store's exemption from the #264 invariant.** mattn/go-sqlite3 serializes a `time.Time` keeping its offset and SQLite compares those strings lexicographically, so the plan store's local-time writes (`timeout_at`, `reviewed_at`, `dispatched_at`) and local-time binds (`GetPending`, `GetApprovedUndispatched`) mis-compared across host timezone changes and DST transitions — a pending plan could appear expired (or an expired one dispatchable) by up to the offset delta, and the dashboard review history could mis-order. Every write and query bind now normalizes to UTC (`Save` also normalizes the plan struct in place so `plan_json` agrees with the DATETIME columns). Existing rows keep their stored offset; comparisons against them behave as before on an unchanged host. Who cares: anyone running plan review (`human_oversight`) on a non-UTC host or moving the SQLite file between hosts. Verify: `go test ./internal/agent/ -run TestPlanReviewStore_ -count=1` (new timezone regression tests mirror `internal/evidence/timezone_test.go`).
+- **`talon costs` identifies Talon before trusting the default `:8080` probe (#293).** `/health` now carries a product marker (`X-Talon-Service: talon` header + `"service":"talon"` body), and the implicit localhost budget probe uses it to classify a reachable-but-failing answer: a responder that identifies as Talon and still rejects the query (e.g. 401 without `TALON_ADMIN_KEY`) is now a hard error — a real runtime's refusal can no longer end in local numbers that may describe a different deployment — while a non-Talon port squatter keeps the loudly-warned local fallback, so offline `talon costs` still works. An explicit `--url` was already authoritative and is unchanged; `--url ""` skips the server path entirely for forced local resolution. This completes the #288 authority model end-to-end. Who cares: FinOps/operators reading budget denominators next to a running gateway. Verify: `go test ./internal/cmd/ -run TestResolveBudgetUsage_ServerAuthority ./internal/server/ -run TestHealth`.
+
 ## [1.8.1] - 2026-07-13
 
 ### Security

--- a/internal/agent/plan.go
+++ b/internal/agent/plan.go
@@ -72,6 +72,10 @@ func GenerateExecutionPlan(
 	promptHash := sha256.Sum256([]byte(systemPrompt))
 	inputHash := sha256.Sum256([]byte(inputPrompt))
 
+	// UTC invariant (#292, cf. #264): go-sqlite3 serializes a time.Time with
+	// its original offset and SQLite compares those strings lexicographically,
+	// so every persisted timestamp must be UTC.
+	now := time.Now().UTC()
 	return &ExecutionPlan{
 		ID:               "plan_" + uuid.New().String()[:12],
 		CorrelationID:    correlationID,
@@ -85,7 +89,7 @@ func GenerateExecutionPlan(
 		PolicyDecision:   policyDecision,
 		SystemPromptHash: hex.EncodeToString(promptHash[:]),
 		InputHash:        hex.EncodeToString(inputHash[:]),
-		CreatedAt:        time.Now(),
-		TimeoutAt:        time.Now().Add(time.Duration(timeoutMinutes) * time.Minute),
+		CreatedAt:        now,
+		TimeoutAt:        now.Add(time.Duration(timeoutMinutes) * time.Minute),
 	}
 }

--- a/internal/agent/plan_review.go
+++ b/internal/agent/plan_review.go
@@ -120,6 +120,13 @@ func (s *PlanReviewStore) Save(ctx context.Context, plan *ExecutionPlan) error {
 		))
 	defer span.End()
 
+	// UTC invariant (#292, cf. #264): go-sqlite3 serializes a time.Time with
+	// its original offset and SQLite compares those strings lexicographically.
+	// Normalize in place before marshaling so plan_json and the DATETIME
+	// columns carry the same UTC instant regardless of the caller's zone.
+	plan.CreatedAt = plan.CreatedAt.UTC()
+	plan.TimeoutAt = plan.TimeoutAt.UTC()
+
 	planJSON, err := json.Marshal(plan)
 	if err != nil {
 		return fmt.Errorf("marshaling plan: %w", err)
@@ -137,10 +144,11 @@ func (s *PlanReviewStore) Save(ctx context.Context, plan *ExecutionPlan) error {
 // GetPending returns all plans awaiting review, optionally filtered by tenant
 // and by the agent the plan belongs to (#286: an agent key reads only its own
 // plans; empty agentID is the tenant-wide admin view).
-// Uses a bound time parameter (time.Now()) so the comparison matches go-sqlite3's
-// serialization of timeout_at; datetime('now') would differ in format and break in non-UTC.
+// Uses a bound UTC time parameter so the comparison matches go-sqlite3's
+// serialization of the UTC-normalized timeout_at (#292); datetime('now') would
+// differ in format, and a local-time bind mis-compares lexicographically.
 func (s *PlanReviewStore) GetPending(ctx context.Context, tenantID, agentID string) ([]*ExecutionPlan, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	query := `SELECT plan_json FROM execution_plans WHERE status = 'pending' AND timeout_at > ?`
 	args := []interface{}{now}
 	if tenantID != "" {
@@ -271,7 +279,7 @@ func (s *PlanReviewStore) Reject(ctx context.Context, planID, tenantID, reviewed
 // Modify marks a plan as approved-with-modifications and stores reviewer annotations, scoped to tenantID.
 func (s *PlanReviewStore) Modify(ctx context.Context, planID, tenantID, reviewedBy string, annotations []Annotation) error {
 	annotJSON, _ := json.Marshal(annotations)
-	now := time.Now()
+	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE execution_plans SET status = ?, reviewed_by = ?, reviewed_at = ?, annotations_json = ?
 		WHERE id = ? AND tenant_id = ? AND status = 'pending'`,
@@ -298,7 +306,7 @@ func (s *PlanReviewStore) Modify(ctx context.Context, planID, tenantID, reviewed
 }
 
 func (s *PlanReviewStore) updateStatus(ctx context.Context, planID, tenantID string, status PlanStatus, reviewedBy, reason string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE execution_plans SET status = ?, reviewed_by = ?, reviewed_at = ?, review_reason = ?
 		WHERE id = ? AND tenant_id = ? AND status = 'pending'`,
@@ -327,7 +335,7 @@ func (s *PlanReviewStore) updateStatus(ctx context.Context, planID, tenantID str
 // GetApprovedUndispatched returns approved plans that have not been auto-dispatched yet.
 // If tenantID is empty, all tenants are included.
 func (s *PlanReviewStore) GetApprovedUndispatched(ctx context.Context, tenantID string) ([]*ExecutionPlan, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	query := `SELECT plan_json FROM execution_plans WHERE status = 'approved' AND timeout_at > ? AND dispatched_at IS NULL`
 	args := []interface{}{now}
 	if tenantID != "" {
@@ -358,7 +366,7 @@ func (s *PlanReviewStore) GetApprovedUndispatched(ctx context.Context, tenantID 
 // MarkDispatched marks an approved plan as dispatched so it won't be executed again.
 // dispatchErr is persisted for diagnostics (empty string means success).
 func (s *PlanReviewStore) MarkDispatched(ctx context.Context, planID, tenantID, dispatchErr string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE execution_plans SET dispatched_at = ?, dispatch_error = ?
 		WHERE id = ? AND tenant_id = ? AND status = 'approved' AND dispatched_at IS NULL`,

--- a/internal/agent/timezone_test.go
+++ b/internal/agent/timezone_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression guards for #292 (the plan-store twin of the evidence-store #264
+// sweep): mattn/go-sqlite3 serializes a time.Time keeping its offset, and
+// SQLite compares those strings lexicographically. Every timestamp the plan
+// review store writes or binds must therefore be normalized to UTC, or the
+// `timeout_at > ?` comparisons in GetPending/GetApprovedUndispatched pick the
+// wrong plans across zones/DST.
+
+// TestPlanReviewStore_NormalizesTimestampsToUTC: a plan whose TimeoutAt is a
+// FUTURE instant expressed in a -08:00 zone must still be returned by
+// GetPending. Before the fix, Save bound the offset-carrying string (e.g.
+// "02:01:00-08:00" for 10:01 UTC), which sorts BEFORE a UTC "10:00:00" now —
+// the pending plan appeared already expired.
+func TestPlanReviewStore_NormalizesTimestampsToUTC(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store, err := NewPlanReviewStore(db)
+	require.NoError(t, err)
+
+	west := time.FixedZone("WEST", -8*3600)
+	plan := GenerateExecutionPlan("corr_tz", "acme", "agent", "gpt-4", 0, nil, 0.01, "allow", "", "", 30)
+	// Rewrite the timestamps in server-local time, as a non-UTC host would.
+	plan.CreatedAt = plan.CreatedAt.In(west)
+	plan.TimeoutAt = time.Now().Add(30 * time.Minute).In(west)
+	require.NoError(t, store.Save(ctx, plan))
+
+	pending, err := store.GetPending(ctx, "acme", "")
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "a plan with a future timeout written in a -08:00 zone must be pending, not expired by string comparison")
+	assert.Equal(t, plan.ID, pending[0].ID)
+
+	// Save normalizes the struct in place (same instant, UTC location), so the
+	// persisted plan_json carries UTC timestamps too.
+	assert.Equal(t, time.UTC, plan.CreatedAt.Location())
+	assert.Equal(t, time.UTC, plan.TimeoutAt.Location())
+}
+
+// TestPlanReviewStore_ExpiredPlanInEastZoneIsNotPending is the mirror case: a
+// plan whose TimeoutAt instant is already PAST but expressed in a +14:00 zone
+// serializes with a next-day date string that sorts AFTER a UTC now — before
+// the fix an expired plan stayed visible (and dispatchable) for up to the
+// offset delta.
+func TestPlanReviewStore_ExpiredPlanInEastZoneIsNotPending(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store, err := NewPlanReviewStore(db)
+	require.NoError(t, err)
+
+	east := time.FixedZone("EAST", 14*3600)
+	plan := GenerateExecutionPlan("corr_tz_exp", "acme", "agent", "gpt-4", 0, nil, 0.01, "allow", "", "", 30)
+	plan.TimeoutAt = time.Now().Add(-10 * time.Minute).In(east)
+	require.NoError(t, store.Save(ctx, plan))
+
+	pending, err := store.GetPending(ctx, "acme", "")
+	require.NoError(t, err)
+	assert.Empty(t, pending, "an expired plan written in a +14:00 zone must not appear pending")
+}
+
+// TestPlanReviewStore_DispatchWindowSurvivesLocalZone covers the other bound
+// comparison (GetApprovedUndispatched) plus the reviewed_at/dispatched_at
+// write paths: approve → visible for dispatch → mark dispatched → gone.
+func TestPlanReviewStore_DispatchWindowSurvivesLocalZone(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store, err := NewPlanReviewStore(db)
+	require.NoError(t, err)
+
+	west := time.FixedZone("WEST", -8*3600)
+	plan := GenerateExecutionPlan("corr_tz_disp", "acme", "agent", "gpt-4", 0, nil, 0.01, "allow", "", "", 30)
+	plan.CreatedAt = plan.CreatedAt.In(west)
+	plan.TimeoutAt = time.Now().Add(30 * time.Minute).In(west)
+	require.NoError(t, store.Save(ctx, plan))
+	require.NoError(t, store.Approve(ctx, plan.ID, "acme", "reviewer"))
+
+	toDispatch, err := store.GetApprovedUndispatched(ctx, "acme")
+	require.NoError(t, err)
+	require.Len(t, toDispatch, 1, "an approved plan with a future timeout written in a -08:00 zone must be dispatchable")
+
+	require.NoError(t, store.MarkDispatched(ctx, plan.ID, "acme", ""))
+	toDispatch, err = store.GetApprovedUndispatched(ctx, "acme")
+	require.NoError(t, err)
+	assert.Empty(t, toDispatch)
+}

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -335,15 +335,9 @@ func resolveBudgetUsage(
 		}
 		return res.daily, res.monthly, nil
 	case serverBudgetFailed:
-		if costsServerURLExplicit {
-			return nil, nil, fmt.Errorf("budget query to %s failed: %w — the running server is authoritative for budget caps; fix the URL/TALON_ADMIN_KEY or stop the server to use local resolution", costsServerURL, err)
+		if haltErr := budgetProbeFailure(ctx, err); haltErr != nil {
+			return nil, nil, haltErr
 		}
-		// The DEFAULT url is a best-effort probe: something answered on
-		// :8080 but not usefully (auth, or not Talon at all). Warn loudly —
-		// a local denominator may describe a different deployment than the
-		// one that rejected us — but do not brick offline use over a port
-		// squatter the operator never pointed us at.
-		fmt.Fprintf(os.Stderr, "warning: budget query to %s failed (%v); falling back to LOCAL resolution, which may disagree with the running server — set --url and TALON_ADMIN_KEY for the authoritative caps\n", costsServerURL, err)
 	case serverBudgetUnavailable:
 		// An operator who EXPLICITLY named a server asked for THAT runtime's
 		// caps — a wrong hostname, TLS failure, or an outage must surface as
@@ -460,6 +454,50 @@ func fetchServerBudget(ctx context.Context, baseURL, tenantID, agentID string) (
 		res.monthly = toBudgetUsage(body.MonthlyUsed, body.MonthlyLimit, label)
 	}
 	return res, serverBudgetAnswered, nil
+}
+
+// budgetProbeFailure decides what a reachable-but-failing budget query means.
+// A non-nil return halts resolution with that error; nil permits the warned
+// local fallback. An explicit --url is always authoritative. For the DEFAULT
+// probe, identify WHAT answered before deciding (#293): a real Talon server
+// rejecting us (auth, incompatible shape) is authoritative — its refusal must
+// not end in local numbers that may describe a different deployment. Only a
+// non-Talon port squatter permits the fallback, so offline `talon costs`
+// keeps working.
+func budgetProbeFailure(ctx context.Context, err error) error {
+	if costsServerURLExplicit {
+		return fmt.Errorf("budget query to %s failed: %w — the running server is authoritative for budget caps; fix the URL/TALON_ADMIN_KEY or stop the server to use local resolution", costsServerURL, err)
+	}
+	if isTalonServer(ctx, costsServerURL) {
+		return fmt.Errorf("budget query to %s failed: %w — the server identifies itself as Talon (/health marker), so the running server is authoritative for budget caps (#288); set TALON_ADMIN_KEY for the runtime-resolved caps, or pass --url \"\" for local resolution", costsServerURL, err)
+	}
+	fmt.Fprintf(os.Stderr, "warning: budget query to %s failed (%v) and the responder does not identify as Talon; falling back to LOCAL resolution, which may disagree with any running server — set --url and TALON_ADMIN_KEY for the authoritative caps\n", costsServerURL, err)
+	return nil
+}
+
+// isTalonServer reports whether the responder at baseURL identifies itself as
+// a Talon server via the /health product marker (#293). Used ONLY to classify
+// a reachable-but-failing DEFAULT budget probe: Talon rejected us → its
+// refusal is authoritative (hard error); anything else on the port → local
+// fallback is safe. Any probe failure (unreachable, non-200, no marker)
+// counts as "not Talon" so this can never brick offline use.
+func isTalonServer(ctx context.Context, baseURL string) bool {
+	trimmed := trimRightSlash(baseURL)
+	if trimmed == "" {
+		return false
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, trimmed+"/health", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := (&http.Client{Timeout: 3 * time.Second}).Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK && resp.Header.Get("X-Talon-Service") == "talon"
 }
 
 // loadAgentEffectiveCaps reports the agent's effective daily/monthly caps via
@@ -804,7 +842,7 @@ func init() {
 	rootCmd.AddCommand(costsCmd)
 	costsCmd.AddCommand(costsExportCmd)
 	costsCmd.Flags().StringVar(&costsAgent, "agent", "", "filter by agent name (budget caps resolve via the running server when reachable; until agents_dir #267 the local fallback knows only the default agent policy)")
-	costsCmd.Flags().StringVar(&costsServerURL, "url", "http://localhost:8080", "base URL of the running talon server for runtime-resolved budget caps (#288); unreachable = local resolution")
+	costsCmd.Flags().StringVar(&costsServerURL, "url", "http://localhost:8080", "base URL of the running talon server for runtime-resolved budget caps (#288); unreachable = local resolution, empty (\"\") = skip the server entirely")
 	costsCmd.Flags().StringVar(&costsTenant, "tenant", "", "tenant ID (default: default)")
 	costsCmd.Flags().BoolVar(&costsByModel, "by-model", false, "group output by model")
 	costsCmd.Flags().BoolVar(&costsByProvider, "by-provider", false, "group output by provider")

--- a/internal/cmd/costs_budget_test.go
+++ b/internal/cmd/costs_budget_test.go
@@ -243,6 +243,39 @@ metadata: { owner: "", tags: [] }
 		assert.Contains(t, err.Error(), "401")
 	})
 
+	// #293: the implicit probe identifies WHAT rejected it before falling
+	// back. A real Talon server (proven by the /health marker) returning 401
+	// is authoritative — hard error, never local numbers; a non-Talon port
+	// squatter keeps the warned local fallback so offline use survives.
+	t.Run("implicit probe, 401 from a server with the Talon /health marker → error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				w.Header().Set("X-Talon-Service", "talon")
+				_, _ = w.Write([]byte(`{"service":"talon","status":"ok"}`))
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+		setServer(t, srv.URL, false)
+		_, _, err := resolveBudgetUsage(ctx, cfg, "default", "", 1, 2)
+		require.Error(t, err, "a real Talon's rejection must not end in local numbers even on the implicit probe (#293)")
+		assert.Contains(t, err.Error(), "401")
+		assert.Contains(t, err.Error(), "identifies itself as Talon")
+	})
+
+	t.Run("implicit probe, 401 from a non-Talon squatter → local fallback", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized) // rejects everything, no Talon marker on /health
+		}))
+		defer srv.Close()
+		setServer(t, srv.URL, false)
+		daily, _, err := resolveBudgetUsage(ctx, cfg, "default", "", 1, 2)
+		require.NoError(t, err)
+		require.NotNil(t, daily, "a port squatter must not brick the default probe's local fallback")
+		assert.Equal(t, "policy_cost_limits", daily.Source)
+	})
+
 	t.Run("authoritative no-cap answer → no local fallback", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -132,9 +132,15 @@ func writeOpenAIError(w http.ResponseWriter, status int, code, typeStr, message 
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	// Product marker (#293): lets clients (e.g. `talon costs`' default
+	// localhost probe) distinguish a real Talon server from an unrelated
+	// service squatting on the port BEFORE deciding whether a failed API
+	// call is authoritative. Sent as a header so HEAD probes see it too.
+	w.Header().Set("X-Talon-Service", "talon")
 	resp := map[string]interface{}{
-		"status": "ok",
-		"uptime": time.Since(s.startTime).String(),
+		"service": "talon",
+		"status":  "ok",
+		"uptime":  time.Since(s.startTime).String(),
 	}
 	if r.URL.Query().Get("detail") == "true" {
 		components := map[string]string{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -48,6 +48,10 @@ func TestHealthEndpoint(t *testing.T) {
 	var out map[string]interface{}
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
 	assert.Equal(t, "ok", out["status"])
+	// Product marker (#293): `talon costs` identifies Talon via this header
+	// before trusting a failed budget probe on the default localhost URL.
+	assert.Equal(t, "talon", rec.Header().Get("X-Talon-Service"))
+	assert.Equal(t, "talon", out["service"])
 
 	// HEAD must answer 200 too: `wget --spider` (the compose healthchecks)
 	// probes with HEAD, and chi's Get-only registration answered 405 —


### PR DESCRIPTION
Fixes #292 and #293.

## #292 — plan review store UTC invariant

The plan review store was the last store exempt from the #264 invariant: mattn/go-sqlite3 serializes a `time.Time` keeping its offset and SQLite compares those strings lexicographically, so local-time writes (`timeout_at`, `reviewed_at`, `dispatched_at`) and local-time binds (`GetPending`, `GetApprovedUndispatched`) mis-compared across host timezone changes and DST — a pending plan could appear expired (or an expired one dispatchable) by up to the offset delta, and `ORDER BY reviewed_at DESC` could mis-order the dashboard review history.

- Normalize at plan creation (`GenerateExecutionPlan`), in `Save` (in place, so `plan_json` agrees with the DATETIME columns, mirroring the evidence store), and at every `time.Now()` query bind.
- New `internal/agent/timezone_test.go` mirrors `internal/evidence/timezone_test.go`; all three tests were verified to FAIL against the pre-fix store (future-timeout plan in a `-08:00` zone invisible to `GetPending`; expired plan in a `+14:00` zone still pending; dispatch window).
- Existing rows keep their stored offset, matching the #264 precedent.

## #293 — `talon costs` identifies Talon before trusting the default `:8080` probe

Implements **option 3** from the issue (preserves today's UX, completes the #288 authority model end-to-end):

- `/health` now carries a product marker: `X-Talon-Service: talon` header (visible to HEAD probes) + `"service":"talon"` body field.
- On the **implicit** default probe, a reachable-but-failing budget answer is classified by probing `GET /health`: responder identifies as Talon → **hard error** (a real runtime's 401 can no longer end in local numbers that may describe a different deployment, with remediation naming `TALON_ADMIN_KEY` and `--url ""`); no marker / unreachable / non-200 → the loudly-warned local fallback survives, so a port squatter still cannot brick offline `talon costs`.
- Explicit `--url` semantics unchanged (already authoritative); `--url ""` skips the server path entirely. `--url` help text documents the empty-string escape hatch.
- The probe-failure decision moved into `budgetProbeFailure` (also keeps `resolveBudgetUsage` under the gocyclo limit).
- New subtests in `TestResolveBudgetUsage_ServerAuthority` cover both classifications; the health test pins the marker.

## Verification

- `go test ./internal/agent/ ./internal/cmd/ ./internal/server/ ./internal/evidence/ -count=1` — pass
- `go test -tags integration ./tests/integration/...` — pass (75s)
- `golangci-lint run internal/agent/... internal/cmd/... internal/server/...` — 0 issues
- Regression validity: new #292 tests confirmed failing with the store changes stashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
