### PR TITLE
fix(mcp): answer the mandatory MCP initialize handshake locally; stable denial codes in error.data (#367, #369)

### DIFF
--- a/docs/ARCHITECTURE_MCP_PROXY.md
+++ b/docs/ARCHITECTURE_MCP_PROXY.md
@@ -208,13 +208,30 @@ when unset and both loaders reject values outside
 forbidden tool only under explicit `passthrough`. An unset or mistyped mode
 can never silently behave as passthrough.
 
-**Method surface is fail-closed (#356):** the proxy governs `tools/list` and
-`tools/call` — every other MCP method (`resources/read`, `prompts/get`,
-`initialize`, …) is rejected with JSON-RPC `-32601` and an attributed
-`proxy_method_rejected` evidence record, in **every** mode. This mirrors the
-native `/mcp` server and closes what would otherwise be an unscanned,
-unaudited data lane (an upstream's resources bypassing PII governance).
-Governed resource/prompt reads are a future feature, not a passthrough.
+**Method surface is fail-closed (#356, #367):** both endpoints speak the
+mandatory MCP lifecycle — `initialize` is answered **locally** (tools
+capability only, the client's `protocolVersion` echoed, never forwarded
+upstream) and `notifications/initialized` is accepted with HTTP 202 — so
+spec-conformant clients (Copilot CLI, Claude Code, MCP Inspector, the SDKs)
+connect normally. Governed traffic is `tools/list` and `tools/call`. Every
+OTHER method (`resources/read`, `prompts/get`, …) is rejected with JSON-RPC
+`-32601`, `error.data.talon_code: TALON_METHOD_NOT_ALLOWED`, and an
+attributed `proxy_method_rejected` evidence record, in **every** mode —
+closing what would otherwise be an unscanned, unaudited data lane. Governed
+resource/prompt reads are a future feature, not a passthrough.
+
+**Stable denial codes (#369):** every Talon-shaped proxy error carries
+`error.data.talon_code` — the machine contract; messages are prose and may
+change:
+
+| talon_code | Meaning |
+|---|---|
+| `TALON_TOOL_FORBIDDEN` | explicit `forbidden_tools` match |
+| `TALON_POLICY_DENIED` | tool-access policy deny (Rego) |
+| `TALON_PII_BLOCKED` | PII deny, residual PII after redaction, invalid redaction output |
+| `TALON_SCANNER_UNAVAILABLE` | PII scanner fail-closed (unavailable/unverifiable) |
+| `TALON_METHOD_NOT_ALLOWED` | non-governed MCP method (#356) |
+| `TALON_UPSTREAM_ERROR` | upstream transport/decode failure (vendor JSON-RPC errors pass through untagged) |
 
 ---
 

--- a/docs/VENDOR_INTEGRATION_GUIDE.md
+++ b/docs/VENDOR_INTEGRATION_GUIDE.md
@@ -182,9 +182,13 @@ Vendor receives data (works normally, unaware of governance layer)
     ↓
 Your compliance officer has a complete audit trail
 
-Note: the proxy governs tools/list and tools/call ONLY. Any other MCP
-method (resources/read, prompts/get, initialize, ...) is rejected
-fail-closed with a signed evidence record — never forwarded ungoverned.
+Note: the proxy speaks the MCP lifecycle (initialize is answered locally —
+never forwarded; notifications/initialized accepted) and governs tools/list
+and tools/call. Any OTHER method (resources/read, prompts/get, ...) is
+rejected fail-closed with error.data.talon_code TALON_METHOD_NOT_ALLOWED
+and a signed evidence record — never forwarded ungoverned. All Talon-shaped
+denials carry stable machine-readable codes in error.data.talon_code (see
+ARCHITECTURE_MCP_PROXY.md for the full table).
 
 Also: tools/list responses are filtered — the vendor only ever discovers
 tools you listed in allowed_tools.

--- a/examples/mcp-proxy-minimal/README.md
+++ b/examples/mcp-proxy-minimal/README.md
@@ -26,9 +26,12 @@ http://localhost:8080/mcp/proxy
 
 Talon intercepts all MCP tool calls, scans for PII, checks against
 allowed/forbidden tool lists, and generates evidence records. The proxy
-governs `tools/list` and `tools/call` only — any other MCP method
-(`resources/read`, `prompts/get`, …) is rejected fail-closed with an
-evidence record, never forwarded ungoverned.
+speaks the MCP lifecycle (`initialize` answered locally, never forwarded;
+`notifications/initialized` accepted) and governs `tools/list` and
+`tools/call` — any other MCP method (`resources/read`, `prompts/get`, …)
+is rejected fail-closed with `error.data.talon_code:
+TALON_METHOD_NOT_ALLOWED` and an evidence record, never forwarded
+ungoverned.
 
 ## What's in the Config
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -91,6 +91,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	cfg.WarnIfDefaultKeys()
 
+	// The MCP initialize handshake advertises the real build version (#367).
+	mcp.ServerVersion = resolvedVersion()
+
 	policyBaseDir := "."
 	policyPath := cfg.DefaultPolicy
 	safePath, err := policy.ResolvePathUnderBase(policyBaseDir, policyPath)

--- a/internal/mcp/handshake.go
+++ b/internal/mcp/handshake.go
@@ -1,0 +1,56 @@
+package mcp
+
+import "encoding/json"
+
+// ServerVersion is stamped by the serve command at startup so the MCP
+// initialize handshake can advertise the real build version without an
+// import cycle on internal/cmd. "dev" when unset (tests, embedders).
+var ServerVersion = "dev"
+
+// defaultMCPProtocolVersion is advertised when the client's initialize
+// request carries no protocolVersion of its own.
+const defaultMCPProtocolVersion = "2025-06-18"
+
+// mcpInitializeResult answers the mandatory MCP initialize handshake LOCALLY
+// (#367): both /mcp and /mcp/proxy advertise ONLY the tools capability —
+// resources and prompts are not part of the governed surface — and
+// initialize is never forwarded upstream, so nothing ungoverned moves. The
+// client's requested protocolVersion is echoed (maximizing compatibility on
+// the plain-HTTP transport this server speaks); absent one, a fixed recent
+// version is advertised.
+func mcpInitializeResult(serverName string, params json.RawMessage) map[string]interface{} {
+	protocolVersion := defaultMCPProtocolVersion
+	var p struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if len(params) > 0 && json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+		protocolVersion = p.ProtocolVersion
+	}
+	return map[string]interface{}{
+		"protocolVersion": protocolVersion,
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    serverName,
+			"version": ServerVersion,
+		},
+	}
+}
+
+// Stable machine-readable denial codes carried in JSON-RPC error.data as
+// {"talon_code": "..."} (#369). Codes are the contract; messages are prose
+// and may change. Documented in docs/ARCHITECTURE_MCP_PROXY.md.
+const (
+	TalonCodeToolForbidden      = "TALON_TOOL_FORBIDDEN"      // forbidden_tools match
+	TalonCodePolicyDenied       = "TALON_POLICY_DENIED"       // tool-access policy deny
+	TalonCodePIIBlocked         = "TALON_PII_BLOCKED"         // PII deny, residual PII, invalid redaction
+	TalonCodeScannerUnavailable = "TALON_SCANNER_UNAVAILABLE" // PII scanner fail-closed
+	TalonCodeMethodNotAllowed   = "TALON_METHOD_NOT_ALLOWED"  // #356 method rejection
+	TalonCodeUpstreamError      = "TALON_UPSTREAM_ERROR"      // Talon-shaped upstream failure
+)
+
+// talonErrData builds the error.data payload for a denial code.
+func talonErrData(code string) map[string]string {
+	return map[string]string{"talon_code": code}
+}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -220,22 +220,35 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Talon-Session-ID", inv.sessionID)
 	}
 
+	// MCP lifecycle (#367): initialize is answered LOCALLY — tools capability
+	// only, never forwarded upstream (nothing ungoverned moves) — and
+	// notifications/initialized is accepted with 202/no body, so
+	// spec-conformant clients (Copilot CLI, Claude Code, MCP Inspector,
+	// SDKs) can complete the mandatory handshake against the proxy.
+	if req.Method == "notifications/initialized" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	var resp *jsonrpcResponse
 	switch req.Method {
+	case "initialize":
+		resp = &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Result: mcpInitializeResult("talon-mcp-proxy", req.Params)}
 	case "tools/list":
 		resp = h.handleToolsList(ctx, body, inv, &req)
 	case "tools/call":
 		resp = h.handleProxyToolCall(ctx, &req, inv)
 	default:
-		// Fail-closed method allowlist (#356): the proxy governs tools/list
-		// and tools/call; every other MCP method is rejected with evidence,
-		// mirroring the native /mcp server's -32601. Forwarding ungoverned
-		// methods (resources/read, prompts/get) would open an unscanned,
-		// unaudited data lane through the governance proxy.
+		// Fail-closed method allowlist (#356): the proxy governs the MCP
+		// lifecycle plus tools/list and tools/call; every other method is
+		// rejected with evidence, mirroring the native /mcp server's -32601.
+		// Forwarding ungoverned methods (resources/read, prompts/get) would
+		// open an unscanned, unaudited data lane through the governance proxy.
 		h.recordEvidence(ctx, inv, "proxy_method_rejected", req.Method, "unsupported_method:"+req.Method, nil, nil)
 		resp = &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{
 			Code:    codeMethodNotFound,
-			Message: "method not found: " + req.Method + " (the proxy governs tools/list and tools/call only)",
+			Message: "method not found: " + req.Method + " (the proxy governs initialize, tools/list, and tools/call only)",
+			Data:    talonErrData(TalonCodeMethodNotAllowed),
 		}}
 	}
 
@@ -279,7 +292,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			span.SetAttributes(attribute.String("proxy.blocked", "forbidden"))
 			if h.config.Proxy.Mode != policy.ProxyModePassthrough {
 				h.recordEvidence(ctx, inv, "proxy_tool_blocked", toolName, "forbidden_tools", nil, nil)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "tool not allowed by policy"}}
+				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "tool not allowed by policy", Data: talonErrData(TalonCodeToolForbidden)}}
 			}
 			h.recordEvidence(ctx, inv, "proxy_shadow_violation", toolName, "forbidden_tools", nil, &evidence.ShadowViolation{
 				Type:   "tool_block",
@@ -306,7 +319,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		denyReason := strings.Join(decision.Reasons, "; ")
 		if h.config.Proxy.Mode == policy.ProxyModeIntercept {
 			h.recordEvidence(ctx, inv, "proxy_tool_blocked", toolName, denyReason, nil, nil)
-			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: denyReason}}
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: denyReason, Data: talonErrData(TalonCodePolicyDenied)}}
 		}
 		// shadow/passthrough (#346): the deny is recorded as a would-have-
 		// denied shadow violation — previously these modes produced no
@@ -328,7 +341,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			flow.requestBlocked = true
 			flow.scannerFailure = scannerFailureKind(scanErr)
 			h.recordEvidence(ctx, inv, "proxy_pii_scan_error", toolName, "scanner_unavailable", &flow, nil)
-			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII scanner unavailable (fail-closed)"}}
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII scanner unavailable (fail-closed)", Data: talonErrData(TalonCodeScannerUnavailable)}}
 		}
 		if result != nil && len(result.Entities) > 0 {
 			flow.requestEntities = classifier.MergeEntitySpans(argStr, result.Entities)
@@ -342,7 +355,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				if h.config.Proxy.Mode == policy.ProxyModeIntercept {
 					flow.requestBlocked = true
 					h.recordEvidence(ctx, inv, "proxy_pii_eval_error", toolName, piiErr.Error(), &flow, nil)
-					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII policy evaluation failed (fail-closed)"}}
+					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII policy evaluation failed (fail-closed)", Data: talonErrData(TalonCodePIIBlocked)}}
 				}
 				// shadow/passthrough (#346): enforce mode would block
 				// fail-closed on an eval error — record it, then continue.
@@ -356,7 +369,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				if h.config.Proxy.Mode == policy.ProxyModeIntercept {
 					flow.requestBlocked = true
 					h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "pii_detected_in_request", &flow, nil)
-					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII detected in request"}}
+					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII detected in request", Data: talonErrData(TalonCodePIIBlocked)}}
 				}
 				// shadow/passthrough (#346): record the would-have-denied PII
 				// decision, then continue to redaction as before.
@@ -371,16 +384,18 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				flow.requestBlocked = true
 				flow.scannerFailure = scannerFailureKind(redactErr)
 				h.recordEvidence(ctx, inv, "proxy_pii_scan_error", toolName, "scanner_unavailable", &flow, nil)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII redaction failed (fail-closed)"}}
+				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Request blocked: PII redaction failed (fail-closed)", Data: talonErrData(TalonCodeScannerUnavailable)}}
 			}
 			if verifyErr := h.classifier.VerifyEgress(classifier.WithPIIDirection(ctx, classifier.PIIDirectionRequest), redactedArgs); verifyErr != nil {
 				flow.requestBlocked = true
 				reason := "request_residual_pii_after_redaction"
 				msg := residualBlockMessage("Request blocked: recognized PII remains after redaction", classifier.ResidualTypes(verifyErr))
+				code := TalonCodePIIBlocked
 				if !errors.Is(verifyErr, classifier.ErrPIIDetected) {
 					reason = "request_redaction_verification_scanner_unavailable"
 					msg = "Request blocked: redaction could not be verified (fail-closed)"
 					flow.scannerFailure = scannerFailureKind(verifyErr)
+					code = TalonCodeScannerUnavailable
 				}
 				h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, reason, &flow, nil)
 				return &jsonrpcResponse{
@@ -389,6 +404,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 					Error: &rpcError{
 						Code:    codeServerError,
 						Message: msg,
+						Data:    talonErrData(code),
 					},
 				}
 			}
@@ -396,7 +412,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				if !json.Valid([]byte(redactedArgs)) {
 					flow.requestBlocked = true
 					h.recordEvidence(ctx, inv, "proxy_pii_request_detected", toolName, "request_redaction_invalid_json", &flow, nil)
-					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction produced invalid JSON (fail-closed)"}}
+					return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction produced invalid JSON (fail-closed)", Data: talonErrData(TalonCodePIIBlocked)}}
 				}
 				params.Arguments = json.RawMessage(redactedArgs)
 				proxyInput.Arguments = paramsToMap(params.Arguments)
@@ -429,14 +445,14 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		// happened.
 		flow.egressUnconfirmed = true
 		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_error: "+err.Error(), &flow, nil)
-		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
+		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error(), Data: talonErrData(TalonCodeUpstreamError)}}
 	}
 	defer upstreamResp.Body.Close()
 	var out jsonrpcResponse
 	if err := json.NewDecoder(upstreamResp.Body).Decode(&out); err != nil {
 		// A response arrived, so egress happened — the flow item is truthful.
 		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_response_invalid", &flow, nil)
-		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "upstream response invalid"}}
+		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "upstream response invalid", Data: talonErrData(TalonCodeUpstreamError)}}
 	}
 	out.ID = req.ID
 	if out.Error != nil {
@@ -457,7 +473,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			flow.responseBlocked = true
 			flow.scannerFailure = scannerFailureKind(scanErr)
 			h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_scanner_unavailable", &flow, nil)
-			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII scanner unavailable (fail-closed)"}}
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII scanner unavailable (fail-closed)", Data: talonErrData(TalonCodeScannerUnavailable)}}
 		}
 		if cls != nil && cls.HasPII {
 			piiTypes := make([]string, 0, len(cls.Entities))
@@ -478,16 +494,18 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 				flow.responseBlocked = true
 				flow.scannerFailure = scannerFailureKind(redactErr)
 				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_scanner_unavailable", &flow, nil)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII redaction failed (fail-closed)"}}
+				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Tool result blocked: PII redaction failed (fail-closed)", Data: talonErrData(TalonCodeScannerUnavailable)}}
 			}
 			if verifyErr := h.classifier.VerifyEgress(classifier.WithPIIDirection(ctx, classifier.PIIDirectionResponse), redacted); verifyErr != nil {
 				flow.responseBlocked = true
 				reason := "output_pii_blocked_residual"
 				msg := residualBlockMessage("Tool result blocked: recognized PII remains after redaction", classifier.ResidualTypes(verifyErr))
+				code := TalonCodePIIBlocked
 				if !errors.Is(verifyErr, classifier.ErrPIIDetected) {
 					reason = "output_redaction_verification_scanner_unavailable"
 					msg = "Tool result blocked: redaction could not be verified (fail-closed)"
 					flow.scannerFailure = scannerFailureKind(verifyErr)
+					code = TalonCodeScannerUnavailable
 				}
 				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, reason, &flow, nil)
 				return &jsonrpcResponse{
@@ -496,6 +514,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 					Error: &rpcError{
 						Code:    codeServerError,
 						Message: msg,
+						Data:    talonErrData(code),
 					},
 				}
 			}
@@ -503,7 +522,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 			if err := json.Unmarshal([]byte(redacted), &redactedResult); err != nil {
 				flow.responseBlocked = true
 				h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_redaction_invalid_json", &flow, nil)
-				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction of tool result produced invalid JSON (fail-closed)"}}
+				return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "PII redaction of tool result produced invalid JSON (fail-closed)", Data: talonErrData(TalonCodePIIBlocked)}}
 			}
 			out.Result = redactedResult
 			h.recordEvidence(ctx, inv, "proxy_tool_call", toolName, "output_pii_redacted", &flow, nil)

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -538,8 +538,18 @@ func TestProxyEvidence_GeneratedCorrelationSharedAcrossRecords(t *testing.T) {
 // server. The contract is mode-INDEPENDENT: passthrough and shadow reject
 // exactly like intercept ("in every mode" is the documented surface, and
 // "passthrough forwards everything" must never grow to cover methods).
+// talonCodeOf extracts error.data.talon_code from a decoded response (#369).
+func talonCodeOf(t *testing.T, e *rpcError) string {
+	t.Helper()
+	require.NotNil(t, e)
+	data, ok := e.Data.(map[string]interface{})
+	require.True(t, ok, "error.data must carry the talon_code object, got %T", e.Data)
+	code, _ := data["talon_code"].(string)
+	return code
+}
+
 func TestProxyUnknownMethod_RejectedFailClosed(t *testing.T) {
-	methods := []string{"resources/read", "prompts/get", "initialize"}
+	methods := []string{"resources/read", "prompts/get", "logging/setLevel"}
 	for _, mode := range []string{policy.ProxyModeIntercept, policy.ProxyModePassthrough, policy.ProxyModeShadow} {
 		t.Run(mode, func(t *testing.T) {
 			hit := false
@@ -559,6 +569,8 @@ func TestProxyUnknownMethod_RejectedFailClosed(t *testing.T) {
 				require.NotNil(t, resp.Error, "method %s must be rejected in mode %s", method, mode)
 				assert.Equal(t, codeMethodNotFound, resp.Error.Code)
 				assert.Contains(t, resp.Error.Message, method)
+				assert.Equal(t, TalonCodeMethodNotAllowed, talonCodeOf(t, resp.Error),
+					"rejections carry the stable #369 code, not just prose")
 			}
 			assert.False(t, hit, "ungoverned methods must never reach the upstream (mode %s)", mode)
 
@@ -583,6 +595,100 @@ func TestProxyUnknownMethod_RejectedFailClosed(t *testing.T) {
 				"every rejection reason names the rejected method")
 		})
 	}
+}
+
+// TestProxyMCPHandshake pins #367: the mandatory MCP lifecycle completes
+// against the proxy — initialize answered LOCALLY (tools capability only,
+// protocolVersion echoed, NEVER forwarded upstream), notifications/initialized
+// accepted with 202 and no body, then governed tools/call proceeds normally.
+func TestProxyMCPHandshake(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, _ := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+
+	// 1. initialize — answered locally.
+	initBody, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]interface{}{"name": "mcp-inspector", "version": "1.0"},
+		},
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(initBody))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var initResp jsonrpcResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &initResp))
+	require.Nil(t, initResp.Error, "initialize must succeed: %v", initResp.Error)
+	result, ok := initResp.Result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "2025-03-26", result["protocolVersion"], "the client's protocolVersion is echoed")
+	caps, ok := result["capabilities"].(map[string]interface{})
+	require.True(t, ok)
+	_, hasTools := caps["tools"]
+	assert.True(t, hasTools, "the tools capability is advertised")
+	assert.NotContains(t, caps, "resources", "resources are NOT advertised — not part of the governed surface")
+	assert.NotContains(t, caps, "prompts", "prompts are NOT advertised")
+	assert.False(t, hit, "initialize is answered locally — NEVER forwarded upstream")
+
+	// 2. notifications/initialized — 202, no body.
+	notifBody, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "method": "notifications/initialized",
+	})
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(notifBody))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Empty(t, rec.Body.String(), "notifications get no response body")
+	assert.False(t, hit, "notifications/initialized is never forwarded upstream")
+
+	// 3. Governed traffic proceeds.
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+	assert.True(t, hit, "tools/call still reaches the upstream")
+}
+
+// TestNativeMCPHandshake pins #367 on the native /mcp server: same local
+// initialize + accepted initialized notification.
+func TestNativeMCPHandshake(t *testing.T) {
+	h := &Handler{}
+	initBody, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]interface{}{"protocolVersion": "2025-06-18"},
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", bytes.NewReader(initBody))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp jsonrpcResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Nil(t, resp.Error, "native initialize must succeed")
+	result, ok := resp.Result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "2025-06-18", result["protocolVersion"])
+
+	notifBody, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "method": "notifications/initialized"})
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", bytes.NewReader(notifBody))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Empty(t, rec.Body.String())
+}
+
+// TestProxyDenialCodes pins #369 on the two most load-bearing denials:
+// integrators key on error.data.talon_code, never on prose.
+func TestProxyDenialCodes(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	h, _ := attribHandler(t, policy.ProxyModeIntercept, up.URL, []string{"user_delete"})
+
+	_, resp := attribCall(t, h, context.Background(), nil, "user_delete")
+	assert.Equal(t, TalonCodeToolForbidden, talonCodeOf(t, resp.Error))
+
+	_, resp = attribCall(t, h, context.Background(), nil, "not_in_allowlist")
+	assert.Equal(t, TalonCodePolicyDenied, talonCodeOf(t, resp.Error))
 }
 
 // TestProxyInvalidAttributionHeader_Rejected400 pins the hygiene contract

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -45,6 +45,10 @@ type jsonrpcResponse struct {
 type rpcError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+	// Data carries the stable machine-readable denial code (#369):
+	// {"talon_code": "TALON_..."} — integrators key on this, never on the
+	// prose Message.
+	Data interface{} `json:"data,omitempty"`
 }
 
 // Standard JSON-RPC 2.0 error codes
@@ -101,8 +105,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// MCP lifecycle (#367): initialize is answered locally (tools capability
+	// only) and notifications/initialized is accepted with 202/no body —
+	// spec-conformant clients can now complete the mandatory handshake.
+	if req.Method == "notifications/initialized" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	var resp *jsonrpcResponse
 	switch req.Method {
+	case "initialize":
+		resp = &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Result: mcpInitializeResult("talon", req.Params)}
 	case "tools/list":
 		resp = h.handleToolsList(ctx, req.ID)
 	case "tools/call":


### PR DESCRIPTION
Closes #367. Closes #369. v1.9.3 milestone; both from real-integrator feedback on the talon-full-demo validation.

## #367 — the handshake (demo-killer)

The #356 allowlist made both endpoints spec-nonconformant: MCP's lifecycle makes `initialize` mandatory, and standard clients (Copilot CLI, Claude Code, MCP Inspector, the SDKs) treat `-32601` on `initialize` as a broken server.

Both `/mcp` and `/mcp/proxy` now answer `initialize` **locally** — tools capability only, the client's `protocolVersion` echoed, `serverInfo` carrying the build version — and accept `notifications/initialized` with HTTP 202/no body. **The fail-closed rationale is fully preserved**: `initialize` is never forwarded upstream (pinned via upstream hit counter), `resources`/`prompts` are never advertised, and every non-lifecycle, non-tools method keeps the #356 rejection with evidence. Full handshake-sequence tests on both endpoints.

## #369 — denial codes

Every Talon-shaped proxy denial now carries `error.data.talon_code`:

`TALON_TOOL_FORBIDDEN` · `TALON_POLICY_DENIED` · `TALON_PII_BLOCKED` · `TALON_SCANNER_UNAVAILABLE` · `TALON_METHOD_NOT_ALLOWED` · `TALON_UPSTREAM_ERROR`

Codes are the contract, messages stay prose; vendor JSON-RPC errors pass through untagged (they're the vendor's). Documented as a table in ARCHITECTURE_MCP_PROXY.md; pinned by `TestProxyDenialCodes` + assertions in the rejection test. Gateway-side codes (response header) remain tracked in #369's phase-2 note — this PR is the proxy phase.

## Verification

Full local surface + `go test -tags integration -count=1 ./tests/integration` — pass.