### PR TITLE
fix(mcp): fail-closed method allowlist on the proxy — reject ungoverned MCP methods (#356)

### DIFF
--- a/docs/ARCHITECTURE_MCP_PROXY.md
+++ b/docs/ARCHITECTURE_MCP_PROXY.md
@@ -208,6 +208,14 @@ when unset and both loaders reject values outside
 forbidden tool only under explicit `passthrough`. An unset or mistyped mode
 can never silently behave as passthrough.
 
+**Method surface is fail-closed (#356):** the proxy governs `tools/list` and
+`tools/call` — every other MCP method (`resources/read`, `prompts/get`,
+`initialize`, …) is rejected with JSON-RPC `-32601` and an attributed
+`proxy_method_rejected` evidence record, in **every** mode. This mirrors the
+native `/mcp` server and closes what would otherwise be an unscanned,
+unaudited data lane (an upstream's resources bypassing PII governance).
+Governed resource/prompt reads are a future feature, not a passthrough.
+
 ---
 
 ## Code: Proxy Implementation (design sketch)

--- a/docs/VENDOR_INTEGRATION_GUIDE.md
+++ b/docs/VENDOR_INTEGRATION_GUIDE.md
@@ -182,6 +182,10 @@ Vendor receives data (works normally, unaware of governance layer)
     ↓
 Your compliance officer has a complete audit trail
 
+Note: the proxy governs tools/list and tools/call ONLY. Any other MCP
+method (resources/read, prompts/get, initialize, ...) is rejected
+fail-closed with a signed evidence record — never forwarded ungoverned.
+
 Also: tools/list responses are filtered — the vendor only ever discovers
 tools you listed in allowed_tools.
 ```

--- a/examples/mcp-proxy-minimal/README.md
+++ b/examples/mcp-proxy-minimal/README.md
@@ -25,7 +25,10 @@ http://localhost:8080/mcp/proxy
 ```
 
 Talon intercepts all MCP tool calls, scans for PII, checks against
-allowed/forbidden tool lists, and generates evidence records.
+allowed/forbidden tool lists, and generates evidence records. The proxy
+governs `tools/list` and `tools/call` only — any other MCP method
+(`resources/read`, `prompts/get`, …) is rejected fail-closed with an
+evidence record, never forwarded ungoverned.
 
 ## What's in the Config
 

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -226,7 +226,16 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "tools/call":
 		resp = h.handleProxyToolCall(ctx, &req, inv)
 	default:
-		resp = h.forwardRequest(ctx, body, &req)
+		// Fail-closed method allowlist (#356): the proxy governs tools/list
+		// and tools/call; every other MCP method is rejected with evidence,
+		// mirroring the native /mcp server's -32601. Forwarding ungoverned
+		// methods (resources/read, prompts/get) would open an unscanned,
+		// unaudited data lane through the governance proxy.
+		h.recordEvidence(ctx, inv, "proxy_method_rejected", req.Method, "unsupported_method:"+req.Method, nil, nil)
+		resp = &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{
+			Code:    codeMethodNotFound,
+			Message: "method not found: " + req.Method + " (the proxy governs tools/list and tools/call only)",
+		}}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -907,7 +916,7 @@ func proxyExplanationFacts(eventType, reason, toolName string, allowed bool) []e
 		trigger = strings.TrimSpace(toolName)
 	}
 	switch eventType {
-	case "proxy_tool_blocked":
+	case "proxy_tool_blocked", "proxy_method_rejected":
 		return []explanation.Fact{{
 			Code:     explanation.CodePolicyDeniedTool,
 			Decision: explanation.DecisionDeny,

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -369,37 +369,54 @@ func TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords(t *testing.T) {
 // TestProxyUnknownMethod_RejectedFailClosed pins #356: the proxy governs
 // tools/list and tools/call only; any other MCP method (resources/read,
 // prompts/get, initialize, ...) is rejected with -32601 and an attributed
-// deny record — never forwarded ungoverned, mirroring the native /mcp server.
+// deny record — never forwarded ungoverned, mirroring the native /mcp
+// server. The contract is mode-INDEPENDENT: passthrough and shadow reject
+// exactly like intercept ("in every mode" is the documented surface, and
+// "passthrough forwards everything" must never grow to cover methods).
 func TestProxyUnknownMethod_RejectedFailClosed(t *testing.T) {
-	hit := false
-	up := attribUpstream(t, &hit)
-	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+	methods := []string{"resources/read", "prompts/get", "initialize"}
+	for _, mode := range []string{policy.ProxyModeIntercept, policy.ProxyModePassthrough, policy.ProxyModeShadow} {
+		t.Run(mode, func(t *testing.T) {
+			hit := false
+			up := attribUpstream(t, &hit)
+			h, store := attribHandler(t, mode, up.URL, nil)
 
-	for _, method := range []string{"resources/read", "prompts/get", "initialize"} {
-		body, _ := json.Marshal(map[string]interface{}{
-			"jsonrpc": "2.0", "id": 7, "method": method,
-			"params": map[string]interface{}{"uri": "file:///etc/passwd"},
+			for _, method := range methods {
+				body, _ := json.Marshal(map[string]interface{}{
+					"jsonrpc": "2.0", "id": 7, "method": method,
+					"params": map[string]interface{}{"uri": "file:///etc/passwd"},
+				})
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, req)
+				var resp jsonrpcResponse
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+				require.NotNil(t, resp.Error, "method %s must be rejected in mode %s", method, mode)
+				assert.Equal(t, codeMethodNotFound, resp.Error.Code)
+				assert.Contains(t, resp.Error.Message, method)
+			}
+			assert.False(t, hit, "ungoverned methods must never reach the upstream (mode %s)", mode)
+
+			records := listRecords(t, store, "default")
+			require.Len(t, records, len(methods), "each rejection is the request's terminal record")
+			gotReasons := make([]string, 0, len(records))
+			for _, r := range records {
+				assert.Equal(t, "proxy_method_rejected", r.InvocationType)
+				assert.False(t, r.PolicyDecision.Allowed)
+				assert.Equal(t, "vendor-proxy-agent", r.AgentID, "rejections carry full #350 attribution")
+				require.NotEmpty(t, r.PolicyDecision.Reasons, "deny records must name their reason")
+				gotReasons = append(gotReasons, r.PolicyDecision.Reasons[0])
+				primary, ok := explanation.Primary(r.Explanations)
+				require.True(t, ok)
+				assert.Equal(t, explanation.CodePolicyDeniedTool, primary.Code)
+			}
+			wantReasons := make([]string, 0, len(methods))
+			for _, m := range methods {
+				wantReasons = append(wantReasons, "unsupported_method:"+m)
+			}
+			assert.ElementsMatch(t, wantReasons, gotReasons,
+				"every rejection reason names the rejected method")
 		})
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
-		var resp jsonrpcResponse
-		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		require.NotNil(t, resp.Error, "method %s must be rejected", method)
-		assert.Equal(t, codeMethodNotFound, resp.Error.Code)
-		assert.Contains(t, resp.Error.Message, method)
-	}
-	assert.False(t, hit, "ungoverned methods must never reach the upstream")
-
-	records := listRecords(t, store, "default")
-	require.Len(t, records, 3, "each rejection is the request's terminal record")
-	for _, r := range records {
-		assert.Equal(t, "proxy_method_rejected", r.InvocationType)
-		assert.False(t, r.PolicyDecision.Allowed)
-		assert.Equal(t, "vendor-proxy-agent", r.AgentID, "rejections carry full #350 attribution")
-		primary, ok := explanation.Primary(r.Explanations)
-		require.True(t, ok)
-		assert.Equal(t, explanation.CodePolicyDeniedTool, primary.Code)
 	}
 }
 

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -366,6 +366,43 @@ func TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords(t *testing.T) {
 	assert.Equal(t, corr, rec.Header().Get("X-Correlation-ID"), "generated correlation is echoed to the caller")
 }
 
+// TestProxyUnknownMethod_RejectedFailClosed pins #356: the proxy governs
+// tools/list and tools/call only; any other MCP method (resources/read,
+// prompts/get, initialize, ...) is rejected with -32601 and an attributed
+// deny record — never forwarded ungoverned, mirroring the native /mcp server.
+func TestProxyUnknownMethod_RejectedFailClosed(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, store := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+
+	for _, method := range []string{"resources/read", "prompts/get", "initialize"} {
+		body, _ := json.Marshal(map[string]interface{}{
+			"jsonrpc": "2.0", "id": 7, "method": method,
+			"params": map[string]interface{}{"uri": "file:///etc/passwd"},
+		})
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		var resp jsonrpcResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Error, "method %s must be rejected", method)
+		assert.Equal(t, codeMethodNotFound, resp.Error.Code)
+		assert.Contains(t, resp.Error.Message, method)
+	}
+	assert.False(t, hit, "ungoverned methods must never reach the upstream")
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 3, "each rejection is the request's terminal record")
+	for _, r := range records {
+		assert.Equal(t, "proxy_method_rejected", r.InvocationType)
+		assert.False(t, r.PolicyDecision.Allowed)
+		assert.Equal(t, "vendor-proxy-agent", r.AgentID, "rejections carry full #350 attribution")
+		primary, ok := explanation.Primary(r.Explanations)
+		require.True(t, ok)
+		assert.Equal(t, explanation.CodePolicyDeniedTool, primary.Code)
+	}
+}
+
 // TestProxyInvalidAttributionHeader_Rejected400 pins the hygiene contract
 // shared with the gateway: an oversized or non-token session header is
 // rejected with HTTP 400 before any evidence is written.


### PR DESCRIPTION
Closes #356. Part of the [v1.9.3 milestone](https://github.com/dativo-io/talon/milestone/6); implements the approved execution contract in the issue body.

## What

The proxy's `default:` dispatch arm forwarded **any** non-tools MCP method (`resources/read`, `prompts/get`, `initialize`, arbitrary strings) verbatim to the upstream with no policy, no PII scanning, and no evidence — the last ungoverned lane on the proxy wire. `resources/read` returns document content: exactly the PII egress surface the proxy exists to govern.

The proxy now governs `tools/list` and `tools/call` only. Every other method is rejected in **every mode** with JSON-RPC `-32601` (mirroring the native `/mcp` server, which has always rejected them) plus an attributed `proxy_method_rejected` deny record carrying `POLICY_DENIED_TOOL` and the `unsupported_method:<method>` reason.

## Why nothing breaks (from the v1.9.3 mapping)

- Zero in-repo usage of any non-tools method against either endpoint (tests, examples, docs, smoke sections — exhaustive grep).
- Stateful streamable-HTTP through the proxy was already broken: session headers are dropped in both directions, so forwarding `initialize` produced a silently broken, ungoverned session.
- The native server's `-32601` shape is preserved (HTTP 200 JSON-RPC error body — what the smoke tests parse).

## Adversarial review (worktree-isolated)

Two mutation-verified coverage findings, both fixed in-branch: the rejection is now pinned across **all three modes** (a "passthrough forwards everything" regression would have merged green and reopened the hole in two of three modes), and the deny reasons are asserted per method.

Docs (`ARCHITECTURE_MCP_PROXY.md`, vendor guide, minimal example) state the governed method surface; the pre-existing notifications spec deviation found during mapping is filed as #363.

## Verification

`go test ./internal/mcp ./internal/server ./internal/evidence` + `go test -tags integration -count=1 ./tests/integration` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)