### PR TITLE
docs+examples: adoption-path truth fixes (#345, #328, #329, #330)

### DIFF
--- a/docs/ARCHITECTURE_MCP_PROXY.md
+++ b/docs/ARCHITECTURE_MCP_PROXY.md
@@ -361,7 +361,8 @@ func (p *ProxyServer) redactPII(data interface{}, rules []RedactionRule) interfa
     // - Apply redaction method (hash, mask, redact_full)
     // - Return redacted copy
     
-    // See internal/classifier/redactor.go for full implementation
+    // Shipped implementation: internal/classifier/pii.go (analysis +
+    // redaction) and internal/classifier/redact_guard.go (egress verify)
     return data
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,7 +156,7 @@ Choose the shortest path for your situation:
 | Doc | Description |
 |-----|-------------|
 | [Policy cookbook](guides/policy-cookbook.md) | Copy-paste policy snippets for common needs. |
-| [Starter policy library](../examples/policies/README.md) | Ready-to-use Rego policies for cost, PII, model allowlists, data residency. |
+| [Starter policy library](../examples/policies/README.md) | Reference Rego policies for cost, PII, model allowlists, data residency (custom Rego loading is a v2 surface; the equivalent shipped controls live in `.talon.yaml`). |
 
 ### Community / internal
 
@@ -189,5 +189,5 @@ Talon's evidence layer supports these control objectives; it is not a compliance
 | [Gateway minimal](../examples/gateway-minimal/README.md) | Smallest working LLM gateway config. |
 | [MCP proxy minimal](../examples/mcp-proxy-minimal/README.md) | Smallest working MCP proxy config. |
 | [Plan review](../examples/plan-review/README.md) | Human-in-the-loop demo (EU AI Act Art. 14). |
-| [Starter policies](../examples/policies/README.md) | OPA/Rego policies for common governance scenarios. |
+| [Starter policies](../examples/policies/README.md) | Reference OPA/Rego policies for common governance scenarios (not auto-loaded; v2 surface). |
 | [Observability stack](../examples/observability/README.md) | Local OTel Collector + Prometheus + Grafana with pre-built Talon dashboard. |

--- a/docs/explanation/what-talon-does-to-your-request.md
+++ b/docs/explanation/what-talon-does-to-your-request.md
@@ -354,6 +354,7 @@ The gateway pipeline implementation lives in these files:
 | `internal/gateway/tool_filter.go` | Tool governance / filtering |
 | `internal/gateway/ratelimit.go` | Token-bucket rate limiting |
 | `internal/gateway/attachment.go` | Attachment extraction + injection scanning |
-| `internal/classifier/scanner.go` | PII regex recognizers |
+| `internal/classifier/patterns.go` | PII regex recognizers (EU pattern set) |
+| `internal/classifier/pii.go` | PII analysis + redaction engine |
 | `internal/evidence/store.go` | Evidence storage + HMAC signing |
 | `internal/evidence/generator.go` | Evidence record creation |

--- a/examples/langchain-integration/README.md
+++ b/examples/langchain-integration/README.md
@@ -13,7 +13,8 @@ from langchain_openai import ChatOpenAI
 
 llm = ChatOpenAI(
     model="gpt-4o-mini",
-    base_url="http://localhost:8080/v1/proxy/openai",
+    # Trailing /v1 required: the client appends /chat/completions
+    base_url="http://localhost:8080/v1/proxy/openai/v1",
     api_key="your-agent-key",
 )
 response = llm.invoke("What is GDPR Article 30?")
@@ -72,8 +73,8 @@ Best for: **LangGraph stateful graphs, multi-step agents, compliance-heavy**.
 
 Talon is framework-agnostic. The same governance applies to:
 
-- **OpenAI SDK**: Point `base_url` at `http://localhost:8080/v1/proxy/openai`
-- **Anthropic SDK**: Use `http://localhost:8080/v1/proxy/anthropic`
+- **OpenAI SDK**: Point `base_url` at `http://localhost:8080/v1/proxy/openai/v1` (the client appends `/chat/completions`; without the trailing `/v1` every request 404s)
+- **Anthropic SDK**: Use `http://localhost:8080/v1/proxy/anthropic` — no trailing `/v1` here: the Anthropic client appends `/v1/messages` itself
 - **MCP clients**: Send tool calls to `POST /mcp` (JSON-RPC 2.0)
 - **Custom agents**: Use the graph events API with any HTTP client
 

--- a/examples/langchain-integration/langchain_stateless.py
+++ b/examples/langchain-integration/langchain_stateless.py
@@ -37,7 +37,10 @@ def run_stateless_call():
     llm = ChatOpenAI(
         model="gpt-4o-mini",
         temperature=0,
-        base_url=f"{talon_url}/v1/proxy/openai",
+        # Trailing /v1 required (#345): the OpenAI client joins
+        # {base_url}/chat/completions, and Talon's path-gated handling
+        # matches /v1/chat/completions.
+        base_url=f"{talon_url}/v1/proxy/openai/v1",
         api_key=agent_key,
         default_headers={
             "X-Talon-Session-ID": "notebook-session-1",

--- a/examples/langchain-integration/notebook_example.py
+++ b/examples/langchain-integration/notebook_example.py
@@ -33,7 +33,8 @@ def cell_langchain_stateless():
     llm = ChatOpenAI(
         model="gpt-4o-mini",
         temperature=0,
-        base_url=f"{TALON_URL}/v1/proxy/openai",
+        # Trailing /v1 required (#345): the OpenAI client appends /chat/completions.
+        base_url=f"{TALON_URL}/v1/proxy/openai/v1",
         api_key=TALON_AGENT_KEY,
         default_headers={"X-Talon-Session-ID": "notebook-demo"},
     )

--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -1,7 +1,16 @@
-# Starter Policy Library
+# Starter Policy Library (reference for the planned custom-policy surface)
 
-Ready-to-use OPA/Rego policies for common governance scenarios. Copy and
-customize for your needs.
+Example OPA/Rego policies for common governance scenarios — a **reference
+library, not a loading mechanism**. Talon does not load custom Rego today:
+the shipped policies are compiled into the binary (`internal/policy`,
+`//go:embed rego/*.rego`) and configured via `.talon.yaml`; custom Rego
+loading is planned for v2 (see `policies/README.md`). Use these files to
+prototype and test policy logic standalone with the `opa` CLI, and to
+express the rules you'll want when the custom surface ships. The governance
+outcomes they describe (cost budgets, PII blocking, model allowlists, data
+residency) are available TODAY via `.talon.yaml` configuration
+(`policies.cost_limits`, PII actions, `allowed_models`/`allowed_providers`,
+`compliance.data_residency`).
 
 ## Policies
 
@@ -12,12 +21,17 @@ customize for your needs.
 | **Model Allowlist** | `model-allowlist.rego` | Restrict which models agents can use |
 | **Data Residency** | `data-residency.rego` | Ensure sensitive data stays in EU-hosted models |
 
-## How to Use
+## How to Use (today)
 
-1. Copy the policy file to `policies/rego/` in your Talon project
-2. Edit thresholds and rules to match your requirements
-3. Test with `opa test policies/rego/ -v`
-4. Restart Talon — policies are loaded automatically
+1. Pick the scenario you need and read its `.rego` file — the `input` shape
+   documents which request facts the rule keys on
+2. Configure the equivalent shipped control in your `.talon.yaml`
+   (cost limits, PII action, model allowlist, data residency)
+3. Iterate on the Rego logic standalone with `opa eval` (see Testing below)
+   so it's ready for the v2 custom-policy surface
+
+These files are NOT loaded by Talon — there is no `policies/rego/`
+auto-load, and restarting Talon does not pick them up.
 
 ## Writing Custom Policies
 
@@ -46,10 +60,10 @@ tier, agent info). See each policy file for the expected input shape.
 ## Testing
 
 ```bash
-# Run all Rego tests
-opa test policies/rego/ -v
-
-# Test a specific policy with sample input
+# Evaluate a policy against sample input (standalone, no Talon involved)
 echo '{"model": "gpt-4o", "allowed_models": ["gpt-4o-mini"]}' | \
   opa eval -d examples/policies/model-allowlist.rego -I 'data.talon.gateway.allow'
+
+# Run Rego unit tests you write alongside these files
+opa test examples/policies/ -v
 ```


### PR DESCRIPTION
Closes #345. Closes #328. Closes #329. Closes #330.

Four open items of the "documentation that sends evaluators down a false path" class, all on adoption-facing surfaces:

- **#345** — `examples/langchain-integration`: the three OpenAI-client `base_url`s gain the required trailing `/v1` (`ChatOpenAI` appends `/chat/completions`; without it every request 404s upstream and silently skips Talon's path-gated handling), matching the already-correct notebook. **Scope note:** the issue said "and the anthropic line" — that line is deliberately left WITHOUT `/v1` and annotated: the Anthropic client appends `/v1/messages` itself, so `…/v1/proxy/anthropic` is the correct form (same as the wizard and the Claude Code guide).
- **#328** — `examples/policies/README.md`: reframed as a **reference library** for the planned v2 custom-policy surface (issue fix option 1). The fabricated "copy to `policies/rego/` … loaded automatically" flow is gone; the README now names the shipped `.talon.yaml` controls that deliver the same outcomes today, and the `opa` examples work standalone. `docs/README.md` link rows aligned so the index doesn't oversell it.
- **#329** — `what-talon-does-to-your-request.md`: nonexistent `internal/classifier/scanner.go` row replaced with the real recognizer files (`patterns.go`, `pii.go`).
- **#330** — `ARCHITECTURE_MCP_PROXY.md`: nonexistent `redactor.go` pointer replaced with the shipped files (`pii.go`, `redact_guard.go`). Per the issue's suggestion, a sweep verified **every** `internal/*.go` path referenced in both docs resolves to a real file — no other stale pointers.

Docs/examples only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)