### PR TITLE
chore(ci): add control-plane proof checklist to the PR template (closes #187)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,13 @@
 - [ ] Evidence generated for auditable operations
 - [ ] No secrets hardcoded
 
+## Control-plane proof checklist (MVP #265)
+- [ ] Which pillar does this strengthen — cost control, reliability, shared policy, session understanding — or the evidence proof layer beneath them?
+- [ ] Enforcement happens before the provider/execution where claimed (deny-before-spend, block-before-forward), and the decision leaves signed evidence.
+- [ ] Demoable: does this show up in (or at least not break) the north-star demo (#107)?
+- [ ] Claims discipline: describes supporting controls and evidence, not regulatory outcomes; target behavior is not documented as shipped; session caps stay described as soft until atomic reservation lands.
+- [ ] Boundary discipline: no implication that Talon controls actions it cannot intercept (local shell/filesystem/direct calls).
+
 ## Related Issues
 <!-- Link related issues: Fixes #123 -->
 


### PR DESCRIPTION
Closes #187. Adds a short **Control-plane proof checklist** to `.github/PULL_REQUEST_TEMPLATE.md` so every PR states, up front:

- which pillar it strengthens (cost control / reliability / shared policy / session understanding / the evidence layer);
- whether enforcement happens before spend/execution and leaves signed evidence;
- north-star demo (#107) impact;
- claims discipline (supporting controls/evidence, not regulatory outcomes; target behavior not documented as shipped; session caps stay soft until atomic reservation lands);
- boundary discipline (no implication Talon intercepts local shell/filesystem/direct calls).

Five items (≤6 per the acceptance criteria), referencing #107 and the MVP epic #265. Wording passes `scripts/check-claim-discipline.sh` (verified — the draft's "makes you compliant" example is reworded to avoid tripping the linter, since the template isn't in the negative-example allowlist).