### PR TITLE
fix(evidence): one call = one request-class record; truthful upstream-failure trail; closed stage set (#357, #360)

### DIFF
--- a/internal/agent/graphadapter/adapter.go
+++ b/internal/agent/graphadapter/adapter.go
@@ -359,7 +359,7 @@ func (a *Adapter) handleRunEnd(ctx context.Context, span trace.Span, ev *Event) 
 			facts = append(facts, explanation.Fact{
 				Code:     explanation.CodePolicyDenied,
 				Decision: explanation.DecisionDeny,
-				Stage:    "graph_governance",
+				Stage:    explanation.StageGraphGovernance,
 				Trigger:  reason,
 			})
 		}
@@ -367,7 +367,7 @@ func (a *Adapter) handleRunEnd(ctx context.Context, span trace.Span, ev *Event) 
 		facts = []explanation.Fact{{
 			Code:     explanation.CodeGraphRunAllowed,
 			Decision: explanation.DecisionAllow,
-			Stage:    "graph_governance",
+			Stage:    explanation.StageGraphGovernance,
 		}}
 	}
 

--- a/internal/explanation/stages.go
+++ b/internal/explanation/stages.go
@@ -8,6 +8,11 @@ const (
 	StageOutputValidation = "output_validation"
 	StagePreExecution     = "pre_execution"
 	StageExecution        = "execution"
+	// StageGraphGovernance is the graph-adapter governance gate (#360):
+	// registered additively — remapping the graphadapter facts onto an
+	// existing stage would reorder Primary() selection (sorted by Stage
+	// first) on existing evidence displays.
+	StageGraphGovernance = "graph_governance"
 )
 
 var stageAliases = map[string]string{
@@ -29,7 +34,7 @@ func CanonicalStage(stage string) string {
 // IsKnownStage reports whether stage is part of the canonical stage set.
 func IsKnownStage(stage string) bool {
 	switch CanonicalStage(stage) {
-	case StagePolicyEvaluation, StageToolExecution, StageOutputValidation, StagePreExecution, StageExecution:
+	case StagePolicyEvaluation, StageToolExecution, StageOutputValidation, StagePreExecution, StageExecution, StageGraphGovernance:
 		return true
 	default:
 		return false

--- a/internal/explanation/stages_pin_test.go
+++ b/internal/explanation/stages_pin_test.go
@@ -1,0 +1,41 @@
+package explanation
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestAllEmittedStageLiteralsKnown pins #360: the explanation stage set is
+// CLOSED — every quoted `Stage: "..."` literal anywhere in production code
+// must pass IsKnownStage, so a new emitter cannot introduce an unregistered
+// stage that sorts into its own bucket and escapes stage-filtered consumers
+// (same discipline as the evidence record-class registry).
+func TestAllEmittedStageLiteralsKnown(t *testing.T) {
+	root := filepath.Join("..", "..")
+	stageLit := regexp.MustCompile(`Stage:\s*"([a-z_]+)"`)
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range stageLit.FindAllStringSubmatch(string(raw), -1) {
+			if !IsKnownStage(m[1]) {
+				t.Errorf("%s emits unregistered explanation stage %q — register it in stages.go or use a canonical constant", path, m[1])
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking source tree: %v", err)
+	}
+}

--- a/internal/explanation/stages_pin_test.go
+++ b/internal/explanation/stages_pin_test.go
@@ -8,6 +8,19 @@ import (
 	"testing"
 )
 
+// TestGraphGovernanceStageRegistered pins the #360 registration directly:
+// the literal-walking test below is blind to CONSTANT usages (the same diff
+// converted graphadapter's literals to StageGraphGovernance), so removing
+// the stage from IsKnownStage must fail here, not merge green.
+func TestGraphGovernanceStageRegistered(t *testing.T) {
+	if !IsKnownStage(StageGraphGovernance) {
+		t.Fatal("StageGraphGovernance must be part of the canonical stage set")
+	}
+	if !IsKnownStage("graph_governance") {
+		t.Fatal(`the "graph_governance" literal must remain a known stage`)
+	}
+}
+
 // TestAllEmittedStageLiteralsKnown pins #360: the explanation stage set is
 // CLOSED — every quoted `Stage: "..."` literal anywhere in production code
 // must pass IsKnownStage, so a new emitter cannot introduce an unregistered

--- a/internal/mcp/openclaw_incident_test.go
+++ b/internal/mcp/openclaw_incident_test.go
@@ -193,21 +193,23 @@ func TestProxy_PIIInArgumentsBlocked(t *testing.T) {
 		assert.Contains(t, r.Error.Message, "PII",
 			"PII in arguments should trigger a block in intercept mode")
 	} else {
-		// PII detection may not block if EvaluateProxyPII allows (depends on rego).
-		// Verify evidence was at least recorded.
+		// PII detection may not block if EvaluateProxyPII allows (depends on
+		// rego). Since #357 the allowed path writes NO separate note record —
+		// the request-side PII classification rides on the call's terminal
+		// record (one call = one request-class record).
 		records, err := store.List(context.Background(), "test-tenant", "",
 			time.Time{}, time.Time{}, 10)
 		require.NoError(t, err)
 		piiRecorded := false
 		for _, ev := range records {
-			if ev.InvocationType == "proxy_pii_request_detected" {
+			if len(ev.Classification.PIIDetected) > 0 {
 				require.NotEmpty(t, ev.Explanations, "proxy evidence should include deterministic explanations")
 				assert.NotEmpty(t, ev.Explanations[0].Code)
 				piiRecorded = true
 			}
 		}
 		assert.True(t, piiRecorded,
-			"PII in proxy arguments must at minimum generate an evidence record")
+			"PII in proxy arguments must at minimum land in the terminal record's classification")
 	}
 }
 

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -401,7 +401,10 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				proxyInput.Arguments = paramsToMap(params.Arguments)
 				flow.requestRedacted = true
 			}
-			h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "", &flow, nil)
+			// #357: no separate allowed "note" record here — the request-side
+			// classification and data flow ride on the call's terminal record
+			// (one call = one request-class record). Denied PII paths above
+			// keep their own terminal records.
 		}
 	}
 
@@ -416,11 +419,16 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
+		// #357: with the PII note folded into the terminal record, the
+		// upstream-failure path must still leave the call's trail —
+		// including any request-side PII classification in flow.
+		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_error: "+err.Error(), &flow, nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
 	}
 	defer upstreamResp.Body.Close()
 	var out jsonrpcResponse
 	if err := json.NewDecoder(upstreamResp.Body).Decode(&out); err != nil {
+		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_response_invalid", &flow, nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "upstream response invalid"}}
 	}
 	out.ID = req.ID
@@ -754,13 +762,16 @@ func (h *ProxyHandler) upstreamEndpointHost() string {
 // for those. A shadow violation is an ALLOWED record — the call was forwarded
 // — with the would-have-denied verdict carried in ShadowViolations +
 // ObservationModeOverride (#346), matching the gateway's shadow vocabulary.
+// An upstream error is likewise ALLOWED (policy permitted the call; the
+// vendor failed): counting it as a deny would inflate the attention queue's
+// denial rate on vendor outages — the failure lives in Status/FailureReason.
 func proxyRecordAllowed(eventType, reason string, flow *proxyFlowState) bool {
 	if flow != nil && (flow.requestBlocked || flow.responseBlocked) {
 		return false
 	}
 	return eventType == "proxy_tool_call" ||
 		eventType == "proxy_shadow_violation" ||
-		(eventType == "proxy_pii_request_detected" && reason == "")
+		eventType == "proxy_upstream_error"
 }
 
 // attachProxyFlow copies the flow's classification and data-flow sections
@@ -823,6 +834,14 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, inv *proxyInvocation,
 	// PolicyDecision.Reasons.
 	if !allowed {
 		ev.Execution.Error = reason
+	}
+	// Upstream failures (#357) are policy-ALLOWED records whose execution
+	// failed: the error must count in session summaries, and the failure is
+	// typed in Status/FailureReason rather than faking a policy deny.
+	if eventType == "proxy_upstream_error" {
+		ev.Execution.Error = reason
+		ev.Status = "failed"
+		ev.FailureReason = "upstream_error"
 	}
 	if sv != nil {
 		ev.ObservationModeOverride = true
@@ -940,6 +959,13 @@ func proxyExplanationFacts(eventType, reason, toolName string, allowed bool) []e
 			Code:     explanation.CodeExecutionFailed,
 			Decision: explanation.DecisionFailure,
 			Stage:    explanation.StagePolicyEvaluation,
+			Trigger:  trigger,
+		}}
+	case "proxy_upstream_error":
+		return []explanation.Fact{{
+			Code:     explanation.CodeExecutionFailed,
+			Decision: explanation.DecisionFailure,
+			Stage:    explanation.StageToolExecution,
 			Trigger:  trigger,
 		}}
 	case "proxy_pii_request_detected":

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -421,17 +422,30 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		span.SetStatus(codes.Error, err.Error())
 		// #357: with the PII note folded into the terminal record, the
 		// upstream-failure path must still leave the call's trail —
-		// including any request-side PII classification in flow.
+		// including any request-side PII classification in flow. Transport
+		// errors mean egress is UNCONFIRMED (connection refused = nothing
+		// left; timeout = maybe): the signed record keeps the classification
+		// but must not assert a data flow to the vendor that may never have
+		// happened.
+		flow.egressUnconfirmed = true
 		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_error: "+err.Error(), &flow, nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
 	}
 	defer upstreamResp.Body.Close()
 	var out jsonrpcResponse
 	if err := json.NewDecoder(upstreamResp.Body).Decode(&out); err != nil {
+		// A response arrived, so egress happened — the flow item is truthful.
 		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_response_invalid", &flow, nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "upstream response invalid"}}
 	}
 	out.ID = req.ID
+	if out.Error != nil {
+		// The vendor answered with a JSON-RPC error: the call executed and
+		// failed — record it as such, never as a clean allowed completion.
+		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName,
+			fmt.Sprintf("upstream_jsonrpc_error: %d %s", out.Error.Code, out.Error.Message), &flow, nil)
+		return &out
+	}
 
 	// Response PII scanning: scan tool result before returning to caller.
 	// A scanner failure blocks the result fail-closed.
@@ -735,6 +749,11 @@ type proxyFlowState struct {
 	// status, decode, validation) when a scanner failure drove a block;
 	// "scanner_unavailable" for non-adapter engines.
 	scannerFailure string
+	// egressUnconfirmed marks upstream TRANSPORT failures (#357 review):
+	// classification still attaches to the record, but no data-flow item is
+	// emitted — a signed flow entry must never assert delivery to the vendor
+	// when the connection may never have been established.
+	egressUnconfirmed bool
 }
 
 // upstreamRegion returns the configured jurisdiction of the upstream vendor
@@ -784,6 +803,11 @@ func (h *ProxyHandler) attachProxyFlow(ev *evidence.Evidence, inv *proxyInvocati
 		OutputPIIDetected: len(flow.responseEntities) > 0,
 		OutputPIITypes:    entityTypeSet(flow.responseEntities),
 		PIIRedacted:       flow.responseRedacted,
+	}
+	if flow.egressUnconfirmed {
+		// Transport failure (#357 review): no flow item — a signed data-flow
+		// entry must never assert delivery the wire may not have made.
+		return
 	}
 	ev.DataFlow = h.buildProxyDataFlow(inv.tenantID, inv.correlationID, toolName, flow)
 	if ev.DataFlow != nil {

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -431,6 +431,82 @@ func TestProxyUpstreamError_RecordsTrail(t *testing.T) {
 	assert.NotEmpty(t, r.Execution.Error, "execution failure must count in session summaries")
 	assert.Contains(t, r.Classification.PIIDetected, "email",
 		"the request-side PII trail survives the upstream failure")
+	assert.Nil(t, r.DataFlow,
+		"transport failure: a signed flow item must never assert delivery the wire may not have made")
+}
+
+// upstreamErrorHandler builds an intercept proxy with a redaction rule whose
+// upstream is the given httptest handler — for the non-transport failure shapes.
+func upstreamErrorHandler(t *testing.T, upstream http.HandlerFunc) (*ProxyHandler, *evidence.Store) {
+	t.Helper()
+	srv := httptest.NewServer(upstream)
+	t.Cleanup(srv.Close)
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode:         policy.ProxyModeIntercept,
+			Upstream:     policy.UpstreamConfig{URL: srv.URL, Vendor: "testvendor"},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+		PIIHandling: policy.PIIHandlingConfig{
+			RedactionRules: []policy.RedactionRule{{Field: "email", Method: "hash"}},
+		},
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner()), store
+}
+
+// TestProxyUpstreamDecodeFailure_RecordsTrail pins the second upstream-error
+// shape (#357 review): a 200 with a non-JSON body. Egress DID happen, so the
+// record keeps its data-flow item, unlike the transport case.
+func TestProxyUpstreamDecodeFailure_RecordsTrail(t *testing.T) {
+	h, store := upstreamErrorHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>gateway timeout</html>"))
+	})
+
+	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
+		map[string]string{"email": "jane.doe@example.com"})
+	require.NotNil(t, resp.Error)
+	assert.Contains(t, resp.Error.Message, "upstream response invalid")
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	r := records[0]
+	assert.Equal(t, "proxy_upstream_error", r.InvocationType)
+	assert.Equal(t, "failed", r.Status)
+	assert.Contains(t, r.PolicyDecision.Reasons, "upstream_response_invalid")
+	assert.Contains(t, r.Classification.PIIDetected, "email")
+	require.NotNil(t, r.DataFlow, "a response arrived, so the egress flow item is truthful and must stay")
+}
+
+// TestProxyUpstreamJSONRPCError_RecordsFailure pins the third shape (#357
+// review): the vendor answers with a valid JSON-RPC error body. The call
+// executed and failed — it must never be recorded as a clean allowed
+// completion, and the vendor's error passes through to the caller.
+func TestProxyUpstreamJSONRPCError_RecordsFailure(t *testing.T) {
+	h, store := upstreamErrorHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"internal error"}}`))
+	})
+
+	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
+		map[string]string{"email": "jane.doe@example.com"})
+	require.NotNil(t, resp.Error, "the vendor's JSON-RPC error passes through")
+	assert.Equal(t, -32603, resp.Error.Code)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	r := records[0]
+	assert.Equal(t, "proxy_upstream_error", r.InvocationType)
+	assert.Equal(t, "failed", r.Status)
+	require.NotEmpty(t, r.PolicyDecision.Reasons)
+	assert.Contains(t, r.PolicyDecision.Reasons[0], "upstream_jsonrpc_error")
+	assert.NotEmpty(t, r.Execution.Error)
 }
 
 // TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords pins the #350

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -327,10 +327,17 @@ func TestProxyShadow_PIIWouldDeny_RecordsShadowViolation(t *testing.T) {
 	assert.True(t, hit)
 
 	records := listRecords(t, store, "default")
-	var sv *evidence.Evidence
+	// #357: exactly TWO records — the shadow violation (non-request class)
+	// and the terminal proxy_tool_call. The old separate allowed PII "note"
+	// is folded into the terminal record.
+	require.Len(t, records, 2, "shadow PII call = shadow violation + ONE terminal record")
+	var sv, terminal *evidence.Evidence
 	for i := range records {
-		if records[i].InvocationType == "proxy_shadow_violation" {
+		switch records[i].InvocationType {
+		case "proxy_shadow_violation":
 			sv = &records[i]
+		case "proxy_tool_call":
+			terminal = &records[i]
 		}
 		if records[i].PolicyDecision.Allowed {
 			assert.Empty(t, records[i].Execution.Error,
@@ -342,6 +349,88 @@ func TestProxyShadow_PIIWouldDeny_RecordsShadowViolation(t *testing.T) {
 	assert.Equal(t, "pii_block", sv.ShadowViolations[0].Type)
 	assert.True(t, sv.ObservationModeOverride)
 	assert.Equal(t, "sess-pii-1", sv.SessionID)
+	require.NotNil(t, terminal, "the terminal record must exist")
+	assert.Contains(t, terminal.Classification.PIIDetected, "email",
+		"#357 fold: request-side PII classification rides on the terminal record")
+}
+
+// TestProxyPIIAllowed_OneRequestClassRecord pins the #357 fold directly:
+// an ALLOWED PII-bearing call in intercept mode (redaction rules present)
+// produces exactly ONE record, carrying the request-side classification and
+// data flow that used to live on the separate note record.
+func TestProxyPIIAllowed_OneRequestClassRecord(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode:         policy.ProxyModeIntercept,
+			Upstream:     policy.UpstreamConfig{URL: up.URL, Vendor: "testvendor"},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+		// Redaction rule present -> rego proxy_pii_redaction allows the call.
+		PIIHandling: policy.PIIHandlingConfig{
+			RedactionRules: []policy.RedactionRule{{Field: "email", Method: "hash"}},
+		},
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+
+	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
+		map[string]string{"email": "jane.doe@example.com"})
+	require.Nil(t, resp.Error)
+	assert.True(t, hit)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1, "#357: one allowed PII call = ONE request-class record (was two)")
+	r := records[0]
+	assert.Equal(t, "proxy_tool_call", r.InvocationType)
+	assert.True(t, r.PolicyDecision.Allowed)
+	assert.Contains(t, r.Classification.PIIDetected, "email")
+	require.NotNil(t, r.DataFlow, "request-side data flow must ride on the terminal record")
+}
+
+// TestProxyUpstreamError_RecordsTrail pins #357 accompaniment 3: a call whose
+// upstream fails must still leave its evidence trail — a policy-ALLOWED
+// record with Status failed, carrying the request-side PII classification.
+func TestProxyUpstreamError_RecordsTrail(t *testing.T) {
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode: policy.ProxyModeIntercept,
+			// Closed port: the upstream request fails.
+			Upstream:     policy.UpstreamConfig{URL: "http://127.0.0.1:1", Vendor: "testvendor"},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+		PIIHandling: policy.PIIHandlingConfig{
+			RedactionRules: []policy.RedactionRule{{Field: "email", Method: "hash"}},
+		},
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+
+	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
+		map[string]string{"email": "jane.doe@example.com"})
+	require.NotNil(t, resp.Error, "upstream failure surfaces as a JSON-RPC error")
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1, "the upstream failure is the call's terminal record")
+	r := records[0]
+	assert.Equal(t, "proxy_upstream_error", r.InvocationType)
+	assert.True(t, r.PolicyDecision.Allowed, "policy allowed the call; the vendor failed — not a deny")
+	assert.Equal(t, "failed", r.Status)
+	assert.Equal(t, "upstream_error", r.FailureReason)
+	assert.NotEmpty(t, r.Execution.Error, "execution failure must count in session summaries")
+	assert.Contains(t, r.Classification.PIIDetected, "email",
+		"the request-side PII trail survives the upstream failure")
 }
 
 // TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords pins the #350


### PR DESCRIPTION
Closes #357. Closes #360. Part of the [v1.9.3 milestone](https://github.com/dativo-io/talon/milestone/6); implements the approved execution contracts in both issue bodies.

## #357 — the fold

The ALLOWED `proxy_pii_request_detected` "note" record is gone: its request-side classification and data flow already ride on the call's terminal `proxy_tool_call` record, so **one PII-carrying allowed call now produces ONE request-class record** (was two), correcting `talon agents` traffic counts and session summaries. The three DENIED PII emissions are untouched (pinned by dataflow_test). The latent else-branch in `openclaw_incident_test` now asserts the folded shape.

## Upstream failures: a truthful trail for all three shapes

The fold made the previously-unrecorded upstream-error paths load-bearing. The worktree-isolated adversarial review caught two truth defects in my first cut, both fixed:

| Failure shape | Record | Data-flow item |
|---|---|---|
| Transport error (refused/timeout) | `proxy_upstream_error`, `Status: failed` | **suppressed** — a signed flow item must never assert delivery the wire may not have made (confirmed 2-0) |
| 200 + non-JSON body | same (`upstream_response_invalid`) | kept — a response arrived, egress happened |
| Valid JSON-RPC error body | same (`upstream_jsonrpc_error: <code>`); vendor's error passes through | kept |

All three are policy-ALLOWED records (a vendor outage must not inflate the attention queue's denial rate) with `Execution.Error` set so session summaries count them, `FailureReason: upstream_error`. Each shape has its own pinning test.

## #360 — closed stage set

`graph_governance` registered as a canonical explanation stage (additive — remapping would reorder `Primary()` selection); graphadapter uses the constant. Two pins: the source-walking literal test plus a direct unit test for the constant registration (the review proved the walker alone was blind to constant usages).

## Breaking note (for the v1.9.3 changelog)

Observable counts change: one PII-carrying allowed call = one request-class record; upstream failures now produce records where none existed.

## Verification

Full local surface + `go test -tags integration -count=1 ./tests/integration` — pass.