### PR TITLE
feat(doctor): warn on unrecognized talon.config.yaml keys (#351)

### DIFF
--- a/internal/cmd/init_pack_test.go
+++ b/internal/cmd/init_pack_test.go
@@ -62,29 +62,15 @@ func TestInitPack_CrewAI_GeneratesFiles(t *testing.T) {
 }
 
 // TestInitPack_GeneratedConfigKeysAreConsumed pins #342: every top-level key
-// in a generated talon.config.yaml must be read by one of the two real
-// loaders — viper (internal/config Key* constants + block loaders +
-// internal/cmd/root.go log bindings) or the gateway loader
-// (internal/gateway/config.go LoadGatewayConfig "gateway" subtree). A key
-// outside this set is dead config: it silently does nothing while looking
-// authoritative (the shipped templates once carried evidence.path,
-// secrets_key_env, tenants, llm_provider — all unread).
+// in a generated talon.config.yaml must be read by a real loader. The
+// consumed-key set is the shared config.ConsumedTopLevelKeys() (#351) — the
+// same source the doctor unrecognized-key check uses, so the pin test and
+// the operator-facing guard cannot drift apart. A key outside this set is
+// dead config: it silently does nothing while looking authoritative (the
+// shipped templates once carried evidence.path, secrets_key_env, tenants,
+// llm_provider — all unread).
 func TestInitPack_GeneratedConfigKeysAreConsumed(t *testing.T) {
-	consumed := map[string]bool{
-		// viper scalar keys (internal/config/config.go)
-		config.KeyDataDir: true, config.KeySecretsKey: true, config.KeySigningKey: true,
-		config.KeyDefaultPolicy: true, config.KeyAgentsDir: true, config.KeyAgentsReloadEvery: true,
-		config.KeyOrphanRetentionDays: true, config.KeyMaxAttachmentMB: true,
-		config.KeyOllamaBaseURL: true, config.KeyOllamaMaxNumPredict: true,
-		// viper-bound logging flags (internal/cmd/root.go BindPFlag)
-		"log_level": true, "log_format": true,
-		// viper block loaders (internal/config/config.go loadLLMConfig,
-		// loadCacheConfig, loadComplianceConfig, loadSovereigntyConfig,
-		// loadScannerConfig)
-		"llm": true, "cache": true, "compliance": true, "sovereignty": true, "scanner": true,
-		// gateway loader subtree (internal/gateway/config.go LoadGatewayConfig)
-		"gateway": true,
-	}
+	consumed := config.ConsumedTopLevelKeys()
 
 	// One pack per template source: generic (base tmpl), coding-agents and
 	// crewai (internal/pack/templates), copaw and openclaw (legacy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,34 @@ const (
 	KeyOllamaMaxNumPredict = "ollama_max_num_predict"
 )
 
+// ConsumedTopLevelKeys returns every top-level talon.config.yaml key a
+// shipped loader actually reads: the viper scalar keys above, the viper
+// block loaders (loadLLMConfig, loadCacheConfig, loadComplianceConfig,
+// loadSovereigntyConfig, loadScannerConfig), the logging flags bound in
+// internal/cmd/root.go, and the gateway subtree (internal/gateway
+// LoadGatewayConfig). One source of truth (#351): consumed by BOTH the
+// doctor unrecognized-key check and the pack-template pin test
+// (TestInitPack_GeneratedConfigKeysAreConsumed) so they cannot drift.
+// A key outside this set is dead config — silently ignored by every loader.
+func ConsumedTopLevelKeys() map[string]bool {
+	return map[string]bool{
+		KeyDataDir: true, KeySecretsKey: true, KeySigningKey: true,
+		KeyDefaultPolicy: true, KeyAgentsDir: true, KeyAgentsReloadEvery: true,
+		KeyOrphanRetentionDays: true, KeyMaxAttachmentMB: true,
+		KeyOllamaBaseURL: true, KeyOllamaMaxNumPredict: true,
+		"log_level": true, "log_format": true,
+		"llm": true, "cache": true, "compliance": true, "sovereignty": true, "scanner": true,
+		"gateway": true,
+	}
+}
+
+// UsedConfigFile returns the config file viper actually loaded, or "" when
+// running configless (defaults/env only). Wrapper so packages outside
+// internal/cmd need no viper knowledge.
+func UsedConfigFile() string {
+	return viper.ConfigFileUsed()
+}
+
 // Defaults that do NOT involve crypto material. Crypto keys intentionally
 // have no baked-in defaults — when unset we generate a deterministic
 // per-machine fallback and warn loudly.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -109,6 +109,8 @@ func checkConfig() []CheckResult {
 }
 
 // deadKeyHints names the real surface for known dead keys (#342 class).
+//
+//nolint:gosec // G101: key-NAME hint strings for operator guidance, not credentials
 var deadKeyHints = map[string]string{
 	"evidence":        "state paths derive from data_dir",
 	"tenants":         "tenancy and budgets live in agent.talon.yaml (key → agent → tenant, #266)",

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/dativo-io/talon/internal/agentbridge"
 	"github.com/dativo-io/talon/internal/agentcatalog"
 	"github.com/dativo-io/talon/internal/config"
@@ -94,6 +96,7 @@ func checkConfig() []CheckResult {
 		}}
 	}
 
+	results = append(results, checkConfigKeys(config.UsedConfigFile()))
 	results = append(results, checkDataDir(cfg))
 	results = append(results, checkPolicy(cfg))
 	results = append(results, checkLLMKeys(cfg))
@@ -103,6 +106,108 @@ func checkConfig() []CheckResult {
 	results = append(results, checkSovereignty(cfg, nil))
 	results = append(results, checkAirGap(cfg, nil))
 	return results
+}
+
+// deadKeyHints names the real surface for known dead keys (#342 class).
+var deadKeyHints = map[string]string{
+	"evidence":        "state paths derive from data_dir",
+	"tenants":         "tenancy and budgets live in agent.talon.yaml (key → agent → tenant, #266)",
+	"secrets_key_env": "the vault key comes from the TALON_SECRETS_KEY env var (or secrets_key here)",
+	"llm_provider":    "providers are configured under llm.providers or gateway.providers",
+}
+
+// checkConfigKeys warns on top-level talon.config.yaml keys no loader reads
+// (#351). Both shipped loaders are permissive by design (viper merges
+// env/defaults; the gateway loader tolerates viper-owned keys), so a dead
+// key silently does nothing while looking authoritative — the worst failure
+// mode for a governance product. Advisory: WARN never fails doctor.
+func checkConfigKeys(path string) CheckResult {
+	const name = "config_keys_recognized"
+	if path == "" {
+		return CheckResult{
+			Name: name, Category: "config", Status: "pass",
+			Message: "no talon.config.yaml loaded (defaults/env only)",
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return CheckResult{
+			Name: name, Category: "config", Status: "warn",
+			Message: fmt.Sprintf("%s could not be re-read — %v", path, err),
+		}
+	}
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return CheckResult{
+			Name: name, Category: "config", Status: "warn",
+			Message: fmt.Sprintf("%s is not parseable as YAML — %v", path, err),
+		}
+	}
+	consumed := config.ConsumedTopLevelKeys()
+	var unknown []string
+	for k := range doc {
+		if !consumed[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return CheckResult{
+			Name: name, Category: "config", Status: "pass",
+			Message: fmt.Sprintf("every top-level key in %s is read by a loader", filepath.Base(path)),
+		}
+	}
+	sort.Strings(unknown)
+	parts := make([]string, 0, len(unknown))
+	for _, k := range unknown {
+		hint := deadKeyHints[k]
+		if hint == "" {
+			if near := nearestConsumedKey(k, consumed); near != "" {
+				hint = fmt.Sprintf("did you mean %q?", near)
+			}
+		}
+		if hint != "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", k, hint))
+		} else {
+			parts = append(parts, k)
+		}
+	}
+	return CheckResult{
+		Name: name, Category: "config", Status: "warn",
+		Message: fmt.Sprintf("%s has keys no loader reads: %s", path, strings.Join(parts, "; ")),
+		Fix:     "Remove or replace these keys — they are silently ignored (#342, #351)",
+	}
+}
+
+// nearestConsumedKey returns the closest consumed key within edit distance 2,
+// or "" — a dumb typo hint, deliberately nothing fancier.
+func nearestConsumedKey(k string, consumed map[string]bool) string {
+	best, bestDist := "", 3
+	for c := range consumed {
+		if d := editDistance(k, c); d < bestDist {
+			best, bestDist = c, d
+		}
+	}
+	return best
+}
+
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(min(curr[j-1]+1, prev[j]+1), prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
 }
 
 func checkDataDir(cfg *config.Config) CheckResult {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -567,3 +567,38 @@ func TestGatewayIdentityPreflight_AgentsDir(t *testing.T) {
 		assert.Contains(t, err.Error(), "coding")
 	})
 }
+
+// TestCheckConfigKeys pins #351: top-level talon.config.yaml keys no loader
+// reads produce an advisory WARN naming each key with a hint — never a fail.
+func TestCheckConfigKeys(t *testing.T) {
+	t.Run("no config file loaded", func(t *testing.T) {
+		r := checkConfigKeys("")
+		assert.Equal(t, "pass", r.Status)
+	})
+
+	t.Run("clean config passes", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "talon.config.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("log_level: info\nllm:\n  pricing_file: pricing/models.yaml\ngateway:\n  enabled: true\n"), 0o600))
+		r := checkConfigKeys(p)
+		assert.Equal(t, "pass", r.Status, r.Message)
+	})
+
+	t.Run("dead keys warn with hints", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "talon.config.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("tenants:\n  - id: default\nevidence:\n  path: ~/.talon/evidence.db\nlog_lvel: info\n"), 0o600))
+		r := checkConfigKeys(p)
+		assert.Equal(t, "warn", r.Status, "dead keys are advisory, not fatal")
+		assert.Contains(t, r.Message, "tenants")
+		assert.Contains(t, r.Message, "agent.talon.yaml", "known dead keys carry their real surface")
+		assert.Contains(t, r.Message, "data_dir", "evidence hint names the real state surface")
+		assert.Contains(t, r.Message, `did you mean "log_level"?`, "typos get a nearest-key hint")
+		assert.NotEmpty(t, r.Fix)
+	})
+
+	t.Run("unparseable config warns not fails", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "talon.config.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("not: yaml: ["), 0o600))
+		r := checkConfigKeys(p)
+		assert.Equal(t, "warn", r.Status)
+	})
+}


### PR DESCRIPTION
Closes #351. Part of the [v1.9.3 milestone](https://github.com/dativo-io/talon/milestone/6); implements the approved execution contract in the issue body.

## What

`talon doctor` gains `config_keys_recognized` (category `config`, appended in `checkConfig()` so same-category rendering stays contiguous): it re-reads the viper-loaded config file raw and **WARNs** on any top-level key no loader reads — the root-cause guard for the #342 dead-key class in operator-authored files.

- Known dead keys carry their real surface (`tenants` → agent files per #266, `evidence` → `data_dir`, …); typos get a nearest-key hint (edit distance ≤ 2, deliberately dumb).
- Advisory by construction: only `fail` affects doctor's exit code — verified live (`tenants:` + typo → WARN with hints, exit 0).
- **Single source of truth**: the consumed-key set is extracted to `config.ConsumedTopLevelKeys()`, now shared by this check AND `TestInitPack_GeneratedConfigKeysAreConsumed` — the operator guard and the CI pin cannot drift apart.
- No config file loaded → pass ("defaults/env only"); unreadable/unparseable file → WARN, never fail.

## Verification

- `TestCheckConfigKeys` (4 subtests: no-file, clean, dead-keys-with-hints, unparseable).
- `go test ./internal/doctor ./internal/cmd ./internal/config` — pass.
- Live: doctor output shows the WARN row with hints and `→` fix line; exit 0.