### PR TITLE
feat(mcp): vault-backed upstream auth for the MCP proxy (#358)

### DIFF
--- a/docs/ARCHITECTURE_MCP_PROXY.md
+++ b/docs/ARCHITECTURE_MCP_PROXY.md
@@ -92,8 +92,15 @@ proxy:
     vendor: "zendesk-ai-agent"
     url: "https://zendesk-ai-vendor.com"
     region: "EU"  # jurisdiction for policy input + data-flow evidence; omitted = "unknown"
-    # Upstream auth-header injection is not yet a config surface (see
-    # Roadmap); front the upstream with your own network-layer credentials.
+    # Vault-backed upstream auth (#358): resolved PER REQUEST (rotation via
+    # `talon secrets set` lands immediately); retrieval failure is
+    # fail-closed — the request never leaves without its credential. The
+    # vault ACL identity is the proxy's own agent.name. No env fallback,
+    # no ${VAR} for secrets.
+    auth:
+      secret_name: "vendor-upstream-key"  # required when the block is present
+      # header: "Authorization"           # default
+      # scheme: "Bearer"                  # default; explicit "" = raw value
 
   allowed_tools:
     - name: "zendesk_ticket_search"
@@ -643,7 +650,7 @@ signal).
 - [ ] Named Prometheus metrics + alerting for proxy traffic
 
 ### Phase 3 — planned
-- [ ] Upstream auth-header injection from config
+- ✅ Vault-backed upstream auth injection (`proxy.upstream.auth`, per-request, fail-closed — #358)
 - [ ] Per-vendor inbound bearer tokens (tool-scoped)
 - [ ] mTLS support
 - [ ] Per-vendor rate limits with burst

--- a/examples/vendor-proxy/zendesk-proxy.talon.yaml
+++ b/examples/vendor-proxy/zendesk-proxy.talon.yaml
@@ -13,9 +13,14 @@ proxy:
   upstream:
     vendor: zendesk-ai
     url: "https://zendesk-ai-vendor.example.com/mcp"
-    # Note: Talon does not yet inject upstream auth headers from config —
-    # if the upstream requires credentials, terminate them at your network
-    # layer (reverse proxy / service mesh) in front of the vendor endpoint.
+    # Vault-backed upstream auth (#358): store the vendor credential once
+    # (`talon secrets set zendesk-upstream-key "<token>"`) and Talon injects
+    # it per request — rotation lands immediately, retrieval failure is
+    # fail-closed. Uncomment to enable:
+    # auth:
+    #   secret_name: "zendesk-upstream-key"
+    #   # header: "Authorization"   # default
+    #   # scheme: "Bearer"          # default; explicit "" = raw value
   allowed_tools:
     - name: zendesk_ticket_search
       upstream_name: ticket_search

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -615,7 +615,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("proxy policy engine: %w", err)
 		}
-		proxyHandler = mcp.NewProxyHandler(proxyCfg, proxyEngine, evidenceStore, cls)
+		proxyHandler = mcp.NewProxyHandler(proxyCfg, proxyEngine, evidenceStore, cls, secretsStore)
 		opts = append(opts, server.WithMCPProxy(proxyHandler))
 	}
 

--- a/internal/mcp/dataflow_test.go
+++ b/internal/mcp/dataflow_test.go
@@ -66,7 +66,7 @@ func proxyFlowHandler(t *testing.T, upstreamURL string, withRedactionRule bool) 
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner()), store
+	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil), store
 }
 
 func callProxyTool(t *testing.T, h *ProxyHandler, arguments string) *jsonrpcResponse {

--- a/internal/mcp/egress_guard_test.go
+++ b/internal/mcp/egress_guard_test.go
@@ -54,7 +54,7 @@ func proxyHandlerWithScanner(t *testing.T, upstreamURL string, scanner *classifi
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return NewProxyHandler(cfg, engine, store, scanner)
+	return NewProxyHandler(cfg, engine, store, scanner, nil)
 }
 
 func TestNoPIIEgressAfterRedaction_MCPProxy(t *testing.T) {

--- a/internal/mcp/openclaw_incident_test.go
+++ b/internal/mcp/openclaw_incident_test.go
@@ -78,7 +78,7 @@ func TestProxy_ForbiddenToolBlocked_DeleteWildcard(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "delete_repo", map[string]interface{}{"repo": "my-project"})
 	require.NotNil(t, r.Error, "delete_repo must be blocked by forbidden_tools: delete_*")
@@ -94,7 +94,7 @@ func TestProxy_ForbiddenToolBlocked_AdminWildcard(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "admin_reset_password", map[string]interface{}{})
 	require.NotNil(t, r.Error, "admin_reset_password must be blocked by forbidden_tools: admin_*")
@@ -110,7 +110,7 @@ func TestProxy_ForbiddenToolBlocked_BulkDelete(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "bulk_delete", map[string]interface{}{"filter": "all"})
 	require.NotNil(t, r.Error, "bulk_delete must be blocked by exact match in forbidden_tools")
@@ -139,7 +139,7 @@ func TestProxy_AllowedToolForwardedToUpstream(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "search_issues", map[string]interface{}{"query": "open bugs"})
 	assert.Nil(t, r.Error, "search_issues is in allowed_tools and should be forwarded")
@@ -155,7 +155,7 @@ func TestProxy_EvidenceRecordedOnBlock(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	_ = proxyCall(t, h, "delete_user", map[string]interface{}{"user": "admin"})
 
@@ -183,7 +183,7 @@ func TestProxy_PIIInArgumentsBlocked(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "search_issues", map[string]interface{}{
 		"query": "emails from hans.mueller@example.de with IBAN DE89370400440532013000",
@@ -236,7 +236,7 @@ func TestProxy_GapF_ResponsePIIScanned(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "search_issues", map[string]interface{}{"query": "test"})
 	require.Nil(t, r.Error, "allowed tool should succeed")
@@ -272,7 +272,7 @@ func TestProxy_UnlistedToolDefaultBehavior(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	r := proxyCall(t, h, "unknown_new_tool", map[string]interface{}{})
 	// Tool is not in forbidden list; whether it's forwarded depends on OPA.

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -26,9 +26,17 @@ import (
 	"github.com/dativo-io/talon/internal/otel"
 	"github.com/dativo-io/talon/internal/policy"
 	"github.com/dativo-io/talon/internal/requestctx"
+	"github.com/dativo-io/talon/internal/secrets"
 )
 
 var proxyTracer = otel.Tracer("github.com/dativo-io/talon/internal/mcp")
+
+// UpstreamSecretGetter is the vault surface the proxy needs for upstream
+// auth (#358) — satisfied by *secrets.SecretStore; an interface so tests can
+// fake retrieval failures.
+type UpstreamSecretGetter interface {
+	Get(ctx context.Context, name, tenantID, agentID string) (*secrets.Secret, error)
+}
 
 // ProxyHandler forwards MCP requests to an upstream vendor endpoint with policy and PII handling.
 type ProxyHandler struct {
@@ -36,16 +44,20 @@ type ProxyHandler struct {
 	proxyEngine   *policy.ProxyEngine
 	evidenceStore *evidence.Store
 	classifier    classifier.Facade
+	secrets       UpstreamSecretGetter
 	httpClient    *http.Client
 	runtime       ProxyRuntimeConfig
 }
 
-// NewProxyHandler creates an MCP proxy handler.
+// NewProxyHandler creates an MCP proxy handler. secretsStore may be nil when
+// the proxy config declares no upstream auth; with an auth block and no
+// store, every upstream call fails closed.
 func NewProxyHandler(
 	cfg *policy.ProxyPolicyConfig,
 	proxyEngine *policy.ProxyEngine,
 	evidenceStore *evidence.Store,
 	cls classifier.Facade,
+	secretsStore UpstreamSecretGetter,
 ) *ProxyHandler {
 	// Defense in depth for #346: the loaders default/validate mode, but a
 	// handler constructed directly (tests, future callers) must never run
@@ -65,6 +77,7 @@ func NewProxyHandler(
 		proxyEngine:   proxyEngine,
 		evidenceStore: evidenceStore,
 		classifier:    cls,
+		secrets:       secretsStore,
 		httpClient:    &http.Client{Timeout: timeout},
 		runtime:       DefaultProxyRuntime(),
 	}
@@ -432,7 +445,7 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 	forwardReq := jsonrpcRequest{JSONRPC: jsonrpcVersion, Method: req.Method, Params: forwardBody, ID: req.ID}
 	forwardJSON, _ := json.Marshal(forwardReq)
 
-	upstreamResp, err := h.doUpstreamRequest(ctx, forwardJSON)
+	upstreamResp, err := h.doUpstreamRequest(ctx, forwardJSON, inv)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -444,6 +457,13 @@ func (h *ProxyHandler) handleProxyToolCall(ctx context.Context, req *jsonrpcRequ
 		// but must not assert a data flow to the vendor that may never have
 		// happened.
 		flow.egressUnconfirmed = true
+		if errors.Is(err, errSecretRetrieval) {
+			// Vault failure (#358): fail-closed, generic message to the
+			// vendor (gateway parity — no vault detail leaks), evidence
+			// carries the typed reason.
+			h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "secret retrieval error", &flow, nil)
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Service configuration error", Data: talonErrData(TalonCodeUpstreamError)}}
+		}
 		h.recordEvidence(ctx, inv, "proxy_upstream_error", toolName, "upstream_error: "+err.Error(), &flow, nil)
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error(), Data: talonErrData(TalonCodeUpstreamError)}}
 	}
@@ -647,11 +667,11 @@ func toolNameFromRaw(raw json.RawMessage) string {
 // It supports multiple upstream result shapes (object with "tools", array at top,
 // or other common keys) and preserves the response shape. If the result shape
 // is unrecognizable, it returns an empty tool list to avoid leaking unfiltered data.
-func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, _ *proxyInvocation, req *jsonrpcRequest) *jsonrpcResponse {
+func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, inv *proxyInvocation, req *jsonrpcRequest) *jsonrpcResponse {
 	ctx, span := proxyTracer.Start(ctx, "mcp.proxy.tools.list")
 	defer span.End()
 
-	resp := h.forwardRequest(ctx, body, req)
+	resp := h.forwardRequest(ctx, body, inv, req)
 	if resp == nil || resp.Error != nil || resp.Result == nil {
 		return resp
 	}
@@ -712,9 +732,13 @@ func (h *ProxyHandler) handleToolsList(ctx context.Context, body []byte, _ *prox
 	return resp
 }
 
-func (h *ProxyHandler) forwardRequest(ctx context.Context, body []byte, req *jsonrpcRequest) *jsonrpcResponse {
-	upstreamResp, err := h.doUpstreamRequest(ctx, body)
+func (h *ProxyHandler) forwardRequest(ctx context.Context, body []byte, inv *proxyInvocation, req *jsonrpcRequest) *jsonrpcResponse {
+	upstreamResp, err := h.doUpstreamRequest(ctx, body, inv)
 	if err != nil {
+		if errors.Is(err, errSecretRetrieval) {
+			// Fail-closed vault failure (#358): generic message, no detail leak.
+			return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: "Service configuration error", Data: talonErrData(TalonCodeUpstreamError)}}
+		}
 		return &jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID, Error: &rpcError{Code: codeServerError, Message: err.Error()}}
 	}
 	defer upstreamResp.Body.Close()
@@ -726,17 +750,43 @@ func (h *ProxyHandler) forwardRequest(ctx context.Context, body []byte, req *jso
 	return &out
 }
 
-func (h *ProxyHandler) doUpstreamRequest(ctx context.Context, body []byte) (*http.Response, error) {
+// errSecretRetrieval marks a vault failure on the upstream-auth path (#358):
+// fail-closed, surfaced to the caller as a generic configuration error
+// (gateway parity — vault details never leak to the vendor).
+var errSecretRetrieval = errors.New("secret retrieval error")
+
+func (h *ProxyHandler) doUpstreamRequest(ctx context.Context, body []byte, inv *proxyInvocation) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.config.Proxy.Upstream.URL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if h.runtime.AuthHeader != "" {
-		parts := strings.SplitN(h.runtime.AuthHeader, ":", 2)
-		if len(parts) == 2 {
-			req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+	// Vault-backed upstream auth (#358): resolved PER REQUEST — rotation via
+	// `talon secrets set` lands immediately, and retrieval failure is
+	// fail-closed (the request never leaves without its credential). The
+	// vault ACL identity is the proxy's own declared agent, stable
+	// regardless of caller.
+	if auth := h.config.Proxy.Upstream.Auth; auth != nil {
+		if h.secrets == nil {
+			return nil, fmt.Errorf("%w: no secrets store wired", errSecretRetrieval)
 		}
+		sec, err := h.secrets.Get(ctx, auth.SecretName, inv.tenantID, h.config.Agent.Name)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", errSecretRetrieval, err)
+		}
+		header := auth.Header
+		if header == "" {
+			header = "Authorization"
+		}
+		value := string(sec.Value)
+		scheme := "Bearer"
+		if auth.Scheme != nil {
+			scheme = *auth.Scheme
+		}
+		if scheme != "" {
+			value = scheme + " " + value
+		}
+		req.Header.Set(header, value)
 	}
 	//nolint:gosec // G704: upstream URL is from proxy config (validated at load), not user request input
 	return h.httpClient.Do(req)
@@ -889,6 +939,11 @@ func (h *ProxyHandler) recordEvidence(ctx context.Context, inv *proxyInvocation,
 	if sv != nil {
 		ev.ObservationModeOverride = true
 		ev.ShadowViolations = []evidence.ShadowViolation{*sv}
+	}
+	// Upstream auth evidence (#358): mode-only, exact gateway parity in
+	// secret mode (fingerprint/source stay client_bearer-only vocabulary).
+	if h.config.Proxy.Upstream.Auth != nil {
+		ev.UpstreamAuthMode = "secret"
 	}
 	if flow != nil {
 		h.attachProxyFlow(ev, inv, toolName, flow)

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -56,7 +56,7 @@ func attribHandler(t *testing.T, mode, upstreamURL string, forbidden []string) (
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return NewProxyHandler(cfg, engine, store, nil), store
+	return NewProxyHandler(cfg, engine, store, nil, nil), store
 }
 
 func attribCall(t *testing.T, h *ProxyHandler, ctx context.Context, headers map[string]string, tool string) (*httptest.ResponseRecorder, jsonrpcResponse) {
@@ -319,7 +319,7 @@ func TestProxyShadow_PIIWouldDeny_RecordsShadowViolation(t *testing.T) {
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	_, resp := attribCallArgs(t, h, context.Background(), map[string]string{"X-Talon-Session-ID": "sess-pii-1"}, "crm_lookup",
 		map[string]string{"email": "jane.doe@example.com"})
@@ -378,7 +378,7 @@ func TestProxyPIIAllowed_OneRequestClassRecord(t *testing.T) {
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
 		map[string]string{"email": "jane.doe@example.com"})
@@ -415,7 +415,7 @@ func TestProxyUpstreamError_RecordsTrail(t *testing.T) {
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	_, resp := attribCallArgs(t, h, context.Background(), nil, "crm_lookup",
 		map[string]string{"email": "jane.doe@example.com"})
@@ -457,7 +457,7 @@ func upstreamErrorHandler(t *testing.T, upstream http.HandlerFunc) (*ProxyHandle
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner()), store
+	return NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil), store
 }
 
 // TestProxyUpstreamDecodeFailure_RecordsTrail pins the second upstream-error

--- a/internal/mcp/proxy_config.go
+++ b/internal/mcp/proxy_config.go
@@ -57,6 +57,12 @@ func validateAndApplyDefaults(cfg *policy.ProxyPolicyConfig) error {
 	if len(cfg.Proxy.AllowedTools) == 0 {
 		return fmt.Errorf("at least one proxy.allowed_tools entry is required")
 	}
+	// Upstream auth (#358): when the block is present, secret_name is
+	// required — a half-configured auth block must fail startup, never
+	// silently send unauthenticated requests.
+	if cfg.Proxy.Upstream.Auth != nil && strings.TrimSpace(cfg.Proxy.Upstream.Auth.SecretName) == "" {
+		return fmt.Errorf("proxy.upstream.auth.secret_name is required when the auth block is present")
+	}
 	// Mode (#346): default unset to intercept — matching LoadProxyPolicy's
 	// documented default — and reject anything outside the three declared
 	// values. An unset mode must never reach the handler, where it would
@@ -85,13 +91,15 @@ func ExpandEnv(s string) string {
 	})
 }
 
-// ProxyRuntimeConfig holds runtime settings for the proxy (timeouts, auth header).
+// ProxyRuntimeConfig holds runtime settings for the proxy (timeouts).
+// Upstream auth is NOT runtime config: it is the vault-backed
+// proxy.upstream.auth block (#358), resolved per request — the old
+// AuthHeader field had zero production callers and is retired.
 type ProxyRuntimeConfig struct {
 	UpstreamTimeout time.Duration
-	AuthHeader      string // e.g. "Authorization: Bearer <token>"
 }
 
-// DefaultProxyRuntime returns default runtime config (30s timeout, no auth).
+// DefaultProxyRuntime returns default runtime config (30s timeout).
 func DefaultProxyRuntime() ProxyRuntimeConfig {
 	return ProxyRuntimeConfig{
 		UpstreamTimeout: 30 * time.Second,

--- a/internal/mcp/proxy_config_test.go
+++ b/internal/mcp/proxy_config_test.go
@@ -196,5 +196,4 @@ func TestExpandEnv(t *testing.T) {
 func TestDefaultProxyRuntime(t *testing.T) {
 	r := DefaultProxyRuntime()
 	assert.Equal(t, 30*time.Second, r.UpstreamTimeout)
-	assert.Empty(t, r.AuthHeader)
 }

--- a/internal/mcp/proxy_scanner_evidence_test.go
+++ b/internal/mcp/proxy_scanner_evidence_test.go
@@ -90,7 +90,7 @@ func newProxyWithUpstream(t *testing.T, cls classifier.Facade, upstreamResult st
 	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return NewProxyHandler(cfg, engine, store, cls), store
+	return NewProxyHandler(cfg, engine, store, cls, nil), store
 }
 
 func callProxyEchoTool(t *testing.T, h *ProxyHandler, args map[string]interface{}) *jsonrpcResponse {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -45,9 +45,9 @@ func TestNewProxyHandler_and_SetRuntime(t *testing.T) {
 	t.Cleanup(func() { _ = store.Close() })
 	cls := classifier.MustNewScanner()
 
-	h := NewProxyHandler(cfg, engine, store, cls)
+	h := NewProxyHandler(cfg, engine, store, cls, nil)
 	require.NotNil(t, h)
-	h.SetRuntime(ProxyRuntimeConfig{UpstreamTimeout: 0, AuthHeader: "Bearer x"})
+	h.SetRuntime(ProxyRuntimeConfig{UpstreamTimeout: 0})
 }
 
 func TestProxyHandler_ServeHTTP_methodAndJSON(t *testing.T) {
@@ -62,7 +62,7 @@ func TestProxyHandler_ServeHTTP_methodAndJSON(t *testing.T) {
 	require.NoError(t, err)
 	store, _ := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	// GET not allowed
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp/proxy", nil)
@@ -108,7 +108,7 @@ func TestProxyHandler_toolsCall_missingName(t *testing.T) {
 	require.NoError(t, err)
 	store, _ := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	body, _ := json.Marshal(map[string]interface{}{
 		"jsonrpc": "2.0", "method": "tools/call", "params": map[string]interface{}{}, "id": 1,
@@ -146,7 +146,7 @@ func TestProxyHandler_forbiddenTool_shadowBlocks(t *testing.T) {
 	store, err := evidence.NewStore(dir+"/e.db", testutil.TestSigningKey)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	// Forbidden exact match: must be blocked (audit + block, no forward).
 	body, _ := json.Marshal(map[string]interface{}{
@@ -282,7 +282,7 @@ func TestProxyHandler_toolsList_filteringAndShapes(t *testing.T) {
 	require.NoError(t, err)
 	store, _ := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "method": "tools/list", "id": 1})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))
@@ -332,7 +332,7 @@ func TestProxyHandler_toolsList_arrayShapeAndUnknownSafe(t *testing.T) {
 	require.NoError(t, err)
 	store, _ := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "method": "tools/list", "id": 1})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))
@@ -375,7 +375,7 @@ func TestProxyHandler_toolsList_unknownShapeReturnsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	store, _ := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
 	t.Cleanup(func() { _ = store.Close() })
-	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner())
+	h := NewProxyHandler(cfg, engine, store, classifier.MustNewScanner(), nil)
 
 	body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "method": "tools/list", "id": 1})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp/proxy", bytes.NewReader(body))

--- a/internal/mcp/proxy_upstream_auth_test.go
+++ b/internal/mcp/proxy_upstream_auth_test.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
+	"github.com/dativo-io/talon/internal/secrets"
+	"github.com/dativo-io/talon/internal/testutil"
+)
+
+// authTestVault builds a real vault with one upstream credential under the
+// given ACL.
+func authTestVault(t *testing.T, name, value string, acl secrets.ACL) *secrets.SecretStore {
+	t.Helper()
+	store, err := secrets.NewSecretStore(t.TempDir()+"/s.db", "0123456789abcdef0123456789abcdef")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	require.NoError(t, store.Set(context.Background(), name, []byte(value), acl))
+	return store
+}
+
+// authProxy builds an intercept proxy with a vault-backed upstream auth block.
+func authProxy(t *testing.T, upstreamURL string, vault UpstreamSecretGetter) (*ProxyHandler, *evidence.Store) {
+	t.Helper()
+	cfg := &policy.ProxyPolicyConfig{
+		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
+		Proxy: policy.ProxyConfig{
+			Mode:         policy.ProxyModeIntercept,
+			Upstream: policy.UpstreamConfig{
+				URL:    upstreamURL,
+				Vendor: "testvendor",
+				Auth:   &policy.UpstreamAuthConfig{SecretName: "vendor-upstream-key"},
+			},
+			AllowedTools: []policy.ToolMapping{{Name: "crm_lookup"}},
+		},
+	}
+	engine, err := policy.NewProxyEngine(context.Background(), cfg)
+	require.NoError(t, err)
+	store, err := evidence.NewStore(t.TempDir()+"/e.db", testutil.TestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return NewProxyHandler(cfg, engine, store, nil, vault), store
+}
+
+// TestProxyUpstreamAuth_HeaderInjected pins #358: the vault-resolved
+// credential arrives at the upstream as "Authorization: Bearer <secret>",
+// and the caller-side response never contains it.
+func TestProxyUpstreamAuth_HeaderInjected(t *testing.T) {
+	var gotAuth string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":"ok"}}`))
+	}))
+	t.Cleanup(up.Close)
+
+	vault := authTestVault(t, "vendor-upstream-key", "vendor-token-123", secrets.ACL{})
+	h, _ := authProxy(t, up.URL, vault)
+
+	rec, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+	assert.Equal(t, "Bearer vendor-token-123", gotAuth, "vault credential injected as Bearer by default")
+	assert.NotContains(t, rec.Body.String(), "vendor-token-123", "the credential never leaks to the caller")
+}
+
+// TestProxyUpstreamAuth_Rotation pins the per-request resolution contract:
+// `talon secrets set` with a new value takes effect on the NEXT request,
+// no restart.
+func TestProxyUpstreamAuth_Rotation(t *testing.T) {
+	var gotAuth string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":"ok"}}`))
+	}))
+	t.Cleanup(up.Close)
+
+	vault := authTestVault(t, "vendor-upstream-key", "token-v1", secrets.ACL{})
+	h, _ := authProxy(t, up.URL, vault)
+
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+	assert.Equal(t, "Bearer token-v1", gotAuth)
+
+	require.NoError(t, vault.Set(context.Background(), "vendor-upstream-key", []byte("token-v2"), secrets.ACL{}))
+	_, resp = attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+	assert.Equal(t, "Bearer token-v2", gotAuth, "rotation lands on the next request without restart")
+}
+
+// TestProxyUpstreamAuth_VaultMissFailsClosed pins the fail-closed contract:
+// a missing vault entry means the request NEVER reaches the upstream; the
+// caller sees a generic configuration error (no vault detail leaks) and
+// signed evidence carries the typed reason.
+func TestProxyUpstreamAuth_VaultMissFailsClosed(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	// Vault exists but holds a DIFFERENT secret name.
+	vault := authTestVault(t, "some-other-secret", "x", secrets.ACL{})
+	h, store := authProxy(t, up.URL, vault)
+
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "Service configuration error", resp.Error.Message, "no vault detail leaks to the vendor")
+	assert.Equal(t, TalonCodeUpstreamError, talonCodeOf(t, resp.Error))
+	assert.False(t, hit, "the request must never leave without its credential")
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	assert.Equal(t, "proxy_upstream_error", records[0].InvocationType)
+	assert.Contains(t, records[0].PolicyDecision.Reasons, "secret retrieval error")
+	assert.Equal(t, "secret", records[0].UpstreamAuthMode, "auth mode recorded, gateway parity")
+	assert.Nil(t, records[0].DataFlow, "nothing egressed")
+}
+
+// TestProxyUpstreamAuth_ACLDenied pins the vault ACL path: the proxy reads
+// the secret as its own declared agent; an ACL that forbids that agent
+// fails closed exactly like a miss.
+func TestProxyUpstreamAuth_ACLDenied(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	vault := authTestVault(t, "vendor-upstream-key", "secret", secrets.ACL{
+		ForbiddenAgents: []string{"vendor-proxy-agent"},
+	})
+	h, store := authProxy(t, up.URL, vault)
+
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "Service configuration error", resp.Error.Message)
+	assert.False(t, hit)
+
+	records := listRecords(t, store, "default")
+	require.Len(t, records, 1)
+	assert.Contains(t, records[0].PolicyDecision.Reasons, "secret retrieval error")
+}
+
+// TestProxyUpstreamAuth_CustomHeaderAndRawScheme pins the header/scheme
+// surface: a custom header name with an explicit empty scheme sends the raw
+// secret value.
+func TestProxyUpstreamAuth_CustomHeaderAndRawScheme(t *testing.T) {
+	var gotKey string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":"ok"}}`))
+	}))
+	t.Cleanup(up.Close)
+
+	vault := authTestVault(t, "vendor-upstream-key", "raw-key-9", secrets.ACL{})
+	h, _ := authProxy(t, up.URL, vault)
+	raw := ""
+	h.config.Proxy.Upstream.Auth.Header = "X-Api-Key"
+	h.config.Proxy.Upstream.Auth.Scheme = &raw
+
+	_, resp := attribCall(t, h, context.Background(), nil, "crm_lookup")
+	require.Nil(t, resp.Error)
+	assert.Equal(t, "raw-key-9", gotKey, "explicit empty scheme sends the raw value in the custom header")
+}

--- a/internal/policy/proxy.go
+++ b/internal/policy/proxy.go
@@ -62,6 +62,22 @@ type UpstreamConfig struct {
 	// used for policy input and data-flow evidence. When empty, Talon
 	// records "unknown" — it never guesses a region.
 	Region string `yaml:"region,omitempty" json:"region,omitempty"`
+	// Auth configures vault-backed upstream credential injection (#358).
+	// Resolved per request (rotation via `talon secrets set` lands
+	// immediately); retrieval failure is fail-closed. Vault only — no env
+	// fallback, no ${VAR} expansion for secrets.
+	Auth *UpstreamAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
+}
+
+// UpstreamAuthConfig is the vault-backed upstream credential surface (#358).
+type UpstreamAuthConfig struct {
+	// SecretName is the vault entry holding the upstream credential (required).
+	SecretName string `yaml:"secret_name" json:"secret_name"`
+	// Header receives the credential; default "Authorization".
+	Header string `yaml:"header,omitempty" json:"header,omitempty"`
+	// Scheme prefixes the value: absent -> "Bearer"; explicit "" -> raw
+	// secret value (pointer distinguishes absent from empty).
+	Scheme *string `yaml:"scheme,omitempty" json:"scheme,omitempty"`
 }
 
 // ToolMapping maps a Talon-facing tool name to the vendor's upstream name.


### PR DESCRIPTION
Closes #358. The last v1.9.3 milestone item — the vendor-path capability gap: essentially every real vendor MCP endpoint requires authentication, and the proxy had no auth surface (the old `ProxyRuntimeConfig.AuthHeader` had zero production callers — retired per the no-installed-base convention).

## Config surface (strict-loader validated)

```yaml
proxy:
  upstream:
    auth:
      secret_name: "vendor-upstream-key"  # vault entry; required when block present
      # header: "Authorization"           # default
      # scheme: "Bearer"                  # default; explicit "" = raw value
```

## Gateway-parity semantics (per the approved execution contract)

- **Per-request vault resolution** — `talon secrets set` rotation lands on the next request, no restart (pinned by `TestProxyUpstreamAuth_Rotation`); the proxy config sits outside the reloader, so startup resolution would freeze the key.
- **Fail-closed**: retrieval failure (miss, ACL deny, no store wired) means the request **never leaves**; the vendor sees a generic `Service configuration error` (no vault detail leaks) with `talon_code: TALON_UPSTREAM_ERROR`; signed evidence carries `secret retrieval error` and **no data-flow item** (nothing egressed).
- Vault ACL identity = the proxy's own declared `agent.name` (stable regardless of caller); ACL denial covered by test.
- Evidence: `upstream_auth_mode: "secret"` (mode-only — exact gateway secret-path parity).
- No env fallback; no `${VAR}` expansion for secrets.

`NewProxyHandler` gains the secrets store (breaking constructor; serve wires the real store). Five contract tests cover header injection + no caller-side leak, rotation, vault-miss, ACL denial, custom header/raw scheme. Docs + the vendor-proxy example move the feature from Roadmap to shipped.

## Verification

Full local surface + `go test -tags integration -count=1 ./tests/integration` — pass.