### PR TITLE
feat(serve)+docs: --gateway-mode override; canonical verify-a-running-gateway snippet (#368, #370)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,6 +60,15 @@ talon run "Your query here"
 # Server (API + dashboard + optional gateway/proxy)
 export TALON_ADMIN_KEY="replace-with-strong-admin-key"
 talon serve --port 8080
+
+# Verify a RUNNING server: which agents is it actually serving? (#370)
+# An explicit --url is authoritative — it errors rather than silently
+# falling back to a local config view; --json for scripting.
+talon agents --url http://localhost:8080
+talon agents --url http://localhost:8080 --json
+
+# Flip gateway enforcement without editing YAML (#368)
+talon serve --gateway --gateway-mode shadow    # or: enforce
 ```
 
 Verify the cold-start path from repo root: `make verify-newcomer`.

--- a/docs/guides/claude-code-integration.md
+++ b/docs/guides/claude-code-integration.md
@@ -66,7 +66,14 @@ gateway provider "anthropic": upstream_auth_mode client_bearer is not supported 
 
 ### 3. Confirm the gateway is running
 
-Leave `talon serve --gateway` running. Optional: test with curl (the agent key is accepted as `Authorization: Bearer` or as `x-api-key` — `extractKey` in `internal/gateway/resolve.go` checks both):
+Leave `talon serve --gateway` running. The canonical check — which agents is
+the server actually serving right now:
+
+```bash
+talon agents --url http://localhost:8080   # RUNTIME fleet view; --json to script it
+```
+
+Optional: test with curl (the agent key is accepted as `Authorization: Bearer` or as `x-api-key` — `extractKey` in `internal/gateway/resolve.go` checks both):
 
 ```bash
 curl -s -X POST http://localhost:8080/v1/proxy/anthropic/v1/messages \

--- a/docs/guides/codex-cli-integration.md
+++ b/docs/guides/codex-cli-integration.md
@@ -66,7 +66,14 @@ Codex presents its agent key; Talon resolves it to the `codex` agent (and its de
 
 ### 3. Confirm the gateway is running
 
-Leave `talon serve --gateway` running. Optional: test the Responses route with curl:
+Leave `talon serve --gateway` running. The canonical check — which agents is
+the server actually serving right now:
+
+```bash
+talon agents --url http://localhost:8080   # RUNTIME fleet view; --json to script it
+```
+
+Optional: test the Responses route with curl:
 
 ```bash
 curl -s -X POST http://localhost:8080/v1/proxy/openai/v1/responses \

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -50,6 +50,7 @@ var (
 	serveDashboard       bool
 	serveGateway         bool
 	serveGatewayConfig   string
+	serveGatewayMode     string
 	serveProxyQuickstart bool
 	serveUnsafeListen    bool
 )
@@ -67,6 +68,7 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveDashboard, "dashboard", true, "Serve embedded dashboard at / and /dashboard")
 	serveCmd.Flags().BoolVar(&serveGateway, "gateway", false, "Enable LLM API gateway at /v1/proxy/*")
 	serveCmd.Flags().StringVar(&serveGatewayConfig, "gateway-config", "talon.config.yaml", "Path to config file with gateway block (used when --gateway is set)")
+	serveCmd.Flags().StringVar(&serveGatewayMode, "gateway-mode", "", "Override gateway.mode from the config file (shadow|enforce|log_only) — no YAML editing needed to flip modes")
 	serveCmd.Flags().BoolVar(&serveProxyQuickstart, "proxy-quickstart", false, "Enable local/dev OpenAI-compatible quickstart proxy at host-root /v1/*")
 	serveCmd.Flags().BoolVar(&serveUnsafeListen, "unsafe-listen", false, "Allow --proxy-quickstart to bind non-loopback addresses")
 	rootCmd.AddCommand(serveCmd)
@@ -80,6 +82,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	gatewayConfigExplicit := cmd.Flags().Changed("gateway-config")
 	if err := validateServeModeFlags(serveProxyQuickstart, serveGateway, gatewayConfigExplicit); err != nil {
 		return err
+	}
+	// --gateway-mode (#368) is validated BEFORE any file loads so a typo or
+	// missing --gateway fails immediately with the flag error, not a
+	// config-load error.
+	if serveGatewayMode != "" {
+		if !serveGateway {
+			return fmt.Errorf("--gateway-mode requires --gateway")
+		}
+		if _, err := resolveGatewayModeOverride(serveGatewayMode); err != nil {
+			return err
+		}
 	}
 
 	cfg, err := config.Load()
@@ -140,6 +153,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 		preloadedGatewayCfg, err = gateway.LoadGatewayConfig(serveGatewayConfig)
 		if err != nil {
 			return fmt.Errorf("loading gateway config for sovereignty: %w", err)
+		}
+		// --gateway-mode (#368): a validated runtime override so flipping
+		// shadow<->enforce never requires YAML surgery (the downstream class
+		// of hand-edited config bugs this kills is real). The flag is
+		// authoritative over the file value and the override is logged.
+		// (Value already validated at the top of runServe.)
+		if serveGatewayMode != "" {
+			mode, _ := resolveGatewayModeOverride(serveGatewayMode)
+			if preloadedGatewayCfg.Mode != "" && preloadedGatewayCfg.Mode != mode {
+				log.Info().
+					Str("file_mode", string(preloadedGatewayCfg.Mode)).
+					Str("flag_mode", string(mode)).
+					Msg("gateway_mode_override")
+			}
+			preloadedGatewayCfg.Mode = mode
 		}
 	}
 	sovereignty.ApplySovereigntyGate(cfg, preloadedGatewayCfg)
@@ -1002,6 +1030,18 @@ func gatewayCostEstimator(pricingTable *pricing.PricingTable) gateway.CostEstima
 		}
 		return gateway.CostResult{Amount: cost, PricingKnown: true, PricingBasis: basis}
 	}
+}
+
+// resolveGatewayModeOverride validates the --gateway-mode flag value (#368):
+// only the three declared gateway modes are accepted — a typo must fail
+// startup loudly, never silently run a different enforcement posture.
+func resolveGatewayModeOverride(flag string) (gateway.Mode, error) {
+	mode := gateway.Mode(flag)
+	switch mode {
+	case gateway.ModeShadow, gateway.ModeEnforce, gateway.ModeLogOnly:
+		return mode, nil
+	}
+	return "", fmt.Errorf("--gateway-mode %q is invalid; use shadow, enforce, or log_only", flag)
 }
 
 // validateServeModeFlags enforces mutual exclusivity between the quickstart

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -67,6 +67,24 @@ func TestMapToGatewayEvent_DefaultTimestampWhenMissing(t *testing.T) {
 	assert.Equal(t, "test", got.AgentName)
 }
 
+// TestResolveGatewayModeOverride pins #368: only the three declared gateway
+// modes are accepted; a typo fails startup loudly instead of silently running
+// a different enforcement posture.
+func TestResolveGatewayModeOverride(t *testing.T) {
+	for _, valid := range []string{"shadow", "enforce", "log_only"} {
+		mode, err := resolveGatewayModeOverride(valid)
+		assert.NoError(t, err)
+		assert.Equal(t, valid, string(mode))
+	}
+	for _, invalid := range []string{"Shadow", "observe", "enforcee", ""} {
+		_, err := resolveGatewayModeOverride(invalid)
+		assert.Error(t, err, "mode %q must be rejected", invalid)
+		if err != nil {
+			assert.Contains(t, err.Error(), "--gateway-mode")
+		}
+	}
+}
+
 func TestValidateServeModeFlags(t *testing.T) {
 	// Not in quickstart mode: any combination is fine.
 	assert.NoError(t, validateServeModeFlags(false, false, false))


### PR DESCRIPTION
Closes #368. Closes #370. v1.9.3 milestone; both from real-integrator feedback.

- **`--gateway-mode shadow|enforce|log_only`**: validated runtime override of `gateway.mode` — no more YAML surgery to flip enforcement (the class of downstream hand-edit bugs this kills produced a shadow-named config that actually ran enforce). Validation runs before any file loads; verified live: missing `--gateway` and typo'd values fail immediately with the flag error. Override logged (`gateway_mode_override file=… flag=…`). Pinned by `TestResolveGatewayModeOverride`.
- **Verify-a-running-gateway docs**: `talon agents --url` existed with exactly the right semantics but no doc showed it (the integrator confabulated the syntax — the evidence of the gap). QUICKSTART + both coding-agent guides now carry the canonical snippet.