### PR TITLE
fix(ci): exec-count -fuzztime in proof gates; dodges Go fuzz coordinator deadline race (#384)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,10 @@ proof-gates: ## Run Epic #112 proof gates (matrix/parity/egress/fuzz/benchmark)
 	@$(GO_ENV) go test -count=1 ./internal/agent/... -run 'PII|Tool|Residual|NoPIIEgress|Remediation|ScannerFailure'
 	@$(GO_ENV) go test -count=1 ./internal/classifier/adapter/... -run 'TestAnalyze|TestRedactText|TestVerifyEgress'
 	@$(GO_ENV) go test -count=1 ./internal/scanner/... -run 'TestBuild|TestValidateEndpointLocality'
-	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzPIIRedactVerify -fuzztime=3s ./internal/classifier
-	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzNormalizeResultsOffsets -fuzztime=3s ./internal/classifier/presidio
-	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzAdapterResponseDecode -fuzztime=3s ./internal/classifier/adapter
+	@# Exec-count fuzztime (Nx), never a duration: duration deadlines race in Go's fuzz coordinator (golang/go#72104) and flake the gate.
+	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzPIIRedactVerify -fuzztime=40000x ./internal/classifier
+	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzNormalizeResultsOffsets -fuzztime=150000x ./internal/classifier/presidio
+	@$(GO_ENV) go test -run '^$$' -fuzz=FuzzAdapterResponseDecode -fuzztime=20000x ./internal/classifier/adapter
 	@if [ "${SKIP_BENCHMARK_REGRESSION:-}" = "1" ]; then \
 		echo "Skipping benchmark regression (SKIP_BENCHMARK_REGRESSION=1)"; \
 	else \


### PR DESCRIPTION
Fixes #384

## What

Switches the three `proof-gates` fuzz invocations from duration-based `-fuzztime=3s` to exec-count form (`40000x` / `150000x` / `20000x`), with a Makefile comment pinning the constraint so it doesn't get "simplified" back.

## Why

CI failed `FuzzPIIRedactVerify` with a bare `context deadline exceeded` exactly at the 3s mark, with no crasher written. That is an upstream race in Go's fuzz coordinator (verified against the CI toolchain go1.25.12 source): duration `-fuzztime` wraps the coordinator context in `WithTimeout`; when the deadline fires, the parent's done channel closes before the child `fuzzCtx` is canceled, so `stop(ctx.Err())` can lose the race against the suppression check `err == fuzzCtx.Err()` (still `nil`) and the run is reported as FAIL. Go's own `TestScript/test_fuzz_fuzztime` flakes with the identical signature — golang/go#72104 (open).

Exec-count `-fuzztime` sets `opts.Limit` instead of creating a deadline context, so the failure mode is structurally impossible, and the gate becomes a fixed work quantum instead of runner-speed-dependent. Budgets preserve today's coverage: the failing CI run did 40,304 execs in its 3s window (13.4k/sec); the other two targets were measured locally (~156k/sec and ~17.5k/sec on go1.25.12) and scaled by the observed ~2.7× CI slowdown.

Full diagnosis, reproduction notes, and rejected alternatives (retry wrapper, seed corpus, Go bump) are in #384.

## Verification

- `make proof-gates` passes end-to-end locally (cold fuzz cache), including the benchmark regression gate.
- The previously-flaky classifier gate run 3× more with `go clean -fuzzcache` between runs: all clean `PASS` at exactly 40000 execs.
- Before the fix, 5× cold-cache runs at `-fuzztime=3s` on go1.25.12 also passed locally — the race needs a slower/loaded runner, hence CI-only flakes; the fix removes the deadline context entirely rather than tuning timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)