### PR TITLE
fix(pack): remove dead config keys from pack templates; pin generated configs to consumed keys (#342)

### DIFF
--- a/internal/cmd/init_pack_test.go
+++ b/internal/cmd/init_pack_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/dativo-io/talon/internal/agentcatalog"
+	"github.com/dativo-io/talon/internal/config"
 	"github.com/dativo-io/talon/internal/policy"
 	"github.com/dativo-io/talon/internal/pricing"
 )
@@ -58,6 +59,58 @@ func TestInitPack_CrewAI_GeneratesFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(configContent), "organization_policy")
 	assert.NotContains(t, string(configContent), "tenant_key", "legacy identity must not scaffold")
+}
+
+// TestInitPack_GeneratedConfigKeysAreConsumed pins #342: every top-level key
+// in a generated talon.config.yaml must be read by one of the two real
+// loaders — viper (internal/config Key* constants + block loaders +
+// internal/cmd/root.go log bindings) or the gateway loader
+// (internal/gateway/config.go LoadGatewayConfig "gateway" subtree). A key
+// outside this set is dead config: it silently does nothing while looking
+// authoritative (the shipped templates once carried evidence.path,
+// secrets_key_env, tenants, llm_provider — all unread).
+func TestInitPack_GeneratedConfigKeysAreConsumed(t *testing.T) {
+	consumed := map[string]bool{
+		// viper scalar keys (internal/config/config.go)
+		config.KeyDataDir: true, config.KeySecretsKey: true, config.KeySigningKey: true,
+		config.KeyDefaultPolicy: true, config.KeyAgentsDir: true, config.KeyAgentsReloadEvery: true,
+		config.KeyOrphanRetentionDays: true, config.KeyMaxAttachmentMB: true,
+		config.KeyOllamaBaseURL: true, config.KeyOllamaMaxNumPredict: true,
+		// viper-bound logging flags (internal/cmd/root.go BindPFlag)
+		"log_level": true, "log_format": true,
+		// viper block loaders (internal/config/config.go loadLLMConfig,
+		// loadCacheConfig, loadComplianceConfig, loadSovereigntyConfig,
+		// loadScannerConfig)
+		"llm": true, "cache": true, "compliance": true, "sovereignty": true, "scanner": true,
+		// gateway loader subtree (internal/gateway/config.go LoadGatewayConfig)
+		"gateway": true,
+	}
+
+	// One pack per template source: generic (base tmpl), coding-agents and
+	// crewai (internal/pack/templates), copaw and openclaw (legacy
+	// pack_<id>.config.yaml.tmpl).
+	for _, packID := range []string{"generic", "coding-agents", "crewai", "copaw", "openclaw"} {
+		t.Run(packID, func(t *testing.T) {
+			dir := t.TempDir()
+			prevWd, err := os.Getwd()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.Chdir(prevWd) })
+			require.NoError(t, os.Chdir(dir))
+
+			rootCmd.SetArgs([]string{"init", "--pack", packID, "--skip-verify"})
+			require.NoError(t, rootCmd.Execute())
+
+			raw, err := os.ReadFile(filepath.Join(dir, "talon.config.yaml"))
+			require.NoError(t, err)
+			var doc map[string]any
+			require.NoError(t, yaml.Unmarshal(raw, &doc))
+			require.NotEmpty(t, doc)
+			for key := range doc {
+				assert.True(t, consumed[key],
+					"pack %q writes talon.config.yaml key %q that no loader reads — dead config (#342)", packID, key)
+			}
+		})
+	}
 }
 
 // TestInitPack_CreatedFilesListMatchesPackFiles pins #341: the printed

--- a/internal/pack/templates/coding-agents/talon.config.yaml
+++ b/internal/pack/templates/coding-agents/talon.config.yaml
@@ -32,23 +32,16 @@ llm:
 # agent with its own key, policy, and routing.
 # agents_dir: "."
 
-llm_provider: anthropic
 log_level: info
 log_format: console
 
-evidence:
-  type: sqlite
-  path: ~/.talon/evidence.db
-
-secrets_key_env: TALON_SECRETS_KEY
-
-tenants:
-  - id: default
-    display_name: Default Tenant
-    budgets:
-      daily: 100.0
-      monthly: 2000.0
-    rate_limit: 240
+# State location (#342): every stateful path (evidence.db, secrets.db,
+# memory.db) derives from data_dir — default ~/.talon. There is no separate
+# evidence path/type key, and the vault key comes from the TALON_SECRETS_KEY
+# env var (or a secrets_key entry here). Tenancy, budgets, and rate limits
+# are NOT configured in this file: they derive from each agent.talon.yaml
+# (key -> agent -> tenant, #266) and gateway.organization_policy below.
+# data_dir: ~/.talon
 
 gateway:
   enabled: true

--- a/internal/pack/templates/crewai/talon.config.yaml
+++ b/internal/pack/templates/crewai/talon.config.yaml
@@ -16,13 +16,8 @@ llm:
 # and routing.
 # agents_dir: "."
 
-llm_provider: openai
 log_level: info
 log_format: console
-
-evidence:
-  type: sqlite
-  path: ~/.talon/evidence.db
 
 cache:
   enabled: false
@@ -30,15 +25,13 @@ cache:
   similarity_threshold: 0.92
   max_entries_per_tenant: 10000
 
-secrets_key_env: TALON_SECRETS_KEY
-
-tenants:
-  - id: default
-    display_name: Default Tenant
-    budgets:
-      daily: 100.0
-      monthly: 2000.0
-    rate_limit: 120
+# State location (#342): every stateful path (evidence.db, secrets.db,
+# memory.db) derives from data_dir — default ~/.talon. There is no separate
+# evidence path/type key, and the vault key comes from the TALON_SECRETS_KEY
+# env var (or a secrets_key entry here). Tenancy, budgets, and rate limits
+# are NOT configured in this file: they derive from each agent.talon.yaml
+# (key -> agent -> tenant, #266) and gateway.organization_policy below.
+# data_dir: ~/.talon
 
 gateway:
   enabled: true


### PR DESCRIPTION
Closes #342.

## What

The coding-agents and crewai `talon.config.yaml` templates shipped four keys **nothing reads**: `llm_provider`, `evidence.type/path`, `secrets_key_env`, and a full `tenants:` block with budgets and rate limits. The `evidence.path` and `tenants` blocks were actively misleading — state location derives solely from `data_dir` (`Config.EvidenceDBPath`), and tenancy/budgets derive from each `agent.talon.yaml` (#266) plus `gateway.organization_policy`.

Both templates now state exactly that where the dead keys used to be, with a commented `data_dir:` as the real surface.

## How the scope was established

A 17-agent audit workflow classified **every** top-level key in all five config-bearing templates (the two pack templates + the three legacy `internal/cmd/templates/init` config `.tmpl`s) against both real loaders — viper (`internal/config` `Key*` constants, block loaders, `root.go` log bindings) and the gateway subtree loader (`internal/gateway/config.go`). Every dead and live classification was then adversarially re-verified by independent agents. Result: unanimous — the legacy `.tmpl` files are fully live; the rot was confined to the two new-style pack templates. Two useful nuances surfaced:

- Both templates carry an explicit `gateway:` block, which is exactly what kept the dead root keys inert (the whole-file-as-GatewayConfig fallback never ran).
- `secrets_key_env: TALON_SECRETS_KEY` was a perfect decoy: its *value* names the env var viper already reads, so the config appeared to work while the key itself did nothing.

## Regression pin

`TestInitPack_GeneratedConfigKeysAreConsumed` runs `talon init` for one pack per template source (generic, coding-agents, crewai, copaw, openclaw) and asserts every top-level key of the **generated** `talon.config.yaml` is in the consumed-key set (built from `config.Key*` constants + block-loader and gateway keys). Dead-key drift now fails CI, not the operator. Root-cause guard for operator-authored configs is filed separately as #351 (`talon doctor` unknown-key warning).

## Verification

- `go test ./internal/cmd ./internal/pack ./internal/config` — pass.
- Both pack inits produce configs whose every top-level key has a named reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)