### PR TITLE
fix(demo): isolate fleet-ops demo state under data_dir — never touch the real ~/.talon (#319)

### DIFF
--- a/examples/fleet-ops/demo.sh
+++ b/examples/fleet-ops/demo.sh
@@ -15,8 +15,12 @@ trap 'echo "ERROR: demo aborted at line $LINENO (see above)." >&2' ERR
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
-export TALON_HOME="$WORK/.talon"
-mkdir -p "$TALON_HOME"
+# Isolation (#319): every stateful path (evidence.db, secrets.db, memory.db)
+# derives from data_dir, so pin it inside the temp workspace — both via env
+# (TALON_DATA_DIR is viper's data_dir) and in the generated talon.config.yaml
+# below, mirroring the product-demo pattern. The real ~/.talon is never touched.
+export TALON_DATA_DIR="$WORK/.talon"
+mkdir -p "$TALON_DATA_DIR"
 
 say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
 run()  { printf '\n\033[2m$ %s\033[0m\n' "$*"; eval "$*"; }
@@ -27,7 +31,8 @@ TALON="$WORK/talon"
 
 say "Discover a fleet: three AI use cases under agents_dir"
 mkdir -p "$WORK/agents/customer-support" "$WORK/agents/coding" "$WORK/agents/summarizer"
-cat > "$WORK/talon.config.yaml" <<'YAML'
+cat > "$WORK/talon.config.yaml" <<YAML
+data_dir: $WORK/.talon
 agents_dir: agents
 signing_key: "demo-signing-key-0123456789abcdef0123456789abcdef"
 YAML


### PR DESCRIPTION
Closes #319.

## What

`examples/fleet-ops/demo.sh` exported `TALON_HOME`, which nothing reads — Talon's stateful paths (evidence.db, secrets.db, memory.db) all derive from `data_dir` (`Config.EvidenceDBPath`). The demo's `agents disable` therefore wrote signed evidence into the operator's **real** `~/.talon/evidence.db`, and the demo's COST column read real spend back.

Fix (issue Option 1, demo-side): pin `data_dir` inside the temp workspace, both via `TALON_DATA_DIR` (viper env for `data_dir`) and explicitly in the generated `talon.config.yaml` — the same belt-and-suspenders pattern `examples/product-demo/demo.sh` already uses. The ineffective `TALON_HOME` export is gone.

Note: the issue text's suggested `evidence: {type: sqlite, path: ...}` block is itself a dead config surface (nothing reads an `evidence` block — filed as #342); `data_dir` is the real isolation surface.

## Acceptance criteria from #319, verified by live run

- [x] Full demo run leaves `~/.talon/evidence.db` byte-identical — md5 `3a25d593…` and mtime unchanged before/after.
- [x] Demo's `talon agents` COST column shows `$0.00 / $…` for the fresh fleet (only spend produced inside the run).
- [x] The run's evidence id (`al_5c085d9c-604`) does not appear in the operator's real store.

Not touched: the two records leaked by the pre-fix run documented in #319 (`al_fe0509c8-30f`, `al_572e695d-a8a`) still sit in the operator's real store. Evidence stores are append-only by design; removing them is an operator decision, not something this fix should do silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)