### PR TITLE
docs(guides)+init: coding-agents guides match what the pack actually does; init prints the real file list (#337, #341)

### DIFF
--- a/docs/guides/claude-code-integration.md
+++ b/docs/guides/claude-code-integration.md
@@ -19,11 +19,12 @@ mkdir talon-coding && cd talon-coding
 talon init --pack coding-agents
 ```
 
-This creates three files:
+This creates four files:
 
 - `agent.talon.yaml` — the **`claude-code` agent**: Claude Code's Talon traffic identity (`agent.key.secret_name: claude-code-talon-key`) plus its policy override with coding-tuned defaults — `session_limits.max_cost: 10.00`, `cost_limits.daily: 50.00` / `monthly: 500.00`, `input_scan: true` (input PII action `warn`), `allowed_providers: ["anthropic"]` — and high-precision credential recognizers (PEM private-key blocks, AWS `AKIA...` key IDs, GitHub `ghp_`/`github_pat_` tokens, Anthropic/OpenAI `sk-ant-...`/`sk-proj-...` keys) so leaked credentials in prompt traffic land in evidence.
 - `agents/codex/agent.talon.yaml` — the `codex` agent for Codex CLI (see the [Codex guide](codex-cli-integration.md)). To serve both agents from one `talon serve`, set `agents_dir: "."` in `talon.config.yaml` (the pack ships it commented out): discovery (#267, shipped) loads every file named exactly `agent.talon.yaml` under it — provision both agents' keys first. Without `agents_dir`, `talon serve` runs the single default `agent.talon.yaml`.
 - `talon.config.yaml` — gateway config with the Anthropic provider, the **organization baseline** (`organization_policy.defaults`: `pii_action: warn`, `response_pii_action: allow`), **shadow mode**, and a raised `request_timeout: 600s` (the response-header wait follows it by default).
+- `pricing/models.yaml` — the LLM cost-estimation table (a copy of the embedded default). The relative `pricing_file` resolves against the active policy file's directory in single-file mode: in this guide's flow (policy at the project root) that's the project root, so edits work; in the Codex single-file flow (`TALON_DEFAULT_POLICY=agents/codex/...`) they are silently ignored — see the [Codex guide's pricing caveat](codex-cli-integration.md#5-verify).
 
 These defaults are deliberate — see [Why the pack defaults look like this](#why-the-pack-defaults-look-like-this) below before changing them.
 

--- a/docs/guides/codex-cli-integration.md
+++ b/docs/guides/codex-cli-integration.md
@@ -21,11 +21,12 @@ mkdir talon-coding && cd talon-coding
 talon init --pack coding-agents
 ```
 
-This creates three files (source of truth: `internal/pack/templates/coding-agents/`):
+This creates four files (source of truth: `internal/pack/templates/coding-agents/`):
 
 - `agents/codex/agent.talon.yaml` — the **`codex` agent**: Codex CLI's Talon traffic identity (`agent.key.secret_name: codex-talon-key`) plus its policy override with coding-tuned defaults — `session_limits.max_cost: 10.00`, `cost_limits.daily: 50.00` / `monthly: 500.00`, `input_scan: true` (input PII action `warn`), `allowed_providers: ["openai"]`, `metadata.team: coding` — and high-precision credential recognizers (PEM private-key blocks, AWS `AKIA...` key IDs, GitHub `ghp_`/`github_pat_` tokens, Anthropic/OpenAI `sk-ant-...`/`sk-proj-...` keys) so leaked credentials in prompt traffic land in evidence.
 - `agent.talon.yaml` — the `claude-code` agent for Claude Code (the pack's primary agent; see the [Claude Code guide](claude-code-integration.md)).
 - `talon.config.yaml` — gateway config with the OpenAI provider, the **organization baseline** (`organization_policy.defaults`: `pii_action: warn`, `response_pii_action: allow`), **shadow mode**, and a raised `request_timeout: 600s` (the response-header wait follows it by default).
+- `pricing/models.yaml` — the LLM cost-estimation table (a copy of the embedded default). Note the resolution caveat in step 5 before editing it in this guide's single-file flow.
 
 **One agent, or the whole fleet (#267, shipped):** this guide provisions only the `codex` agent, so `talon serve` runs it single-file via `TALON_DEFAULT_POLICY=agents/codex/agent.talon.yaml` (step 2). To govern Codex **and** Claude Code from one `talon serve`, set `agents_dir: "."` in `talon.config.yaml` (the pack ships it commented out) — discovery loads every `agent.talon.yaml` under it, each served with its own key, policy, and routing; provision both agents' keys first. See the [Claude Code guide](claude-code-integration.md) for the second agent.
 
@@ -105,7 +106,7 @@ codex --profile talon
 
 **Important:**
 
-- **The trailing `/v1` in `base_url` is required.** Codex builds `POST {base_url}/responses`, and Talon's Responses handling matches the `/v1/responses` path (`isResponsesAPIPath` in `internal/gateway/responses_api.go`). Without it the joined path misses both Talon's Responses handling and OpenAI's endpoint — you get 404 on every request. Note: the pack wizard's printed next-steps currently omit the `/v1` (#235); use the value shown here.
+- **The trailing `/v1` in `base_url` is required.** Codex builds `POST {base_url}/responses`, and Talon's Responses handling matches the `/v1/responses` path (`isResponsesAPIPath` in `internal/gateway/responses_api.go`). Without it the joined path misses both Talon's Responses handling and OpenAI's endpoint — you get 404 on every request. The pack wizard's printed next-steps show the same `/v1`-suffixed value.
 - **Never set `requires_openai_auth = true` on the Talon provider.** That makes Codex send its ChatGPT-subscription OAuth token, which Talon rejects as an unknown agent key. Subscription billing cannot be governed; this is a hard boundary, not a configuration gap ([LIMITATIONS.md §7](../../LIMITATIONS.md#7-coding-agent-and-orchestration-boundary)).
 - The value in `TALON_CODEX_KEY` is the Talon **agent key**, not your real OpenAI key. Talon resolves the `codex` agent by this key and injects the vault-stored key upstream — Codex never sees your `sk-...` key.
 - The Codex IDE extension reads the same `~/.codex/config.toml`, including `model_providers`, so this configuration governs it too (verified 2026-07 against the `openai/codex` source; re-verify on Codex majors per the recapture notes in `internal/gateway/testdata/conformance/responses/README.md`).
@@ -151,9 +152,14 @@ The dashboard (`talon serve` HTTP UI) shows the same data in the **Coding Sessio
 
 Because Codex always streams, cost figures depend on Talon parsing the usage block out of the terminal `response.completed` event — that parsing is shipped (`internal/gateway/forward.go`, `TestExtractUsage_ResponsesCompleted`); without it streamed cost would be estimate-only. One pricing caveat from [LIMITATIONS.md §7](../../LIMITATIONS.md#7-coding-agent-and-orchestration-boundary): a pricing entry without cache rates bills cache tokens at the full input rate (`pricing_basis: "cache_fallback_input_rate"`) — keep the pricing table current.
 
+**Where the pricing table is read from (single-file caveat):** in this guide's single-file flow (`TALON_DEFAULT_POLICY=agents/codex/agent.talon.yaml`), the relative `pricing_file: "pricing/models.yaml"` in `talon.config.yaml` resolves against the **policy file's directory** — `talon serve` looks for `agents/codex/pricing/models.yaml`, misses, and logs `pricing file not found; using embedded default pricing`. That's harmless untouched (the pack file is identical to the embedded default), but **edits to `./pricing/models.yaml` are silently ignored in this flow**. To make your edits count, do one of:
+- switch to fleet mode (`agents_dir: "."` in `talon.config.yaml`) — fleet mode resolves pricing from the project root (#267), or
+- set `llm.pricing_file` to an absolute path, or
+- move the table to `agents/codex/pricing/models.yaml`.
+
 **Troubleshooting**
 
-- **404 on every request** — The `base_url` is missing the trailing `/v1`. Codex appends `/responses`, so `.../v1/proxy/openai` becomes `.../v1/proxy/openai/responses`, which matches neither Talon's `/v1/responses` handling nor OpenAI's endpoint. Set `base_url = "http://localhost:8080/v1/proxy/openai/v1"` (#235).
+- **404 on every request** — The `base_url` is missing the trailing `/v1`. Codex appends `/responses`, so `.../v1/proxy/openai` becomes `.../v1/proxy/openai/responses`, which matches neither Talon's `/v1/responses` handling nor OpenAI's endpoint. Set `base_url = "http://localhost:8080/v1/proxy/openai/v1"`.
 - **Authentication errors on every request** — Either `TALON_CODEX_KEY` is unset in the shell running Codex (the `env_key` mechanism sends nothing), or the provider has `requires_openai_auth = true` and Codex is sending subscription OAuth, which Talon rejects. Remove `requires_openai_auth`, export the agent key, restart Codex. [LIMITATIONS.md §7](../../LIMITATIONS.md#7-coding-agent-and-orchestration-boundary).
 - **`gateway_secret_get_failed` / "cipher: message authentication failed" / "Service configuration error"** — Vault decryption failed. Use the **same** `TALON_SECRETS_KEY` for `talon secrets set` and `talon serve`. If you lost it, set a new one and re-run `talon secrets set openai-api-key "sk-..."`.
 - **Long generations are cut off mid-response** — Your `request_timeout` is too low. The pack sets `600s`; the server-wide default of `120s` hard-cuts long coding generations. The response-header wait defaults to `request_timeout` (tunable via `response_header_timeout`), so slow non-streaming prompts get the same budget. Also note Codex itself aborts a stream that has been idle for ~300 seconds and retries; Talon cannot extend that client-side limit.

--- a/docs/guides/governing-coding-agents.md
+++ b/docs/guides/governing-coding-agents.md
@@ -56,7 +56,7 @@ mkdir talon-coding && cd talon-coding
 talon init --pack coding-agents --name coding-gateway
 ```
 
-This creates `agent.talon.yaml`, `agents/codex/agent.talon.yaml`, and `talon.config.yaml` pre-configured for coding traffic (source of truth: `internal/pack/templates/coding-agents/`). The defaults are deliberate:
+This creates `agent.talon.yaml`, `agents/codex/agent.talon.yaml`, `talon.config.yaml`, and `pricing/models.yaml` pre-configured for coding traffic (source of truth: `internal/pack/templates/coding-agents/`; the pricing table is a copy of the embedded default). The defaults are deliberate:
 
 - **Two agents, one per tool** — `claude-code` (the primary `agent.talon.yaml`, Anthropic route) and `codex` (`agents/codex/agent.talon.yaml`, OpenAI route), each its own AI use case with its own vault-bound agent key, `metadata.team: coding`, `policies.allowed_providers`, and its own budgets. Budgets and audit attribute **per tool**. To serve both from one `talon serve`, set `agents_dir: "."` (#267, shipped; the pack ships it commented out) — discovery matches the exact filename `agent.talon.yaml` and fails closed on duplicate `agent.name`. Without `agents_dir`, `talon serve` runs the single default `agent.talon.yaml`.
 - **Shadow mode** — would-have-denied decisions are recorded in signed evidence while nothing blocks. Flip to `mode: "enforce"` once the dashboard looks right.

--- a/internal/cmd/init_cmd.go
+++ b/internal/cmd/init_cmd.go
@@ -278,6 +278,30 @@ func runListCompliance(out io.Writer) error {
 	return nil
 }
 
+// printCreatedFiles lists exactly what init wrote (#341): packs with declared
+// Files get their real file list (the hardcoded three-file list omitted e.g.
+// agents/codex/agent.talon.yaml); pricing/models.yaml is written by the
+// shared scaffold for every pack.
+func printCreatedFiles(out io.Writer, packID string) {
+	fmt.Fprintln(out, "Created files:")
+	if p, ok := pack.FindByID(packID); ok && len(p.Files) > 0 {
+		width := len("pricing/models.yaml")
+		for _, f := range p.Files {
+			if len(f.OutputPath) > width {
+				width = len(f.OutputPath)
+			}
+		}
+		for _, f := range p.Files {
+			fmt.Fprintf(out, "  - %-*s  (%s)\n", width, f.OutputPath, f.Description)
+		}
+		fmt.Fprintf(out, "  - %-*s  (LLM cost estimation table)\n", width, "pricing/models.yaml")
+		return
+	}
+	fmt.Fprintln(out, "  - agent.talon.yaml     (agent policy — governance/compliance team)")
+	fmt.Fprintln(out, "  - talon.config.yaml    (infrastructure config — DevOps/platform team)")
+	fmt.Fprintln(out, "  - pricing/models.yaml  (LLM cost estimation table)")
+}
+
 //nolint:gocyclo // runPackInit dispatches pack validation, init, and post-message by pack type
 func runPackInit(out, errOut io.Writer) error {
 	ok := false
@@ -306,10 +330,7 @@ func runPackInit(out, errOut io.Writer) error {
 	log.Info().Str("name", initName).Str("pack", initPack).Msg("Initialized Talon project")
 	fmt.Fprintln(out, "Initialized Talon project")
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Created files:")
-	fmt.Fprintln(out, "  - agent.talon.yaml     (agent policy — governance/compliance team)")
-	fmt.Fprintln(out, "  - talon.config.yaml    (infrastructure config — DevOps/platform team)")
-	fmt.Fprintln(out, "  - pricing/models.yaml  (LLM cost estimation table)")
+	printCreatedFiles(out, initPack)
 	fmt.Fprintln(out)
 	if p, ok := pack.FindByID(initPack); ok && p.PostMessage != "" {
 		fmt.Fprintln(out, strings.TrimSpace(p.PostMessage))

--- a/internal/cmd/init_pack_test.go
+++ b/internal/cmd/init_pack_test.go
@@ -60,6 +60,35 @@ func TestInitPack_CrewAI_GeneratesFiles(t *testing.T) {
 	assert.NotContains(t, string(configContent), "tenant_key", "legacy identity must not scaffold")
 }
 
+// TestInitPack_CreatedFilesListMatchesPackFiles pins #341: the printed
+// "Created files" list must name every file the pack actually wrote — the
+// old hardcoded three-file list omitted pack-declared files like
+// agents/codex/agent.talon.yaml.
+func TestInitPack_CreatedFilesListMatchesPackFiles(t *testing.T) {
+	dir := t.TempDir()
+	prevWd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(prevWd) })
+	require.NoError(t, os.Chdir(dir))
+
+	buf := new(strings.Builder)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"init", "--pack", "coding-agents", "--skip-verify"})
+	require.NoError(t, rootCmd.Execute())
+
+	out := buf.String()
+	for _, f := range []string{
+		"agent.talon.yaml",
+		"agents/codex/agent.talon.yaml",
+		"talon.config.yaml",
+		"pricing/models.yaml",
+	} {
+		assert.Contains(t, out, f, "Created files list must include %s", f)
+		require.FileExists(t, filepath.Join(dir, filepath.FromSlash(f)))
+	}
+}
+
 func TestInitPack_ComplianceGDPR_MergesOverlay(t *testing.T) {
 	dir := t.TempDir()
 	prevWd, err := os.Getwd()

--- a/internal/pack/templates/coding-agents/talon.config.yaml
+++ b/internal/pack/templates/coding-agents/talon.config.yaml
@@ -19,6 +19,12 @@
 # docs/guides/governing-coding-agents.md).
 
 llm:
+  # Relative pricing_file resolution (#337): fleet mode (agents_dir) resolves
+  # from the project root; single-file mode resolves from the ACTIVE policy
+  # file's directory. With TALON_DEFAULT_POLICY=agents/codex/agent.talon.yaml
+  # this file is NOT found and serve falls back to embedded defaults — use
+  # agents_dir, an absolute path, or keep the policy at the project root
+  # before editing the pricing table.
   pricing_file: "pricing/models.yaml"
 
 # Fleet mode (#267): scan this project for agent.talon.yaml files (finds the


### PR DESCRIPTION
Closes #337. Closes #341.

## What

### Guide corrections (#337)

1. **"This creates three files" → four** in all three guides ([claude-code-integration.md](docs/guides/claude-code-integration.md), [codex-cli-integration.md](docs/guides/codex-cli-integration.md), [governing-coding-agents.md](docs/guides/governing-coding-agents.md)) — `talon init --pack coding-agents` also writes `pricing/models.yaml`, verified by live run.
2. **Stale #235 claim removed** — the codex guide said the pack wizard's printed next-steps omit the trailing `/v1`; the wizard has printed the `/v1`-suffixed base URL (with an explanatory note) since the fix. Verified against live `talon init --pack coding-agents` output.
3. **Single-file pricing resolution documented** (the issue's "decide" point, resolved as *document*): in the codex single-file flow, the relative `pricing_file` resolves against the policy file's directory, so edits to `./pricing/models.yaml` are silently ignored (`pricing file not found; using embedded default pricing` in the serve log). The guide now spells out the three ways to make edits take effect (fleet mode `agents_dir: "."` — resolves from project root; absolute `llm.pricing_file`; table next to the active policy). The same caveat is now a comment in the pack's `talon.config.yaml` template, where operators actually see it.

**Why document rather than change the product:** `cliPricingBaseDir` (#267 review) deliberately preserves the pre-fleet contract — "pricing next to the policy file" — for single-file mode, and the claude-code root-policy flow depends on it (policy at project root ⇒ pricing resolves correctly there). Changing resolution semantics in a trust-fix patch release would trade one surprise for another; the fleet path already has the root-resolution behavior.

### `talon init` output (#341)

The hardcoded "Created files" list omitted every pack-declared file. Now packs with declared `Files` print their real list:

```
Created files:
  - agent.talon.yaml               (Agent policy (claude-code, primary; credential recognizers))
  - agents/codex/agent.talon.yaml  (Agent policy (codex))
  - talon.config.yaml              (Gateway config (organization baseline + providers))
  - pricing/models.yaml            (LLM cost estimation table)
```

crewai now correctly lists both role agents too. Legacy packs without `Files` keep the previous output. Pinned by `TestInitPack_CreatedFilesListMatchesPackFiles`.

## Verification
- Live `talon init --pack coding-agents` and `--pack crewai` runs show the corrected lists (above).
- `go test ./internal/cmd ./internal/pack` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)