### PR TITLE
fix(mcp): proxy fail-closed mode + truthful evidence attribution (#346, #350)

### DIFF
--- a/docs/ARCHITECTURE_MCP_PROXY.md
+++ b/docs/ARCHITECTURE_MCP_PROXY.md
@@ -162,8 +162,10 @@ proxy:
 
 **Behavior:**
 - Talon logs calls but doesn't block — even explicitly forbidden tools are
-  forwarded (with a `proxy_tool_blocked` evidence record noting the match)
-- Policy and PII violations recorded in evidence, request forwarded
+  forwarded, recorded honestly as `proxy_shadow_violation` evidence
+  (`ObservationModeOverride: true` + a `ShadowViolations` entry saying what
+  enforce mode would have done), never as a fake "blocked" record
+- Policy and PII violations recorded the same way, request forwarded
 - Full evidence trail generated
 
 **Flow:**
@@ -199,6 +201,12 @@ traffic before flipping to intercept.
 
 **All modes:** a PII-scanner failure blocks the call fail-closed regardless of
 mode — arguments Talon cannot classify must not reach the upstream tool.
+
+**Mode is fail-closed at every layer (#346):** `mode` defaults to `intercept`
+when unset and both loaders reject values outside
+`intercept | passthrough | shadow` at startup; the handler itself forwards a
+forbidden tool only under explicit `passthrough`. An unset or mistyped mode
+can never silently behave as passthrough.
 
 ---
 
@@ -641,6 +649,35 @@ Both the MCP proxy and the LLM API gateway now scan **responses** from upstream 
 ### `tools/list` filtering
 
 When a vendor calls `tools/list` via the MCP proxy, Talon filters the response so the caller only sees tools listed in `allowed_tools`. Forbidden tools and unlisted tools are stripped from the response before it reaches the vendor. This reduces the attack surface — agents cannot discover or attempt to call tools they are not authorized to use.
+
+### Evidence attribution (#350)
+
+Every proxy evidence record attributes to the real caller, resolved once at
+the HTTP boundary and reused across all records of one call:
+
+- **Agent**: the authenticated agent from the key middleware
+  (`agent_id: coding-assistant` when the request presented that agent's key);
+  on the admin-key and dev-open paths, which carry no agent identity, records
+  attribute to the proxy config's own `agent.name`. The tenant derives the
+  same way (key → agent → tenant, #266).
+- **Session**: a caller-supplied `X-Talon-Session-ID` lands in the record's
+  `session_id`, so MCP tool calls join the same session's LLM gateway
+  traffic. Client-asserted — **attribution, not authentication**; never a
+  policy input. No session is synthesized when none is asserted.
+- **Correlation**: an inbound `X-Correlation-ID` is preserved; otherwise one
+  request-scoped ID is generated and shared by every record of that call
+  (intent and result records are joinable). Both resolved identifiers are
+  echoed on the response headers.
+- **Header hygiene**: the same contract as the gateway (128-byte cap, RFC
+  7230 token charset, reject — never truncate; shared implementation in
+  `internal/evidence`): an invalid attribution header is an HTTP 400 before
+  any evidence is written. The `X-Talon-Agent-ID` / `X-Talon-Parent-Agent-ID`
+  / `X-Talon-Client` identity headers populate the record's `orchestration`
+  block exactly as on the gateway. Vendor header adapters (Claude Code,
+  Codex) are an LLM-wire concern and are not consulted on the MCP wire.
+- **Denied tool calls** carry the deterministic `POLICY_DENIED_TOOL`
+  explanation code alongside the native trigger (`forbidden_tools`, Rego
+  reasons) for debugging.
 
 ---
 

--- a/internal/evidence/orchvalue.go
+++ b/internal/evidence/orchvalue.go
@@ -1,0 +1,38 @@
+package evidence
+
+import "fmt"
+
+// OrchHeaderMaxLen caps client-asserted attribution header values
+// (X-Talon-Session-ID and friends).
+const OrchHeaderMaxLen = 128
+
+// ValidateOrchValue enforces header hygiene for client-asserted attribution
+// values: length-capped and restricted to the RFC 7230 token charset, and
+// rejected — never truncated — on violation. This blocks header/HTML
+// injection at ingestion so hostile client-asserted strings never reach
+// signed evidence or operator dashboards. Shared by the LLM gateway
+// (orchestration metadata) and the MCP proxy (#350) so the two ingestion
+// surfaces cannot diverge.
+func ValidateOrchValue(name, v string) (string, error) {
+	if v == "" {
+		return "", nil
+	}
+	if len(v) > OrchHeaderMaxLen {
+		return "", fmt.Errorf("orchestration header %s exceeds %d bytes", name, OrchHeaderMaxLen)
+	}
+	for i := 0; i < len(v); i++ {
+		if !isOrchTokenChar(v[i]) {
+			return "", fmt.Errorf("orchestration header %s contains a disallowed character", name)
+		}
+	}
+	return v, nil
+}
+
+// isOrchTokenChar reports whether c is an RFC 7230 tchar (the HTTP token charset).
+func isOrchTokenChar(c byte) bool {
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}

--- a/internal/evidence/record_class.go
+++ b/internal/evidence/record_class.go
@@ -47,6 +47,12 @@ var nonRequestClass = map[string]RecordClass{
 	"llm_failover_decision":    ClassProviderAttempt,
 	"gateway_count_tokens":     ClassProviderAttempt,
 
+	// Per-request would-deny sub-record of one proxied MCP call (#346): a
+	// shadow/passthrough violation is always followed by the call's terminal
+	// record (proxy_tool_call or a block), so counting it as a request would
+	// multiply one call into several.
+	"proxy_shadow_violation": ClassProviderAttempt,
+
 	// Operator / control-plane actions.
 	"agent_enabled":        ClassOperatorEvent,
 	"agent_disabled":       ClassOperatorEvent,

--- a/internal/gateway/orchmeta.go
+++ b/internal/gateway/orchmeta.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/dativo-io/talon/internal/evidence"
@@ -62,34 +61,14 @@ var vendorAdapters = []vendorAdapter{
 	},
 }
 
-const orchHeaderMaxLen = 128
+const orchHeaderMaxLen = evidence.OrchHeaderMaxLen
 
 // validateOrchValue enforces header hygiene: values are length-capped and
 // restricted to the RFC 7230 token charset, and rejected — never truncated —
-// on violation. This blocks header/HTML injection at ingestion so hostile
-// client-asserted strings never reach signed evidence or operator dashboards.
+// on violation. The shared implementation lives in internal/evidence so the
+// gateway and the MCP proxy (#350) cannot diverge on ingestion hygiene.
 func validateOrchValue(name, v string) (string, error) {
-	if v == "" {
-		return "", nil
-	}
-	if len(v) > orchHeaderMaxLen {
-		return "", fmt.Errorf("orchestration header %s exceeds %d bytes", name, orchHeaderMaxLen)
-	}
-	for i := 0; i < len(v); i++ {
-		if !isTokenChar(v[i]) {
-			return "", fmt.Errorf("orchestration header %s contains a disallowed character", name)
-		}
-	}
-	return v, nil
-}
-
-// isTokenChar reports whether c is an RFC 7230 tchar (the HTTP token charset).
-func isTokenChar(c byte) bool {
-	switch c {
-	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
-		return true
-	}
-	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+	return evidence.ValidateOrchValue(name, v)
 }
 
 // orchHeaders is the validated raw header set from one request.

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -46,6 +46,12 @@ func NewProxyHandler(
 	evidenceStore *evidence.Store,
 	cls classifier.Facade,
 ) *ProxyHandler {
+	// Defense in depth for #346: the loaders default/validate mode, but a
+	// handler constructed directly (tests, future callers) must never run
+	// with an empty mode — empty used to fail open as passthrough.
+	if cfg != nil && cfg.Proxy.Mode == "" {
+		cfg.Proxy.Mode = policy.ProxyModeIntercept
+	}
 	timeout := 30 * time.Second
 	return &ProxyHandler{
 		config:        cfg,
@@ -55,6 +61,101 @@ func NewProxyHandler(
 		httpClient:    &http.Client{Timeout: timeout},
 		runtime:       DefaultProxyRuntime(),
 	}
+}
+
+// proxyInvocation carries request-scoped attribution for evidence (#350):
+// resolved once at the HTTP boundary and reused by every record the call
+// produces, so tenant, agent, session, and correlation stay consistent
+// across the intent/result records of one MCP call and joinable with the
+// same use case's LLM gateway traffic.
+type proxyInvocation struct {
+	tenantID string
+	// agentID is the authenticated agent from the key middleware when
+	// present; otherwise the proxy config's agent name; "mcp-proxy" only as
+	// the final legacy fallback (admin/dev-open paths with an unnamed config).
+	agentID string
+	team    string
+	// sessionID is the validated X-Talon-Session-ID ("" when not asserted).
+	// Client-asserted: attribution, not authentication — never a policy input.
+	sessionID string
+	// correlationID is the validated inbound X-Correlation-ID, or one
+	// generated ID reused across all records of this request.
+	correlationID string
+	orch          *evidence.OrchestrationContext
+}
+
+// resolveProxyInvocation builds the invocation context from the authenticated
+// request context and the neutral X-Talon-* attribution headers. Header
+// values follow the same hygiene contract as the gateway (128-byte cap, RFC
+// 7230 token charset, reject — never truncate): an error here must become an
+// HTTP 400 before any evidence is written. Vendor header adapters are an LLM
+// wire concern and deliberately not consulted on the MCP wire.
+func (h *ProxyHandler) resolveProxyInvocation(r *http.Request) (*proxyInvocation, error) {
+	ctx := r.Context()
+	inv := &proxyInvocation{}
+
+	inv.tenantID = requestctx.TenantID(ctx)
+	if inv.tenantID == "" {
+		inv.tenantID = "default"
+	}
+	if id, ok := requestctx.AgentIdentityFrom(ctx); ok {
+		inv.agentID = id.AgentID
+		inv.team = id.Team
+	} else if h.config != nil && h.config.Agent.Name != "" {
+		// Admin-key and dev-open paths carry no agent identity: attribute to
+		// the proxy's own declared agent identity from the config.
+		inv.agentID = h.config.Agent.Name
+	} else {
+		inv.agentID = "mcp-proxy"
+	}
+
+	sessionID, err := evidence.ValidateOrchValue("X-Talon-Session-ID", r.Header.Get("X-Talon-Session-ID"))
+	if err != nil {
+		return nil, err
+	}
+	subagent, err := evidence.ValidateOrchValue("X-Talon-Agent-ID", r.Header.Get("X-Talon-Agent-ID"))
+	if err != nil {
+		return nil, err
+	}
+	parent, err := evidence.ValidateOrchValue("X-Talon-Parent-Agent-ID", r.Header.Get("X-Talon-Parent-Agent-ID"))
+	if err != nil {
+		return nil, err
+	}
+	client, err := evidence.ValidateOrchValue("X-Talon-Client", r.Header.Get("X-Talon-Client"))
+	if err != nil {
+		return nil, err
+	}
+	correlationID, err := evidence.ValidateOrchValue("X-Correlation-ID", r.Header.Get("X-Correlation-ID"))
+	if err != nil {
+		return nil, err
+	}
+	if correlationID == "" {
+		correlationID = "mcp_proxy_" + uuid.New().String()[:8]
+	}
+	inv.sessionID = sessionID
+	inv.correlationID = correlationID
+
+	// Same emission rule as the gateway: a bare session id fills the
+	// session_id column only; the orchestration block exists when the client
+	// asserted identity beyond the session.
+	if subagent != "" || parent != "" || client != "" {
+		if client == "" {
+			client = "generic"
+		}
+		sessionSource := ""
+		if sessionID != "" {
+			sessionSource = "client_asserted"
+		}
+		inv.orch = &evidence.OrchestrationContext{
+			SessionID:     sessionID,
+			AgentID:       subagent,
+			ParentAgentID: parent,
+			Client:        client,
+			SessionSource: sessionSource,
+			Provenance:    "client_asserted",
+		}
+	}
+	return inv, nil
 }
 
 // SetRuntime overrides timeout and auth for upstream calls.
@@ -89,19 +190,34 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tenantID := requestctx.TenantID(ctx)
-	if tenantID == "" {
-		tenantID = "default"
+	// Attribution is resolved once per request (#350). Header hygiene
+	// violations are rejected before any evidence is written, mirroring the
+	// gateway contract (reject, never truncate).
+	inv, err := h.resolveProxyInvocation(r)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(&jsonrpcResponse{
+			JSONRPC: jsonrpcVersion, ID: req.ID,
+			Error: &rpcError{Code: codeInvalidRequest, Message: "invalid attribution header: " + err.Error()},
+		})
+		return
+	}
+	// Echo the resolved identifiers so callers can join their receipts to
+	// the audit trail.
+	w.Header().Set("X-Correlation-ID", inv.correlationID)
+	if inv.sessionID != "" {
+		w.Header().Set("X-Talon-Session-ID", inv.sessionID)
 	}
 
 	var resp *jsonrpcResponse
 	switch req.Method {
 	case "tools/list":
-		resp = h.handleToolsList(ctx, body, tenantID, &req)
+		resp = h.handleToolsList(ctx, body, inv, &req)
 	case "tools/call":
-		resp = h.handleProxyToolCall(ctx, &req, tenantID)
+		resp = h.handleProxyToolCall(ctx, &req, inv)
 	default:
-		resp = h.forwardRequest(ctx, body, tenantID, &req)
+		resp = h.forwardRequest(ctx, body, &req)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -110,7 +226,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 //nolint:gocyclo // proxy flow: forbidden, policy, PII, forward, evidence
-func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequest, tenantID string) *jsonrpcResponse {
+func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequest, inv *proxyInvocation) *jsonrpcResponse {
 	ctx, span := proxyTracer.Start(ctx, "mcp.proxy.tools.call")
 	defer span.End()
 
@@ -134,18 +250,23 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		}
 	}
 
-	// Forbidden check: explicitly forbidden tools are never forwarded in intercept or shadow.
-	// intercept = block; shadow = audit then block; passthrough = log only then forward.
+	// Forbidden check (#346, fail-closed): explicitly forbidden tools are
+	// forwarded ONLY under explicit passthrough mode — intercept, shadow, and
+	// any unexpected mode value block. Evidence must say what actually
+	// happened: a block records proxy_tool_blocked; a passthrough forward
+	// records a shadow violation on an allowed record, never a fake "blocked".
 	for _, f := range h.config.Proxy.ForbiddenTools {
 		if f == toolName || (strings.HasSuffix(f, "*") && strings.HasPrefix(toolName, strings.TrimSuffix(f, "*"))) {
-			h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, "forbidden_tools", nil)
 			span.SetAttributes(attribute.String("proxy.blocked", "forbidden"))
-			switch h.config.Proxy.Mode {
-			case "intercept", "shadow":
-				// Block: intercept always; shadow audits then blocks (never forward forbidden tools).
+			if h.config.Proxy.Mode != policy.ProxyModePassthrough {
+				h.recordEvidence(ctx, inv, "proxy_tool_blocked", toolName, "forbidden_tools", nil, nil)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "tool not allowed by policy"}}
 			}
-			// passthrough: evidence recorded, fall through to forward
+			h.recordEvidence(ctx, inv, "proxy_shadow_violation", toolName, "forbidden_tools", nil, &evidence.ShadowViolation{
+				Type:   "tool_block",
+				Detail: "forbidden tool " + toolName + " forwarded in passthrough mode",
+				Action: "block",
+			})
 			break
 		}
 	}
@@ -162,9 +283,20 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		span.RecordError(err)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
 	}
-	if !decision.Allowed && h.config.Proxy.Mode == "intercept" {
-		h.recordEvidence(ctx, tenantID, "proxy_tool_blocked", toolName, nil, strings.Join(decision.Reasons, "; "), nil)
-		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: strings.Join(decision.Reasons, "; ")}}
+	if !decision.Allowed {
+		denyReason := strings.Join(decision.Reasons, "; ")
+		if h.config.Proxy.Mode == policy.ProxyModeIntercept {
+			h.recordEvidence(ctx, inv, "proxy_tool_blocked", toolName, denyReason, nil, nil)
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: denyReason}}
+		}
+		// shadow/passthrough (#346): the deny is recorded as a would-have-
+		// denied shadow violation — previously these modes produced no
+		// evidence of the deny at all.
+		h.recordEvidence(ctx, inv, "proxy_shadow_violation", toolName, denyReason, nil, &evidence.ShadowViolation{
+			Type:   "policy_deny",
+			Detail: denyReason,
+			Action: "block",
+		})
 	}
 
 	// PII scan on arguments. A scanner failure blocks the call fail-closed:
@@ -176,7 +308,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		if scanErr != nil {
 			flow.requestBlocked = true
 			flow.scannerFailure = scannerFailureKind(scanErr)
-			h.recordEvidence(ctx, tenantID, "proxy_pii_scan_error", toolName, nil, "scanner_unavailable", &flow)
+			h.recordEvidence(ctx, inv, "proxy_pii_scan_error", toolName, "scanner_unavailable", &flow, nil)
 			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII scanner unavailable (fail-closed)"}}
 		}
 		if result != nil && len(result.Entities) > 0 {
@@ -187,21 +319,39 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				proxyInput.DetectedPII = append(proxyInput.DetectedPII, e.Type)
 			}
 			piiDecision, piiErr := h.proxyEngine.EvaluateProxyPII(ctx, proxyInput)
-			if piiErr != nil && h.config.Proxy.Mode == "intercept" {
-				flow.requestBlocked = true
-				h.recordEvidence(ctx, tenantID, "proxy_pii_eval_error", toolName, nil, piiErr.Error(), &flow)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII policy evaluation failed (fail-closed)"}}
+			if piiErr != nil {
+				if h.config.Proxy.Mode == policy.ProxyModeIntercept {
+					flow.requestBlocked = true
+					h.recordEvidence(ctx, inv, "proxy_pii_eval_error", toolName, piiErr.Error(), &flow, nil)
+					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII policy evaluation failed (fail-closed)"}}
+				}
+				// shadow/passthrough (#346): enforce mode would block
+				// fail-closed on an eval error — record it, then continue.
+				h.recordEvidence(ctx, inv, "proxy_shadow_violation", toolName, "pii_eval_error: "+piiErr.Error(), &flow, &evidence.ShadowViolation{
+					Type:   "pii_block",
+					Detail: "PII policy evaluation failed: " + piiErr.Error(),
+					Action: "block",
+				})
 			}
-			if piiDecision != nil && !piiDecision.Allowed && h.config.Proxy.Mode == "intercept" {
-				flow.requestBlocked = true
-				h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "pii_detected_in_request", &flow)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII detected in request"}}
+			if piiDecision != nil && !piiDecision.Allowed {
+				if h.config.Proxy.Mode == policy.ProxyModeIntercept {
+					flow.requestBlocked = true
+					h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "pii_detected_in_request", &flow, nil)
+					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII detected in request"}}
+				}
+				// shadow/passthrough (#346): record the would-have-denied PII
+				// decision, then continue to redaction as before.
+				h.recordEvidence(ctx, inv, "proxy_shadow_violation", toolName, "pii_detected_in_request", &flow, &evidence.ShadowViolation{
+					Type:   "pii_block",
+					Detail: "PII detected in request: " + strings.Join(proxyInput.DetectedPII, ", "),
+					Action: "block",
+				})
 			}
 			redactedArgs, redactErr := h.classifier.RedactText(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), argStr)
 			if redactErr != nil {
 				flow.requestBlocked = true
 				flow.scannerFailure = scannerFailureKind(redactErr)
-				h.recordEvidence(ctx, tenantID, "proxy_pii_scan_error", toolName, nil, "scanner_unavailable", &flow)
+				h.recordEvidence(ctx, inv, "proxy_pii_scan_error", toolName, "scanner_unavailable", &flow, nil)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII redaction failed (fail-closed)"}}
 			}
 			if verifyErr := h.classifier.VerifyEgress(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), redactedArgs); verifyErr != nil {
@@ -213,7 +363,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 					msg = "Request blocked: redaction could not be verified (fail-closed)"
 					flow.scannerFailure = scannerFailureKind(verifyErr)
 				}
-				h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, reason, &flow)
+				h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, reason, &flow, nil)
 				return &jsonrpcResponse{
 					JSONRPC: jsonrpcVersion,
 					ID:      req.ID,
@@ -226,14 +376,14 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			if redactedArgs != argStr {
 				if !json.Valid([]byte(redactedArgs)) {
 					flow.requestBlocked = true
-					h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "request_redaction_invalid_json", &flow)
+					h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "request_redaction_invalid_json", &flow, nil)
 					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction produced invalid JSON (fail-closed)"}}
 				}
 				params.Arguments = json.RawMessage(redactedArgs)
 				proxyInput.Arguments = paramsToMap(params.Arguments)
 				flow.requestRedacted = true
 			}
-			h.recordEvidence(ctx, tenantID, "proxy_pii_request_detected", toolName, nil, "", &flow)
+			h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "", &flow, nil)
 		}
 	}
 
@@ -266,7 +416,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		if scanErr != nil {
 			flow.responseBlocked = true
 			flow.scannerFailure = scannerFailureKind(scanErr)
-			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_scanner_unavailable", &flow)
+			h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_scanner_unavailable", &flow, nil)
 			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII scanner unavailable (fail-closed)"}}
 		}
 		if cls != nil && cls.HasPII {
@@ -287,7 +437,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			if redactErr != nil {
 				flow.responseBlocked = true
 				flow.scannerFailure = scannerFailureKind(redactErr)
-				h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_scanner_unavailable", &flow)
+				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_scanner_unavailable", &flow, nil)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII redaction failed (fail-closed)"}}
 			}
 			if verifyErr := h.classifier.VerifyEgress(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), redacted); verifyErr != nil {
@@ -299,7 +449,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 					msg = "Tool result blocked: redaction could not be verified (fail-closed)"
 					flow.scannerFailure = scannerFailureKind(verifyErr)
 				}
-				h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, reason, &flow)
+				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, reason, &flow, nil)
 				return &jsonrpcResponse{
 					JSONRPC: jsonrpcVersion,
 					ID:      req.ID,
@@ -312,16 +462,16 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			var redactedResult interface{}
 			if err := json.Unmarshal([]byte(redacted), &redactedResult); err != nil {
 				flow.responseBlocked = true
-				h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_redaction_invalid_json", &flow)
+				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_redaction_invalid_json", &flow, nil)
 				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction of tool result produced invalid JSON (fail-closed)"}}
 			}
 			out.Result = redactedResult
-			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "output_pii_redacted", &flow)
+			h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_pii_redacted", &flow, nil)
 		} else {
-			h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "", &flow)
+			h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "", &flow, nil)
 		}
 	} else {
-		h.recordEvidence(ctx, tenantID, "proxy_tool_call", toolName, nil, "", &flow)
+		h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "", &flow, nil)
 	}
 
 	return &out
@@ -438,11 +588,11 @@ func toolNameFromRaw(raw json.RawMessage) string {
 // It supports multiple upstream result shapes (object with "tools", array at top,
 // or other common keys) and preserves the response shape. If the result shape
 // is unrecognizable, it returns an empty tool list to avoid leaking unfiltered data.
-func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, tenantID string, req *jsonrpcRequest) *jsonrpcResponse {
+func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, _ *proxyInvocation, req *jsonrpcRequest) *jsonrpcResponse {
 	ctx, span := proxyTracer.Start(ctx, "mcp.proxy.tools.list")
 	defer span.End()
 
-	resp := h.forwardRequest(ctx, body, tenantID, req)
+	resp := h.forwardRequest(ctx, body, req)
 	if resp == nil || resp.Error != nil || resp.Result == nil {
 		return resp
 	}
@@ -503,7 +653,7 @@ func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, tenantI
 	return resp
 }
 
-func (h *ProxyHandler) forwardRequest(ctx context.Context, body []byte, tenantID string, req *jsonrpcRequest) *jsonrpcResponse {
+func (h *ProxyHandler) forwardRequest(ctx context.Context, body []byte, req *jsonrpcRequest) *jsonrpcResponse {
 	upstreamResp, err := h.doUpstreamRequest(ctx, body)
 	if err != nil {
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
@@ -579,15 +729,20 @@ func (h *ProxyHandler) upstreamEndpointHost() string {
 	return u.Host
 }
 
-func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, toolName string, result []byte, reason string, flow *proxyFlowState) {
+func (h *ProxyHandler) recordEvidence(ctx context.Context, inv *proxyInvocation, eventType, toolName, reason string, flow *proxyFlowState, sv *evidence.ShadowViolation) {
 	if h.evidenceStore == nil {
 		return
 	}
 	// Allowed must reflect what actually happened, not the event label: the
 	// output fail-closed branches (scanner unavailable, residual PII, invalid
 	// redaction JSON) record eventType proxy_tool_call with a blocked flow,
-	// and evidence must say denied for those.
-	allowed := eventType == "proxy_tool_call" || (eventType == "proxy_pii_request_detected" && reason == "")
+	// and evidence must say denied for those. A shadow violation is an
+	// ALLOWED record — the call was forwarded — with the would-have-denied
+	// verdict carried in ShadowViolations + ObservationModeOverride (#346),
+	// matching the gateway's shadow-mode vocabulary.
+	allowed := eventType == "proxy_tool_call" ||
+		eventType == "proxy_shadow_violation" ||
+		(eventType == "proxy_pii_request_detected" && reason == "")
 	if flow != nil && (flow.requestBlocked || flow.responseBlocked) {
 		allowed = false
 	}
@@ -599,13 +754,14 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, 
 	if reason != "" {
 		reasons = []string{reason}
 	}
-	correlationID := "mcp_proxy_" + uuid.New().String()[:8]
 	ev := &evidence.Evidence{
 		ID:              "proxy_" + uuid.New().String()[:8],
-		CorrelationID:   correlationID,
+		CorrelationID:   inv.correlationID,
+		SessionID:       inv.sessionID,
 		Timestamp:       time.Now(),
-		TenantID:        tenantID,
-		AgentID:         "mcp-proxy",
+		TenantID:        inv.tenantID,
+		AgentID:         inv.agentID,
+		Team:            inv.team,
 		InvocationType:  eventType,
 		RequestSourceID: h.config.Proxy.Upstream.Vendor,
 		PolicyDecision:  evidence.PolicyDecision{Allowed: allowed, Action: action, Reasons: reasons},
@@ -613,6 +769,11 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, 
 			ToolsCalled: []string{toolName},
 			Error:       reason,
 		},
+		Orchestration: inv.orch,
+	}
+	if sv != nil {
+		ev.ObservationModeOverride = true
+		ev.ShadowViolations = []evidence.ShadowViolation{*sv}
 	}
 	if flow != nil {
 		ev.Classification = evidence.Classification{
@@ -623,12 +784,12 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, tenantID, eventType, 
 			OutputPIITypes:    entityTypeSet(flow.responseEntities),
 			PIIRedacted:       flow.responseRedacted,
 		}
-		ev.DataFlow = h.buildProxyDataFlow(tenantID, correlationID, toolName, flow)
+		ev.DataFlow = h.buildProxyDataFlow(inv.tenantID, inv.correlationID, toolName, flow)
 		if ev.DataFlow != nil {
 			log.Info().
-				Str("correlation_id", correlationID).
-				Str("tenant_id", tenantID).
-				Str("agent_id", "mcp-proxy").
+				Str("correlation_id", inv.correlationID).
+				Str("tenant_id", inv.tenantID).
+				Str("agent_id", inv.agentID).
 				Str("flow_destination", evidence.FlowDestMCPTool+":"+h.config.Proxy.Upstream.Vendor).
 				Str("flow_region", h.upstreamRegion()).
 				Int("flow_items", len(ev.DataFlow.Items)).
@@ -726,6 +887,18 @@ func proxyExplanationFacts(eventType, reason, toolName string, allowed bool) []e
 			Decision: explanation.DecisionDeny,
 			Stage:    explanation.StageToolExecution,
 			Trigger:  trigger,
+		}}
+	case "proxy_shadow_violation":
+		// The call was forwarded (allowed); the would-have-denied verdict
+		// lives in ShadowViolations. Gateway precedent: shadow evidence
+		// explains as allowed, with the trigger naming what enforce would
+		// have denied.
+		return []explanation.Fact{{
+			Code:     explanation.CodePolicyAllowed,
+			Decision: explanation.DecisionAllow,
+			Stage:    explanation.StageToolExecution,
+			Trigger:  trigger,
+			Fix:      "Observation mode forwarded a call enforce mode would deny; set proxy.mode: intercept to enforce.",
 		}}
 	case "proxy_pii_eval_error":
 		return []explanation.Fact{{

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -48,9 +48,15 @@ func NewProxyHandler(
 ) *ProxyHandler {
 	// Defense in depth for #346: the loaders default/validate mode, but a
 	// handler constructed directly (tests, future callers) must never run
-	// with an empty mode — empty used to fail open as passthrough.
-	if cfg != nil && cfg.Proxy.Mode == "" {
-		cfg.Proxy.Mode = policy.ProxyModeIntercept
+	// with an empty OR unknown mode — empty used to fail open as passthrough,
+	// and an unrecognized value must get the strictest semantics, not
+	// shadow's forward-with-record.
+	if cfg != nil {
+		switch cfg.Proxy.Mode {
+		case policy.ProxyModeIntercept, policy.ProxyModePassthrough, policy.ProxyModeShadow:
+		default:
+			cfg.Proxy.Mode = policy.ProxyModeIntercept
+		}
 	}
 	timeout := 30 * time.Second
 	return &ProxyHandler{
@@ -767,9 +773,16 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, inv *proxyInvocation,
 		PolicyDecision:  evidence.PolicyDecision{Allowed: allowed, Action: action, Reasons: reasons},
 		Execution: evidence.Execution{
 			ToolsCalled: []string{toolName},
-			Error:       reason,
 		},
 		Orchestration: inv.orch,
+	}
+	// Execution.Error only on records that actually denied/failed: session
+	// summaries count any non-empty Execution.Error as a session error, and
+	// allowed records (shadow violations, output_pii_redacted notes) now
+	// join sessions via SessionID — their reason already lives in
+	// PolicyDecision.Reasons.
+	if !allowed {
+		ev.Execution.Error = reason
 	}
 	if sv != nil {
 		ev.ObservationModeOverride = true

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dativo-io/talon/internal/classifier"
 	"github.com/dativo-io/talon/internal/evidence"
 	"github.com/dativo-io/talon/internal/explanation"
 	"github.com/dativo-io/talon/internal/policy"
@@ -60,9 +61,14 @@ func attribHandler(t *testing.T, mode, upstreamURL string, forbidden []string) (
 
 func attribCall(t *testing.T, h *ProxyHandler, ctx context.Context, headers map[string]string, tool string) (*httptest.ResponseRecorder, jsonrpcResponse) {
 	t.Helper()
+	return attribCallArgs(t, h, ctx, headers, tool, map[string]string{"q": "hello"})
+}
+
+func attribCallArgs(t *testing.T, h *ProxyHandler, ctx context.Context, headers map[string]string, tool string, args map[string]string) (*httptest.ResponseRecorder, jsonrpcResponse) {
+	t.Helper()
 	body, _ := json.Marshal(map[string]interface{}{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-		"params": map[string]interface{}{"name": tool, "arguments": map[string]string{"q": "hello"}},
+		"params": map[string]interface{}{"name": tool, "arguments": args},
 	})
 	req := httptest.NewRequest(http.MethodPost, "/mcp/proxy", bytes.NewReader(body)).WithContext(ctx)
 	for k, v := range headers {
@@ -131,19 +137,24 @@ func TestProxyPassthrough_ForbiddenForwarded_HonestEvidence(t *testing.T) {
 	assert.True(t, hit)
 
 	records := listRecords(t, store, "default")
-	var sv *evidence.Evidence
+	svTypes := map[string]*evidence.Evidence{}
 	for i := range records {
 		if records[i].InvocationType == "proxy_shadow_violation" {
-			sv = &records[i]
+			require.Len(t, records[i].ShadowViolations, 1)
+			svTypes[records[i].ShadowViolations[0].Type] = &records[i]
 		}
 		assert.NotEqual(t, "proxy_tool_blocked", records[i].InvocationType,
 			"a forwarded call must not be recorded as blocked")
 	}
-	require.NotNil(t, sv, "passthrough must record the would-have-denied verdict")
-	assert.True(t, sv.PolicyDecision.Allowed, "the call was forwarded; the deny verdict lives in ShadowViolations")
-	assert.True(t, sv.ObservationModeOverride)
-	require.Len(t, sv.ShadowViolations, 1)
-	assert.Equal(t, "tool_block", sv.ShadowViolations[0].Type)
+	// user_delete is both explicitly forbidden AND absent from allowed_tools,
+	// so passthrough must record BOTH would-have-denied verdicts (#346): the
+	// forbidden-tool match and the tool-access policy deny.
+	require.Contains(t, svTypes, "tool_block", "passthrough must record the forbidden-tool would-deny")
+	require.Contains(t, svTypes, "policy_deny", "passthrough must record the policy would-deny")
+	for _, sv := range svTypes {
+		assert.True(t, sv.PolicyDecision.Allowed, "the call was forwarded; the deny verdict lives in ShadowViolations")
+		assert.True(t, sv.ObservationModeOverride)
+	}
 }
 
 // TestProxyShadow_PolicyDeny_RecordsWouldDeny pins the #346 gap where shadow
@@ -240,6 +251,119 @@ func TestProxyEvidence_BlockedCarriesPolicyDeniedTool(t *testing.T) {
 	primary, ok := explanation.Primary(records[0].Explanations)
 	require.True(t, ok)
 	assert.Equal(t, explanation.CodePolicyDeniedTool, primary.Code)
+}
+
+// TestProxyEvidence_OrchestrationBlockEmission pins the #350 orchestration
+// contract on the MCP wire: identity headers populate the record's
+// orchestration block (client defaulting to "generic", client_asserted
+// provenance), and each identity header is hygiene-validated.
+func TestProxyEvidence_OrchestrationBlockEmission(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+
+	_, resp := attribCall(t, h, context.Background(), map[string]string{
+		"X-Talon-Session-ID":      "sess-orch-1",
+		"X-Talon-Agent-ID":        "reviewer-subagent",
+		"X-Talon-Parent-Agent-ID": "orchestrator",
+	}, "crm_lookup")
+	require.Nil(t, resp.Error)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	orch := records[0].Orchestration
+	require.NotNil(t, orch, "identity headers must emit the orchestration block")
+	assert.Equal(t, "reviewer-subagent", orch.AgentID)
+	assert.Equal(t, "orchestrator", orch.ParentAgentID)
+	assert.Equal(t, "generic", orch.Client, "client defaults to generic when identity is asserted without X-Talon-Client")
+	assert.Equal(t, "sess-orch-1", orch.SessionID)
+	assert.Equal(t, "client_asserted", orch.SessionSource)
+	assert.Equal(t, "client_asserted", orch.Provenance)
+
+	// A bare session (no identity headers) must NOT emit the block —
+	// the session_id column alone carries it (gateway emission rule).
+	h2, store2 := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+	_, resp = attribCall(t, h2, context.Background(), map[string]string{"X-Talon-Session-ID": "sess-bare"}, "crm_lookup")
+	require.Nil(t, resp.Error)
+	recs2 := listRecords(t, store2, "default")
+	require.Len(t, recs2, 1)
+	assert.Nil(t, recs2[0].Orchestration)
+	assert.Equal(t, "sess-bare", recs2[0].SessionID)
+
+	// Identity headers are hygiene-validated like the session header.
+	rec, _ := attribCall(t, h2, context.Background(), map[string]string{
+		"X-Talon-Agent-ID": "bad value with spaces",
+	}, "crm_lookup")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestProxyShadow_PIIWouldDeny_RecordsShadowViolation pins the #346 gap on
+// the PII gate: in shadow mode a PII policy deny (detected PII with no
+// redaction rule) is recorded as a would-have-denied shadow violation while
+// the (redacted) call is forwarded — and the allowed records carry no
+// Execution.Error, so session summaries do not count them as errors.
+func TestProxyShadow_PIIWouldDeny_RecordsShadowViolation(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode:         policy.ProxyModeShadow,
+			Upstream:     policy.UpstreamConfig{URL: up.URL, Vendor: "testvendor"},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+		// No redaction rules: rego proxy_pii_redaction denies any detected PII.
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+
+	_, resp := attribCallArgs(t, h, context.Background(), map[string]string{"X-Talon-Session-ID": "sess-pii-1"}, "crm_lookup",
+		map[string]string{"email": "jane.doe@example.com"})
+	require.Nil(t, resp.Error, "shadow mode forwards the PII would-deny")
+	assert.True(t, hit)
+
+	records := listRecords(t, store, "default")
+	var sv *evidence.Evidence
+	for i := range records {
+		if records[i].InvocationType == "proxy_shadow_violation" {
+			sv = &records[i]
+		}
+		if records[i].PolicyDecision.Allowed {
+			assert.Empty(t, records[i].Execution.Error,
+				"allowed records must not carry Execution.Error (session summaries count it as an error)")
+		}
+	}
+	require.NotNil(t, sv, "shadow mode must record the PII would-deny")
+	require.Len(t, sv.ShadowViolations, 1)
+	assert.Equal(t, "pii_block", sv.ShadowViolations[0].Type)
+	assert.True(t, sv.ObservationModeOverride)
+	assert.Equal(t, "sess-pii-1", sv.SessionID)
+}
+
+// TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords pins the #350
+// correlation contract for the no-header case: one generated request-scoped
+// ID is shared by every record of the call.
+func TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	// Passthrough + forbidden yields multiple records for one call.
+	h, store := attribHandler(t, policy.ProxyModePassthrough, up.URL, []string{"user_delete"})
+
+	rec, resp := attribCall(t, h, context.Background(), nil, "user_delete")
+	require.Nil(t, resp.Error)
+
+	records := listRecords(t, store, "default")
+	require.GreaterOrEqual(t, len(records), 2)
+	corr := records[0].CorrelationID
+	assert.True(t, strings.HasPrefix(corr, "mcp_proxy_"), "generated correlation keeps the mcp_proxy_ prefix")
+	for _, r := range records {
+		assert.Equal(t, corr, r.CorrelationID, "all records of one call share the generated correlation ID")
+	}
+	assert.Equal(t, corr, rec.Header().Get("X-Correlation-ID"), "generated correlation is echoed to the caller")
 }
 
 // TestProxyInvalidAttributionHeader_Rejected400 pins the hygiene contract

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -1,0 +1,259 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/explanation"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/requestctx"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// attribUpstream is a permissive fake vendor that records whether it was hit.
+func attribUpstream(t *testing.T, hit *bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*hit = true
+		var req jsonrpcRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]string{"content": "ok"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// attribHandler builds a proxy with the given mode and forbidden list. The
+// classifier stays nil so allowed calls produce exactly one evidence record.
+func attribHandler(t *testing.T, mode, upstreamURL string, forbidden []string) (*ProxyHandler, *evidence.Store) {
+	t.Helper()
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode:           mode,
+			Upstream:       policy.UpstreamConfig{URL: upstreamURL, Vendor: "testvendor"},
+			AllowedTools:   []policy.ToolMapping{{Name: "crm_lookup"}},
+			ForbiddenTools: forbidden,
+		},
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return NewProxyHandler(cfg, engine, store, nil), store
+}
+
+func attribCall(t *testing.T, h *ProxyHandler, ctx context.Context, headers map[string]string, tool string) (*httptest.ResponseRecorder, jsonrpcResponse) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]interface{}{"name": tool, "arguments": map[string]string{"q": "hello"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp/proxy", bytes.NewReader(body)).WithContext(ctx)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var resp jsonrpcResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	return rec, resp
+}
+
+func listRecords(t *testing.T, store *evidence.Store, tenant string) []evidence.Evidence {
+	t.Helper()
+	records, err := store.List(context.Background(), tenant, "", time.Now().Add(-time.Minute), time.Now().Add(time.Minute), 20)
+	require.NoError(t, err)
+	return records
+}
+
+// TestProxyUnsetMode_ForbiddenBlocked pins the #346 fail-open: a handler
+// constructed with an unset mode (bypassing the loaders) must still block
+// forbidden tools — empty mode used to silently behave as passthrough while
+// evidence claimed the call was blocked.
+func TestProxyUnsetMode_ForbiddenBlocked(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, "" /* unset */, up.URL, []string{"user_delete"})
+
+	_, resp := attribCall(t, h, context.Background(), nil, "user_delete")
+	require.NotNil(t, resp.Error, "forbidden tool must be blocked with unset mode")
+	assert.Contains(t, resp.Error.Message, "tool not allowed by policy")
+	assert.False(t, hit, "forbidden tool must never reach the upstream outside explicit passthrough")
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	assert.Equal(t, "proxy_tool_blocked", records[0].InvocationType)
+	assert.False(t, records[0].PolicyDecision.Allowed)
+}
+
+// TestProxyLoader_ModeDefaultAndValidation pins the #346 loader contract:
+// unset mode defaults to intercept; unknown values are rejected.
+func TestProxyLoader_ModeDefaultAndValidation(t *testing.T) {
+	cfg := &policy.ProxyPolicyConfig{}
+	cfg.Proxy.Upstream.URL = "http://example.com/mcp"
+	cfg.Proxy.AllowedTools = []policy.ToolMapping{{Name: "t"}}
+	require.NoError(t, validateAndApplyDefaults(cfg))
+	assert.Equal(t, policy.ProxyModeIntercept, cfg.Proxy.Mode, "unset mode must default to intercept")
+
+	cfg.Proxy.Mode = "intercpt" // typo must fail loudly, not fail open
+	err := validateAndApplyDefaults(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `proxy.mode "intercpt" is invalid`)
+}
+
+// TestProxyPassthrough_ForbiddenForwarded_HonestEvidence pins the #346
+// evidence-honesty fix: explicit passthrough forwards a forbidden tool, and
+// the record says so — an ALLOWED shadow-violation record, not a fake
+// "blocked" one.
+func TestProxyPassthrough_ForbiddenForwarded_HonestEvidence(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModePassthrough, up.URL, []string{"user_delete"})
+
+	_, resp := attribCall(t, h, context.Background(), nil, "user_delete")
+	require.Nil(t, resp.Error, "passthrough forwards forbidden tools")
+	assert.True(t, hit)
+
+	records := listRecords(t, store, "default")
+	var sv *evidence.Evidence
+	for i := range records {
+		if records[i].InvocationType == "proxy_shadow_violation" {
+			sv = &records[i]
+		}
+		assert.NotEqual(t, "proxy_tool_blocked", records[i].InvocationType,
+			"a forwarded call must not be recorded as blocked")
+	}
+	require.NotNil(t, sv, "passthrough must record the would-have-denied verdict")
+	assert.True(t, sv.PolicyDecision.Allowed, "the call was forwarded; the deny verdict lives in ShadowViolations")
+	assert.True(t, sv.ObservationModeOverride)
+	require.Len(t, sv.ShadowViolations, 1)
+	assert.Equal(t, "tool_block", sv.ShadowViolations[0].Type)
+}
+
+// TestProxyShadow_PolicyDeny_RecordsWouldDeny pins the #346 gap where shadow
+// mode produced no evidence at all for a policy deny: the deny must land as a
+// would-have-denied shadow violation while the call is forwarded.
+func TestProxyShadow_PolicyDeny_RecordsWouldDeny(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeShadow, up.URL, nil)
+
+	// not_in_allowlist is not in AllowedTools -> tool-access policy denies it.
+	_, resp := attribCall(t, h, context.Background(), nil, "not_in_allowlist")
+	require.Nil(t, resp.Error, "shadow mode forwards policy denials")
+	assert.True(t, hit)
+
+	records := listRecords(t, store, "default")
+	var found bool
+	for _, rec := range records {
+		if rec.InvocationType == "proxy_shadow_violation" {
+			found = true
+			require.Len(t, rec.ShadowViolations, 1)
+			assert.Equal(t, "policy_deny", rec.ShadowViolations[0].Type)
+		}
+	}
+	assert.True(t, found, "shadow mode must record the would-have-denied policy decision")
+}
+
+// TestProxyEvidence_AuthenticatedAttribution pins #350: records carry the
+// authenticated agent, the asserted session, and ONE correlation ID across
+// all records of the request — never the hardcoded "mcp-proxy".
+func TestProxyEvidence_AuthenticatedAttribution(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	// Passthrough + forbidden produces two records for one call (shadow
+	// violation + final proxy_tool_call), exercising correlation reuse.
+	h, store := attribHandler(t, policy.ProxyModePassthrough, up.URL, []string{"user_delete"})
+
+	ctx := requestctx.SetTenantID(context.Background(), "acme")
+	ctx = requestctx.SetAgentIdentity(ctx, requestctx.AgentIdentity{
+		AgentID: "coding-assistant", TenantID: "acme", Team: "coding",
+	})
+	rec, resp := attribCall(t, h, ctx, map[string]string{
+		"X-Talon-Session-ID": "sess-demo-1",
+		"X-Correlation-ID":   "corr-demo-1",
+	}, "user_delete")
+	require.Nil(t, resp.Error)
+	assert.Equal(t, "corr-demo-1", rec.Header().Get("X-Correlation-ID"), "resolved correlation is echoed")
+	assert.Equal(t, "sess-demo-1", rec.Header().Get("X-Talon-Session-ID"), "asserted session is echoed")
+
+	records := listRecords(t, store, "acme")
+	require.GreaterOrEqual(t, len(records), 2, "one call in passthrough with a forbidden tool yields at least two records")
+	for _, r := range records {
+		assert.Equal(t, "coding-assistant", r.AgentID, "evidence must carry the authenticated agent")
+		assert.Equal(t, "acme", r.TenantID)
+		assert.Equal(t, "coding", r.Team)
+		assert.Equal(t, "sess-demo-1", r.SessionID)
+		assert.Equal(t, "corr-demo-1", r.CorrelationID, "every record of one call shares the inbound correlation ID")
+	}
+}
+
+// TestProxyEvidence_NoIdentity_FallsBackToConfigAgent pins the admin/dev-open
+// attribution: with no authenticated identity, records attribute to the proxy
+// config's own agent name (not the legacy hardcoded "mcp-proxy").
+func TestProxyEvidence_NoIdentity_FallsBackToConfigAgent(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	assert.Equal(t, "vendor-proxy-agent", records[0].AgentID)
+	assert.NotEmpty(t, records[0].CorrelationID)
+	assert.Empty(t, records[0].SessionID, "no session is synthesized when none is asserted")
+}
+
+// TestProxyEvidence_BlockedCarriesPolicyDeniedTool pins the #350 acceptance
+// criterion: a forbidden-tool deny in intercept mode carries the
+// deterministic POLICY_DENIED_TOOL explanation code.
+func TestProxyEvidence_BlockedCarriesPolicyDeniedTool(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, []string{"user_delete"})
+
+	_, resp := attribCall(t, h, context.Background(), nil, "user_delete")
+	require.NotNil(t, resp.Error)
+	assert.False(t, hit)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	require.NotEmpty(t, records[0].Explanations)
+	primary, ok := explanation.Primary(records[0].Explanations)
+	require.True(t, ok)
+	assert.Equal(t, explanation.CodePolicyDeniedTool, primary.Code)
+}
+
+// TestProxyInvalidAttributionHeader_Rejected400 pins the hygiene contract
+// shared with the gateway: an oversized or non-token session header is
+// rejected with HTTP 400 before any evidence is written.
+func TestProxyInvalidAttributionHeader_Rejected400(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+
+	rec, _ := attribCall(t, h, context.Background(), map[string]string{
+		"X-Talon-Session-ID": strings.Repeat("a", evidence.OrchHeaderMaxLen+1),
+	}, "crm_lookup")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.False(t, hit, "rejected requests must not reach the upstream")
+	assert.Empty(t, listRecords(t, store, "default"), "rejected requests must not write evidence")
+}

--- a/internal/mcp/proxy_config.go
+++ b/internal/mcp/proxy_config.go
@@ -57,6 +57,18 @@ func validateAndApplyDefaults(cfg *policy.ProxyPolicyConfig) error {
 	if len(cfg.Proxy.AllowedTools) == 0 {
 		return fmt.Errorf("at least one proxy.allowed_tools entry is required")
 	}
+	// Mode (#346): default unset to intercept — matching LoadProxyPolicy's
+	// documented default — and reject anything outside the three declared
+	// values. An unset mode must never reach the handler, where it would
+	// silently behave as passthrough (forbidden tools recorded as blocked
+	// but forwarded upstream).
+	switch cfg.Proxy.Mode {
+	case "":
+		cfg.Proxy.Mode = policy.ProxyModeIntercept
+	case policy.ProxyModeIntercept, policy.ProxyModePassthrough, policy.ProxyModeShadow:
+	default:
+		return fmt.Errorf("proxy.mode %q is invalid; use intercept, passthrough, or shadow", cfg.Proxy.Mode)
+	}
 	// Defaults: rate limits
 	if cfg.Proxy.RateLimits.RequestsPerMinute <= 0 {
 		cfg.Proxy.RateLimits.RequestsPerMinute = 100

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -245,9 +245,15 @@ func LoadProxyPolicy(path string, baseDir string) (*ProxyPolicyConfig, error) {
 		return nil, fmt.Errorf("proxy.allowed_tools must have at least one entry")
 	}
 
-	// Default proxy mode to "intercept" when unset.
-	if config.Proxy.Mode == "" {
-		config.Proxy.Mode = "intercept"
+	// Mode (#346): default unset to intercept and reject unknown values —
+	// identical contract to the serve loader (internal/mcp LoadProxyConfig)
+	// so the two loaders cannot diverge on enforcement semantics again.
+	switch config.Proxy.Mode {
+	case "":
+		config.Proxy.Mode = ProxyModeIntercept
+	case ProxyModeIntercept, ProxyModePassthrough, ProxyModeShadow:
+	default:
+		return nil, fmt.Errorf("proxy.mode %q is invalid; use intercept, passthrough, or shadow", config.Proxy.Mode)
 	}
 
 	return &config, nil

--- a/internal/policy/proxy.go
+++ b/internal/policy/proxy.go
@@ -36,6 +36,15 @@ type ProxyAgentConfig struct {
 	Version     string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
+// Proxy modes (#346). These are the only three declared values; loaders
+// default unset to intercept and reject anything else, so the handler never
+// sees an empty or unknown mode (which would otherwise fail open).
+const (
+	ProxyModeIntercept   = "intercept"   // block policy/PII violations and forbidden tools
+	ProxyModePassthrough = "passthrough" // record everything, forward everything
+	ProxyModeShadow      = "shadow"      // record would-have-denied, forward; forbidden tools still blocked
+)
+
 // ProxyConfig defines the MCP proxy behaviour.
 type ProxyConfig struct {
 	Mode           string               `yaml:"mode,omitempty" json:"mode,omitempty"` // intercept | passthrough | shadow


### PR DESCRIPTION
Closes #346. Closes #350.

## What

Two governance-integrity defects in the MCP proxy, fixed together because both reshape `recordEvidence` and its call sites.

### #346 — fail-open mode

- The production loader (`mcp.LoadProxyConfig`) never defaulted `proxy.mode`, and every enforcement gate compared mode literals — an **unset or typo'd mode silently behaved as passthrough**: forbidden tools were recorded as "blocked" but forwarded upstream. Meanwhile the loader that did default (`policy.LoadProxyPolicy`) had zero production callers.
- Both loaders now share one contract: unset → `intercept`, anything outside `intercept|passthrough|shadow` rejected at startup (constants in `internal/policy`). The constructor normalizes empty **and unknown** modes for directly-built handlers, and the forbidden gate itself forwards only under explicit `passthrough` — fail-closed at three layers.
- **Evidence now says what actually happened.** A block records `proxy_tool_blocked`; a record-then-forward (passthrough forbidden tool; shadow/passthrough policy or PII would-deny) records an ALLOWED `proxy_shadow_violation` with `ObservationModeOverride` + a `ShadowViolations` entry — the gateway's shadow vocabulary. Previously, shadow/passthrough policy denials produced **no evidence at all**, contradicting what the docs (and the v1.9.1 guide rewrite) said shadow mode does.

### #350 — evidence attribution

- `recordEvidence` hardcoded `AgentID: "mcp-proxy"` and minted a fresh correlation ID **per record** (the intent/result records of one call weren't even joinable with each other).
- A request-scoped `proxyInvocation` is now resolved once at the HTTP boundary: authenticated agent identity (requestctx, i.e. `agent_id: coding-assistant` for a request presenting that key) → proxy config `agent.name` → `"mcp-proxy"` last; tenant + team from the identity; validated `X-Talon-Session-ID` into `session_id` (client-asserted, never synthesized); inbound `X-Correlation-ID` preserved or one request-scoped ID shared by all records; `X-Talon-Agent-ID`/`Parent`/`Client` populate the `orchestration` block under the gateway's emission rule. Resolved identifiers are echoed on response headers.
- Header hygiene is the gateway contract (128-byte cap, RFC 7230 tchar, reject-never-truncate) with the implementation **extracted to `internal/evidence.ValidateOrchValue`** and the gateway delegating — the two ingestion surfaces can no longer diverge. Invalid headers are HTTP 400 before any evidence.
- Denied tool calls carry the deterministic `POLICY_DENIED_TOOL` explanation code alongside the native trigger.

## Multi-agent verification

The implementation was preceded by a 7-reader mapping workflow (handler flow, middleware identity, gateway orchmeta, evidence schema, explanation contract, loader divergence, test house style) and followed by a 4-lens adversarial review of the diff, which produced real fixes now in the branch:

- `proxy_shadow_violation` registered in the closed record-class registry — as a request-class type it would have inflated `talon agents` traffic counts 2–3× per shadow/passthrough call.
- `Execution.Error` set only on denied/failed records — allowed records now join sessions via `SessionID`, where session summaries count any non-empty `Error` as a session error.
- Constructor normalization widened to unknown (not just empty) mode values.
- Three mutation-verified coverage gaps pinned (orchestration emission, PII would-deny in shadow, generated-correlation sharing), plus the passthrough test now asserts **both** would-deny verdicts.

## Acceptance criteria from #350

- [x] Authenticated `coding-assistant` key ⇒ `tenant_id`/`agent_id` from the resolved identity (`TestProxyEvidence_AuthenticatedAttribution`)
- [x] `X-Talon-Session-ID` in evidence `session_id`, client-asserted provenance documented (docs + `TestProxyEvidence_OrchestrationBlockEmission`)
- [x] Inbound correlation preserved / one request-scoped ID reused (`TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords`)
- [x] All record kinds share the attribution contract (single `resolveProxyInvocation` at the boundary)
- [x] Forbidden tool denied before upstream in intercept; evidence carries `POLICY_DENIED_TOOL` (`TestProxyEvidence_BlockedCarriesPolicyDeniedTool`)
- [x] Tests assert tenant/agent/session/correlation/decision/explanation
- [x] Docs state attribution-not-authentication (`docs/ARCHITECTURE_MCP_PROXY.md` "Evidence attribution")

## Verification

`go test` on mcp/evidence/policy/gateway/server/cmd + `go test -tags integration -count=1 ./tests/integration` (84s) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)