### PR TITLE
fix(mcp): gofumpt proxy_upstream_auth_test.go (repairs red main from #376)

### DIFF
--- a/internal/mcp/proxy_upstream_auth_test.go
+++ b/internal/mcp/proxy_upstream_auth_test.go
@@ -32,7 +32,7 @@ func authProxy(t *testing.T, upstreamURL string, vault UpstreamSecretGetter) (*P
 	cfg := &policy.ProxyPolicyConfig{
 		Agent: policy.ProxyAgentConfig{Name: "vendor-proxy-agent", Type: "mcp_proxy"},
 		Proxy: policy.ProxyConfig{
-			Mode:         policy.ProxyModeIntercept,
+			Mode: policy.ProxyModeIntercept,
 			Upstream: policy.UpstreamConfig{
 				URL:    upstreamURL,
 				Vendor: "testvendor",


### PR DESCRIPTION
Fix-forward for the red Lint + Test(format-check) merged with #376 — one gofumpt whitespace fix in the new test file, no behavior change. `gofumpt -l` across internal/ and cmd/ is clean; the upstream-auth suite passes.