### PR TITLE
test(costs): lock single-provider gateway cost estimation (closes #208)

### DIFF
--- a/internal/cmd/estimator_test.go
+++ b/internal/cmd/estimator_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dativo-io/talon/internal/gateway"
+	"github.com/dativo-io/talon/internal/pricing"
+)
+
+// TestGatewayCostEstimator_NoProviderSweepWarnings is the #208 regression: the
+// gateway cost estimator prices ONLY the routed provider through the pricing
+// TABLE (EstimateCached), so it never sweeps every configured provider via
+// provider.EstimateCost — the behavior that logged one "unknown model for cost
+// estimation" per non-matching provider on every request (an Anthropic provider
+// will never know an OpenAI model). Configuring a second provider must therefore
+// produce no unrelated pricing warnings; even a provider that does not know the
+// model yields a flat estimate with NO warning.
+func TestGatewayCostEstimator_NoProviderSweepWarnings(t *testing.T) {
+	// Load the table BEFORE capturing the logger, so the load path's own INFO
+	// (embedded-default fallback) never pollutes the assertion.
+	pt := pricing.LoadOrDefault("")
+
+	var buf bytes.Buffer
+	prev := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() { log.Logger = prev })
+
+	est := gatewayCostEstimator(pt)
+	usage := gateway.Usage{Input: 100, Output: 50}
+
+	// Routed provider knows the model → priced from the table.
+	known := est("openai", "gpt-4o-mini", usage)
+	assert.True(t, known.PricingKnown, "openai/gpt-4o-mini is in the default pricing table")
+
+	// A second configured provider that does NOT know the model → flat estimate,
+	// marked unknown, but STILL no warning: the estimator uses the pricing table,
+	// never the per-provider EstimateCost sweep that logged #208.
+	unknown := est("anthropic", "gpt-4o-mini", usage)
+	assert.False(t, unknown.PricingKnown)
+
+	assert.NotContains(t, buf.String(), "unknown model for cost estimation",
+		"configuring multiple providers must not spam pricing warnings (#208)")
+}


### PR DESCRIPTION
Closes #208.

**Already resolved on main, now locked with a regression test** (not a feature change). The bug was `gatewayCostEstimator` taking the max estimate across **all** configured providers, calling `provider.EstimateCost(model, …)` on each — so an Anthropic provider that never knew an OpenAI model logged `unknown model for cost estimation model=gpt-4o-mini provider=anthropic` on every request, reading like a misconfiguration.

Current `gatewayCostEstimator` prices only the **routed** provider through the pricing **table** (`pricingTable.EstimateCached`), which returns `known=false` silently — `WarnUnknownModelOnce` is only called by the per-provider `EstimateCost` methods, which the estimator no longer invokes and never sweeps.

The new `TestGatewayCostEstimator_NoProviderSweepWarnings` captures the logger and asserts that even a second configured provider which does not know the model (`anthropic`/`gpt-4o-mini`) produces a flat unknown estimate with **no** "unknown model for cost estimation" warning.

Verify: `go test ./internal/cmd/ -run TestGatewayCostEstimator_NoProviderSweepWarnings`.