### PR TITLE
fix(cli): runtime errors print only the error — no cobra usage dump (#339)

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -83,6 +83,50 @@ func TestPackageLevelTracer_IsNotNil(t *testing.T) {
 	assert.NotNil(t, tracer, "package-level tracer should be initialized")
 }
 
+// TestRuntimeError_NoUsageDump pins #339: a RUNTIME error (command parsed
+// fine, execution failed) must print only the error — no usage block
+// burying the message the operator needs.
+func TestRuntimeError_NoUsageDump(t *testing.T) {
+	t.Setenv("TALON_DATA_DIR", t.TempDir())
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"audit", "show", "al_does-not-exist"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, buf.String(), "Usage:", "runtime errors must not dump the usage block")
+}
+
+// TestParseError_KeepsUsage pins the #339 counterpart: a flag PARSE error is
+// a syntax mistake and still gets the usage block (via the FlagErrorFunc).
+func TestParseError_KeepsUsage(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version", "--no-such-flag"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "unknown flag: --no-such-flag")
+	assert.Contains(t, buf.String(), "Usage:", "flag parse errors must keep the usage block")
+}
+
+// TestUnknownCommand_KeepsHelpHint: unknown commands keep cobra's
+// "Run 'talon --help' for usage." pointer (unaffected by SilenceUsage).
+func TestUnknownCommand_KeepsHelpHint(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"no-such-command"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "unknown command")
+	assert.Contains(t, buf.String(), "--help")
+}
+
 func TestMemoryAsOfCmd_EmptyStore(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("TALON_DATA_DIR", dir)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -94,6 +94,13 @@ It enforces policies on AI agent execution with:
 - Multi-tenant isolation
 - MCP-native tool integration`,
 
+	// Runtime errors print only the error, not the full usage block (#339):
+	// a failed RunE means the operator needs the message (an evidence id, a
+	// path, a fix hint), not flag documentation. Parse errors still get
+	// usage via the FlagErrorFunc in init(), and unknown commands keep
+	// cobra's "Run 'talon --help' for usage." hint.
+	SilenceUsage: true,
+
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Initialize logging
 		setupLogging()
@@ -141,6 +148,13 @@ func setupLogging() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Flag PARSE errors (unknown flag, bad value) are syntax mistakes and DO
+	// warrant usage — SilenceUsage on the root suppresses cobra's default
+	// print, so append the usage block to the error here (#339).
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return fmt.Errorf("%w\n\n%s", err, cmd.UsageString())
+	})
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "infrastructure config file (default: ./talon.config.yaml or ~/.talon/talon.config.yaml)")


### PR DESCRIPTION
Closes #339.

## What

Sets `SilenceUsage: true` on the root command (children inherit) and adds a `FlagErrorFunc` that appends the usage block to flag **parse** errors, preserving the distinction the issue requires:

| Input | Before | After |
|---|---|---|
| `talon audit verify --session does-not-exist` | error + ~30-line usage dump | `Error: no evidence records found for session does-not-exist` |
| `talon compliance ropa --format pdf` | error + usage dump | `Error: unsupported --format "pdf"; use html or json` |
| `talon serve --mcp-proxy` (unknown flag) | error + usage | error + usage (unchanged) |
| `talon frobnicate` (unknown command) | `Run 'talon --help' for usage.` hint | unchanged |

Note: cobra cannot distinguish args-count validation (`Args:`) from runtime errors, so `talon run` with no args now prints only `Error: accepts 1 arg(s), received 0` — self-explanatory without the usage block.

## Tests

- `TestRuntimeError_NoUsageDump` — runtime error output contains no `Usage:`
- `TestParseError_KeepsUsage` — unknown-flag output contains `unknown flag` + `Usage:`
- `TestUnknownCommand_KeepsHelpHint` — unknown-command output keeps the `--help` pointer

All three plus the existing `./internal/cmd` package pass; behavior additionally verified live on the built binary with the issue's exact repros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)