### PR TITLE
fix(release): ship native macOS binaries (darwin_arm64 + darwin_amd64) (#359, #326)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # goreleaser-cross provides CGO cross-compilers (Darwin, Windows) so we can
-      # build all targets from Linux; plain goreleaser fails with "unsupported -arch"
-      # when building darwin/arm64 from Linux.
-      - name: Run GoReleaser (goreleaser-cross)
+      # goreleaser (via goreleaser-cross image) builds and publishes the
+      # linux/amd64 archive + Docker images + release notes. Darwin archives
+      # are NOT built here — CGO (mattn/go-sqlite3) cross-compilation via
+      # osxcross has been unreliable (#326) — they come from the native
+      # macOS job below (#359).
+      - name: Run GoReleaser (linux + docker)
         run: |
           docker run --rm --privileged \
             -v $PWD:/work -w /work \
@@ -37,3 +39,53 @@ jobs:
             -e CGO_ENABLED=1 \
             ghcr.io/goreleaser/goreleaser-cross:v1.26.4 \
             release --clean
+
+  # Darwin binaries (#359): built natively on a macOS runner because the
+  # evidence store is CGO (mattn/go-sqlite3) — Apple clang builds both
+  # arm64 and amd64 (-arch x86_64) without osxcross. Runs after the
+  # goreleaser job so the release exists; a failure here never blocks the
+  # linux/docker release, and re-runs are safe (--clobber).
+  release-darwin:
+    name: Darwin binaries (${{ matrix.arch }})
+    needs: release
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build and package (darwin/${{ matrix.arch }})
+        env:
+          CGO_ENABLED: "1"
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          go build -trimpath -ldflags "-s -w \
+            -X github.com/dativo-io/talon/internal/cmd.Version=${VERSION} \
+            -X github.com/dativo-io/talon/internal/cmd.Commit=${COMMIT} \
+            -X github.com/dativo-io/talon/internal/cmd.BuildDate=${DATE}" \
+            -o talon ./cmd/talon
+          # Smoke-run only the native arch (amd64 on the arm64 runner would
+          # need Rosetta); the cross build is still verified by `file`.
+          if [ "${{ matrix.arch }}" = "$(uname -m | sed 's/x86_64/amd64/')" ]; then ./talon version; fi
+          file talon
+          ARCHIVE="talon_${VERSION}_darwin_${{ matrix.arch }}.tar.gz"
+          tar -czf "${ARCHIVE}" talon LICENSE README.md CHANGELOG.md
+          shasum -a 256 "${ARCHIVE}" > "${ARCHIVE}.sha256"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARCHIVE="talon_${VERSION}_darwin_${{ matrix.arch }}.tar.gz"
+          gh release upload "${GITHUB_REF_NAME}" "${ARCHIVE}" "${ARCHIVE}.sha256" --clobber

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,12 @@ builds:
     goarch:
       - amd64
       - arm64
-    # goreleaser-cross v1.25.7: darwin and windows cross-compilation from Linux is
-    # broken (osxcross passes -arch to host gcc). Ship linux/amd64 via CI; macOS
-    # users build natively with `go install` or `make build`.
+    # goreleaser builds ONLY linux/amd64 (#326): CGO (mattn/go-sqlite3)
+    # cross-compilation via osxcross/mingw has been unreliable, so darwin
+    # archives are built natively by the release-darwin job in
+    # .github/workflows/release.yml (#359) and uploaded to the same release
+    # (with per-file .sha256 checksums, separate from checksums.txt).
+    # Windows and linux/arm64 remain unshipped — tracked in #359.
     ignore:
       - goos: linux
         goarch: arm64

--- a/docs/VENDOR_INTEGRATION_GUIDE.md
+++ b/docs/VENDOR_INTEGRATION_GUIDE.md
@@ -70,11 +70,16 @@ Third-Party AI Agent → Talon MCP Server → Your Zendesk/CRM
 ```bash
 # On your infrastructure (VM, EC2, on-prem server) — check
 # https://github.com/dativo-io/talon/releases/latest for the newest version
-TALON_VERSION=1.9.0   # set to the latest release tag
+TALON_VERSION=1.9.1   # set to the latest release tag
 wget https://github.com/dativo-io/talon/releases/download/v${TALON_VERSION}/talon_${TALON_VERSION}_linux_amd64.tar.gz
 tar -xzf talon_${TALON_VERSION}_linux_amd64.tar.gz
 sudo mv talon /usr/local/bin/talon
 ```
+
+macOS archives (`talon_<version>_darwin_arm64.tar.gz` / `_darwin_amd64.tar.gz`)
+ship from v1.9.2 onward; earlier releases are linux_amd64 only — on macOS use
+`go install github.com/dativo-io/talon/cmd/talon@<tag>` (prefix with
+`CC=/usr/bin/clang` if the linker errors) or `make install` from a clone.
 
 #### Step 2: Create the Proxy Policy
 


### PR DESCRIPTION
Closes #359. Closes #326.

## What

v1.9.1 shipped exactly one release asset (`talon_1.9.1_linux_amd64.tar.gz`) while the guides' `go install` fallback carries a documented macOS linker failure — a Mac evaluator (the primary coding-agents persona) had no clean install path. This was the top item in the adoption-blocker review.

- **New `release-darwin` job** (macos-latest, matrix arm64/amd64): native CGO builds — no osxcross — with the same ldflags as goreleaser, packaged as `talon_<version>_darwin_<arch>.tar.gz` (+ per-file `.sha256`), uploaded to the same release with `--clobber`. `needs: release`, so a darwin failure can never block the linux/docker release, and re-runs are safe.
- **#326 comment truth**: `release.yml` no longer claims goreleaser-cross ships Darwin/Windows; `.goreleaser.yml`'s ignore block now states the real constraint (CGO/osxcross unreliability) and points at the darwin job. Windows + linux/arm64 remain unshipped, tracked in #359's thread.
- Vendor guide install step version-scopes platform availability ("darwin from v1.9.2 onward") so the docs are true both before and after the tag.

## Verification

- Both darwin builds executed locally on an arm64 Mac with the exact job commands and release ldflags: `Mach-O 64-bit executable arm64` / `x86_64`, `talon version` reports injected version/commit/date.
- `actionlint` on the workflow: no findings in the new job (two pre-existing info-level shellcheck notes on the old goreleaser block remain).
- The job itself first runs live on the **v1.9.2 tag** — worth merging before tagging so v1.9.2 ships with Mac binaries (noted on #355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)