### PR TITLE
feat(sessions): session summary contract for talon session show (#271)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,6 @@ The gaps between today and the MVP contract, each tracked by an issue in the [MV
 - **Cost-control contract** — warning thresholds as signed evidence (once per crossing), one organization webhook delivered after evidence commit, session-cap hardening ([#144](https://github.com/dativo-io/talon/issues/144))
 - **Same-provider retries with backoff** — transient failures only, cost-counted, evidence-visible ([#139](https://github.com/dativo-io/talon/issues/139))
 - **Error contract** with stable machine codes ([#142](https://github.com/dativo-io/talon/issues/142), [#195](https://github.com/dativo-io/talon/issues/195))
-- **Session summary contract** for `talon session show` ([#271](https://github.com/dativo-io/talon/issues/271))
 - **Per-execution tool lifecycle evidence + tool-destination egress** on the MCP path ([#146](https://github.com/dativo-io/talon/issues/146))
 - **Read-only operations dashboard** over the same semantics the CLI uses ([#143](https://github.com/dativo-io/talon/issues/143))
 

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -468,6 +469,13 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 		fmt.Fprintln(w, "  (no records)")
 		return
 	}
+	renderSessionSummaryBody(w, sum)
+}
+
+// renderSessionSummaryBody prints the summary lines below the header — shared
+// by `talon audit --session` and `talon session show` (#271) so the two
+// commands can never describe the same session differently.
+func renderSessionSummaryBody(w io.Writer, sum evidence.SessionSummary) {
 	fmt.Fprintf(w, "  Tenant:    %s\n", sum.TenantID)
 	if len(sum.AgentIDs) > 0 {
 		fmt.Fprintf(w, "  Agent:     %s\n", strings.Join(sum.AgentIDs, ", "))
@@ -475,10 +483,19 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 	if sum.Client != "" || sum.SessionSource != "" {
 		fmt.Fprintf(w, "  Source:    %s (%s)\n", sum.Client, sum.SessionSource)
 	}
-	fmt.Fprintf(w, "  Window:    %s → %s\n",
-		sum.FirstSeen.Format(time.RFC3339), sum.LastSeen.Format(time.RFC3339))
-	fmt.Fprintf(w, "  Requests:  %d (%d allowed, %d denied, %d error)\n",
+	fmt.Fprintf(w, "  Window:    %s → %s (%s)\n",
+		sum.FirstSeen.Format(time.RFC3339), sum.LastSeen.Format(time.RFC3339),
+		formatSessionDuration(sum.DurationMS))
+	fmt.Fprintf(w, "  Requests:  %d LLM", sum.Requests)
+	if sum.ToolCalls > 0 {
+		fmt.Fprintf(w, " · %d tool calls", sum.ToolCalls)
+	}
+	fmt.Fprintf(w, " · %d records (%d allowed, %d denied, %d error)\n",
 		sum.RecordCount, sum.Allowed, sum.Denied, sum.Errors)
+	renderSessionReliability(w, sum)
+	if len(sum.ProviderPath) > 0 {
+		fmt.Fprintf(w, "  Path:      %s\n", strings.Join(sum.ProviderPath, " → "))
+	}
 	if len(sum.Providers) > 0 {
 		fmt.Fprintf(w, "  Providers: %s\n", strings.Join(sum.Providers, ", "))
 	}
@@ -488,6 +505,16 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 	fmt.Fprintf(w, "  Tokens:    in %d / out %d / cache-read %d / cache-write %d\n",
 		sum.InputTokens, sum.OutputTokens, sum.CacheReadTokens, sum.CacheWriteTokens)
 	fmt.Fprintf(w, "  Cost:      %s\n", formatMoney(sum.Currency, sum.TotalCost))
+	renderSessionDenials(w, sum)
+	renderSessionInterventions(w, sum)
+	renderSessionToolCalls(w, sum)
+	if sum.LastFailure != nil {
+		fmt.Fprintf(w, "  Failure:   [%s] %s", sum.LastFailure.At.Format(time.RFC3339), sum.LastFailure.Code)
+		if sum.LastFailure.Detail != "" && sum.LastFailure.Detail != sum.LastFailure.Code {
+			fmt.Fprintf(w, ": %s", sum.LastFailure.Detail)
+		}
+		fmt.Fprintln(w)
+	}
 	if sessionHasAgentBreakdown(sum) {
 		fmt.Fprintln(w, "\n  Per-agent:")
 		for i := range sum.Subagents {
@@ -504,6 +531,115 @@ func renderSessionSummary(w io.Writer, sum evidence.SessionSummary) {
 				id, parent, a.RecordCount, formatMoney(sum.Currency, a.TotalCost), a.InputTokens, a.OutputTokens)
 		}
 	}
+}
+
+// renderSessionReliability prints the retry/fallback line when the session saw
+// any reliability event.
+func renderSessionReliability(w io.Writer, sum evidence.SessionSummary) {
+	if sum.Retries == 0 && sum.FailedAttempts == 0 && sum.Fallbacks == 0 && sum.FailClosed == 0 {
+		return
+	}
+	parts := []string{}
+	if sum.Retries > 0 {
+		parts = append(parts, fmt.Sprintf("retries %d", sum.Retries))
+	}
+	if sum.FailedAttempts > 0 {
+		parts = append(parts, fmt.Sprintf("failed attempts %d", sum.FailedAttempts))
+	}
+	if sum.Fallbacks > 0 {
+		parts = append(parts, fmt.Sprintf("fallbacks %d", sum.Fallbacks))
+	}
+	if sum.FailClosed > 0 {
+		parts = append(parts, fmt.Sprintf("fail-closed %d", sum.FailClosed))
+	}
+	fmt.Fprintf(w, "  Reliability: %s\n", strings.Join(parts, " · "))
+}
+
+// renderSessionDenials prints denial counts bucketed by machine reason code,
+// most frequent first (ties by code for a stable line).
+func renderSessionDenials(w io.Writer, sum evidence.SessionSummary) {
+	if len(sum.DeniedByReason) == 0 {
+		return
+	}
+	codes := make([]string, 0, len(sum.DeniedByReason))
+	for code := range sum.DeniedByReason {
+		codes = append(codes, code)
+	}
+	sort.Slice(codes, func(i, j int) bool {
+		if sum.DeniedByReason[codes[i]] != sum.DeniedByReason[codes[j]] {
+			return sum.DeniedByReason[codes[i]] > sum.DeniedByReason[codes[j]]
+		}
+		return codes[i] < codes[j]
+	})
+	parts := make([]string, 0, len(codes))
+	for _, code := range codes {
+		parts = append(parts, fmt.Sprintf("%s ×%d", code, sum.DeniedByReason[code]))
+	}
+	fmt.Fprintf(w, "  Denials:   %s\n", strings.Join(parts, ", "))
+}
+
+// renderSessionInterventions prints the policy-intervention line: PII
+// redactions, tool filtering, shadow-mode violations.
+func renderSessionInterventions(w io.Writer, sum evidence.SessionSummary) {
+	parts := []string{}
+	if sum.PIIRedactions > 0 {
+		p := fmt.Sprintf("PII redacted ×%d", sum.PIIRedactions)
+		if len(sum.PIITypes) > 0 {
+			p += " (" + strings.Join(sum.PIITypes, ", ") + ")"
+		}
+		parts = append(parts, p)
+	} else if len(sum.PIITypes) > 0 {
+		parts = append(parts, "PII detected ("+strings.Join(sum.PIITypes, ", ")+")")
+	}
+	if sum.ToolFilterEvents > 0 {
+		p := fmt.Sprintf("tools filtered ×%d", sum.ToolFilterEvents)
+		if len(sum.ToolsFiltered) > 0 {
+			p += " (" + strings.Join(sum.ToolsFiltered, ", ") + ")"
+		}
+		parts = append(parts, p)
+	}
+	if sum.ShadowViolations > 0 {
+		parts = append(parts, fmt.Sprintf("shadow violations ×%d", sum.ShadowViolations))
+	}
+	if len(parts) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "  Interventions: %s\n", strings.Join(parts, " · "))
+}
+
+// renderSessionToolCalls prints the intercepted-MCP line. The count covers
+// only calls Talon intercepted — local actions that bypass Talon are invisible
+// by design and never implied.
+func renderSessionToolCalls(w io.Writer, sum evidence.SessionSummary) {
+	if sum.ToolCalls == 0 {
+		return
+	}
+	allowed := sum.ToolCalls - sum.ToolCallsDenied - sum.ToolCallsFailed
+	line := fmt.Sprintf("  Tool calls: %d intercepted (%d allowed", sum.ToolCalls, allowed)
+	if sum.ToolCallsDenied > 0 {
+		line += fmt.Sprintf(", %d denied", sum.ToolCallsDenied)
+	}
+	if sum.ToolCallsFailed > 0 {
+		line += fmt.Sprintf(", %d failed upstream", sum.ToolCallsFailed)
+	}
+	line += ")"
+	if len(sum.ToolNames) > 0 {
+		line += " — " + strings.Join(sum.ToolNames, ", ")
+	}
+	fmt.Fprintln(w, line)
+}
+
+// formatSessionDuration renders the observed window compactly (e.g. "4m12s");
+// sub-second windows render as "<1s" so a one-record session isn't "0s".
+func formatSessionDuration(ms int64) string {
+	if ms <= 0 {
+		return "single record"
+	}
+	if ms < 1000 {
+		return "<1s"
+	}
+	d := time.Duration(ms) * time.Millisecond
+	return d.Round(time.Second).String()
 }
 
 // sessionHasAgentBreakdown reports whether the per-agent table adds information

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -3,19 +3,25 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dativo-io/talon/internal/config"
+	"github.com/dativo-io/talon/internal/evidence"
 	talonsession "github.com/dativo-io/talon/internal/session"
 )
 
 var (
-	sessTenant string
-	sessStatus string
+	sessTenant     string
+	sessStatus     string
+	sessListJSON   bool
+	sessShowTenant string
+	sessShowJSON   bool
 )
 
 var sessionCmd = &cobra.Command{
@@ -31,14 +37,25 @@ var sessionListCmd = &cobra.Command{
 
 var sessionShowCmd = &cobra.Command{
 	Use:   "show [session-id]",
-	Short: "Show session details",
-	Args:  cobra.ExactArgs(1),
-	RunE:  sessionShow,
+	Short: "Show the session summary (status, cost, reliability, interventions, tool calls)",
+	Long: `Show the operational summary of a session: status, duration, cost, request
+count, retries/fallbacks/denials, intercepted tool calls, the provider path
+that served it, key policy interventions, and a failure explanation when the
+session failed.
+
+Accepts the internal id (sess_...) or the external client/vendor-asserted
+session id. The summary covers only traffic Talon intercepted — local actions
+that bypass Talon are invisible and are not part of this account.`,
+	Args: cobra.ExactArgs(1),
+	RunE: sessionShow,
 }
 
 func init() {
 	sessionListCmd.Flags().StringVar(&sessTenant, "tenant", "default", "Tenant ID")
 	sessionListCmd.Flags().StringVar(&sessStatus, "status", "", "Filter by status")
+	sessionListCmd.Flags().BoolVar(&sessListJSON, "json", false, "Emit the session rows as JSON")
+	sessionShowCmd.Flags().StringVar(&sessShowTenant, "tenant", "", "Scope to a tenant (default: unscoped operator read)")
+	sessionShowCmd.Flags().BoolVar(&sessShowJSON, "json", false, "Emit the session detail as JSON")
 	sessionCmd.AddCommand(sessionListCmd, sessionShowCmd)
 	rootCmd.AddCommand(sessionCmd)
 }
@@ -54,20 +71,37 @@ func sessionList(cmd *cobra.Command, args []string) error {
 	}
 	defer store.Close()
 
-	// Operator CLI on the local DB: tenant-wide view (no agent scope).
+	// Operator CLI on the local DB: tenant-wide view (no agent scope). Only
+	// real asserted/talon sessions have rows — synthetic request-level ids
+	// never reach this store, so they cannot appear here (#271 boundary).
 	sessions, err := store.ListByTenant(context.Background(), sessTenant, "", talonsession.Status(sessStatus))
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
 
-	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tSTATUS\tAGENT\tCOST\tTOKENS\tCREATED")
-	for _, s := range sessions {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%.4f\t%d\t%s\n",
-			s.ID, s.Status, s.AgentID, s.TotalCost, s.TotalTokens, s.CreatedAt.Format("2006-01-02 15:04:05"))
+	if sessListJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(sessions)
 	}
-	tw.Flush()
-	return nil
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tSESSION\tSOURCE\tSTATUS\tAGENT\tCOST\tTOKENS\tCREATED")
+	for _, s := range sessions {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%.4f\t%d\t%s\n",
+			s.ID, valueOrDash(s.ExternalSessionID), valueOrDash(s.Source), s.Status, s.AgentID,
+			s.TotalCost, s.TotalTokens, s.CreatedAt.Format("2006-01-02 15:04:05"))
+	}
+	return tw.Flush()
+}
+
+// sessionDetail is the `session show` contract: the session-store row (when
+// one exists) plus the evidence-derived summary. The summary is built by
+// evidence.BuildSessionSummary — the same pure function behind the dashboard
+// session drill-down, so the two views cannot disagree (#271).
+type sessionDetail struct {
+	Session   *talonsession.Session   `json:"session,omitempty"`
+	Ambiguous []*talonsession.Session `json:"ambiguous_sessions,omitempty"`
+	Summary   evidence.SessionSummary `json:"summary"`
 }
 
 func sessionShow(cmd *cobra.Command, args []string) error {
@@ -80,14 +114,126 @@ func sessionShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("opening session store: %w", err)
 	}
 	defer store.Close()
-
-	// Local CLI has direct DB access: unscoped read (operator context).
-	sess, err := store.Get(context.Background(), args[0], "")
+	evStore, err := evidence.NewStore(cfg.EvidenceDBPath(), cfg.SigningKey)
 	if err != nil {
-		return fmt.Errorf("getting session %s: %w", args[0], err)
+		return fmt.Errorf("opening evidence store: %w", err)
+	}
+	defer evStore.Close()
+
+	detail, err := loadSessionDetail(cmd.Context(), store, evStore, args[0], sessShowTenant)
+	if err != nil {
+		return err
+	}
+	if sessShowJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(detail)
+	}
+	renderSessionDetail(cmd.OutOrStdout(), args[0], detail)
+	if len(detail.Ambiguous) > 0 {
+		return fmt.Errorf("external session id %q matches %d sessions; re-run with an internal id", args[0], len(detail.Ambiguous))
+	}
+	return nil
+}
+
+// loadSessionDetail resolves the argument against both id namespaces (internal
+// sess_... primary key, then external asserted id) and joins the row with the
+// session's evidence records. A session with evidence but no row (e.g. one
+// asserted only on the MCP proxy path) still gets a summary.
+func loadSessionDetail(ctx context.Context, store *talonsession.Store, evStore *evidence.Store, idOrExternal, tenant string) (*sessionDetail, error) {
+	detail := &sessionDetail{}
+	sess, err := store.Get(ctx, idOrExternal, tenant)
+	switch {
+	case err == nil:
+		detail.Session = sess
+	case errors.Is(err, talonsession.ErrSessionNotFound):
+		matches, listErr := store.ListByExternalID(ctx, idOrExternal, tenant)
+		if listErr != nil {
+			return nil, listErr
+		}
+		switch len(matches) {
+		case 0: // evidence-only session, or unknown id — decided below
+		case 1:
+			detail.Session = matches[0]
+		default:
+			detail.Ambiguous = matches
+			return detail, nil
+		}
+	default:
+		return nil, fmt.Errorf("getting session %s: %w", idOrExternal, err)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(sess)
+	// Evidence keys sessions by the EXTERNAL id when one was asserted; runner
+	// lifecycle sessions use the internal id itself.
+	evidenceKey := idOrExternal
+	if detail.Session != nil {
+		evidenceKey = detail.Session.ID
+		if detail.Session.ExternalSessionID != "" {
+			evidenceKey = detail.Session.ExternalSessionID
+		}
+	}
+	records, err := fetchSessionRecords(ctx, evStore, evidenceKey, tenant, "")
+	if err != nil {
+		return nil, err
+	}
+	if detail.Session == nil && len(records) == 0 {
+		return nil, fmt.Errorf("session %s not found (no session row, no evidence records)", idOrExternal)
+	}
+	detail.Summary = evidence.BuildSessionSummary(evidenceKey, records)
+	return detail, nil
+}
+
+// renderSessionDetail prints the one-screen session summary: the store row's
+// lifecycle facts, then the shared evidence rollup.
+func renderSessionDetail(w io.Writer, requested string, detail *sessionDetail) {
+	if len(detail.Ambiguous) > 0 {
+		fmt.Fprintf(w, "External session id %s matches %d sessions:\n", requested, len(detail.Ambiguous))
+		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "ID\tTENANT\tAGENT\tSTATUS\tCREATED")
+		for _, s := range detail.Ambiguous {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.TenantID, s.AgentID, s.Status, s.CreatedAt.Format("2006-01-02 15:04:05"))
+		}
+		tw.Flush()
+		return
+	}
+
+	sum := detail.Summary
+	sess := detail.Session
+	header := sum.SessionID
+	if sess != nil {
+		header = sess.ID
+		if sess.ExternalSessionID != "" {
+			header += " (external: " + sess.ExternalSessionID + ")"
+		}
+	}
+	fmt.Fprintf(w, "Session %s\n", header)
+	renderSessionRow(w, sess)
+	if sum.RecordCount == 0 {
+		fmt.Fprintln(w, "  (no evidence records)")
+		return
+	}
+	renderSessionSummaryBody(w, sum)
+}
+
+// renderSessionRow prints the lifecycle facts held by the session store. A
+// missing row is stated plainly: the session was observed in evidence only.
+func renderSessionRow(w io.Writer, sess *talonsession.Session) {
+	if sess == nil {
+		fmt.Fprintln(w, "  Status:    (no session row — observed in evidence only)")
+		return
+	}
+	status := fmt.Sprintf("  Status:    %s — created %s", sess.Status, sess.CreatedAt.Format(time.RFC3339))
+	if sess.CompletedAt != nil {
+		status += ", completed " + sess.CompletedAt.Format(time.RFC3339)
+	} else if !sess.UpdatedAt.Equal(sess.CreatedAt) {
+		status += ", last activity " + sess.UpdatedAt.Format(time.RFC3339)
+	}
+	fmt.Fprintln(w, status)
+	if sess.Source != "" {
+		fmt.Fprintf(w, "  Asserted:  %s\n", sess.Source)
+	}
+	if sess.MaxCost > 0 {
+		fmt.Fprintf(w, "  Budget:    session cap %s, tracked spend %s\n",
+			formatMoney("", sess.MaxCost), formatMoney("", sess.TotalCost))
+	}
 }

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	talonsession "github.com/dativo-io/talon/internal/session"
+)
+
+const sessTestSigningKey = "test-signing-key-1234567890123456"
+
+// sessionTestEnv points config.Load at a temp data dir and resets the
+// package-level session flags (cobra flag values persist across Execute calls
+// within one test binary).
+func sessionTestEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TALON_DATA_DIR", dir)
+	t.Setenv("TALON_SIGNING_KEY", sessTestSigningKey)
+	sessTenant, sessStatus, sessListJSON = "default", "", false
+	sessShowTenant, sessShowJSON = "", false
+	return dir
+}
+
+func sessionTestStores(t *testing.T, dir string) (sessions *talonsession.Store, ev *evidence.Store) {
+	t.Helper()
+	dbPath := filepath.Join(dir, "evidence.db")
+	sessions, err := talonsession.NewStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sessions.Close() })
+	ev, err = evidence.NewStore(dbPath, sessTestSigningKey)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ev.Close() })
+	return sessions, ev
+}
+
+func runSessionCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// seedOperationalSession stores the #271 acceptance fixture under external
+// session id ext-sess-1: a served request, a failed failover attempt, a
+// fallback-served request, a budget denial, and a blocked MCP tool call.
+func seedOperationalSession(t *testing.T, evStore *evidence.Store) {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-10 * time.Minute)
+	put := func(id string, ev *evidence.Evidence) {
+		ev.ID = id
+		ev.CorrelationID = "corr_" + id
+		ev.SessionID = "ext-sess-1"
+		ev.TenantID = "default"
+		ev.AgentID = "support-bot"
+		require.NoError(t, evStore.Store(ctx, ev))
+	}
+	put("e_served", &evidence.Evidence{
+		Timestamp:       base,
+		InvocationType:  "gateway",
+		PolicyDecision:  evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		RoutingDecision: &evidence.RoutingDecision{SelectedProvider: "anthropic"},
+		ToolGovernance: &evidence.ToolGovernance{
+			ToolsRequested: []string{"delete_record", "search"},
+			ToolsFiltered:  []string{"delete_record"},
+			ToolsForwarded: []string{"search"},
+		},
+		Classification: evidence.Classification{PIIRedacted: true, PIIDetected: []string{"EMAIL"}},
+		Execution: evidence.Execution{
+			ModelUsed: "claude-sonnet-5", Cost: 0.10, Currency: "EUR",
+			Tokens: evidence.TokenUsage{Input: 1000, Output: 200},
+		},
+	})
+	put("e_attempt", &evidence.Evidence{
+		Timestamp:      base.Add(1 * time.Minute),
+		InvocationType: "gateway_failover_attempt",
+		Status:         "failed",
+		FailureReason:  evidence.FailureReasonProviderTransient,
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Execution:      evidence.Execution{ModelUsed: "claude-sonnet-5", Error: "upstream status 529"},
+		Failover:       &evidence.FailoverContext{Role: evidence.FailoverRoleFailedAttempt, Provider: "anthropic", Model: "claude-sonnet-5"},
+	})
+	put("e_fallback", &evidence.Evidence{
+		Timestamp:      base.Add(2 * time.Minute),
+		InvocationType: "gateway",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Execution: evidence.Execution{
+			ModelUsed: "gpt-5", Cost: 0.08, Currency: "EUR",
+			Tokens: evidence.TokenUsage{Input: 800, Output: 150},
+		},
+		Failover: &evidence.FailoverContext{Role: evidence.FailoverRoleFallbackDecision, Provider: "openai", Model: "gpt-5"},
+	})
+	put("e_denied", &evidence.Evidence{
+		Timestamp:      base.Add(3 * time.Minute),
+		InvocationType: "gateway",
+		PolicyDecision: evidence.PolicyDecision{
+			Allowed: false, Action: "deny",
+			Reasons: []string{"session_budget_exceeded: estimated cost exceeds remaining session budget"},
+		},
+	})
+	put("e_toolblocked", &evidence.Evidence{
+		Timestamp:      base.Add(90 * time.Second),
+		InvocationType: "proxy_tool_blocked",
+		PolicyDecision: evidence.PolicyDecision{Allowed: false, Action: "deny", Reasons: []string{"mcp_tool_denied: delete_record"}},
+		Execution:      evidence.Execution{ToolsCalled: []string{"delete_record"}, Error: "mcp_tool_denied: delete_record"},
+	})
+}
+
+// The mandatory #271 screen: a session with a fallback and a denial shows
+// both, with counts and the provider path, plus interventions, tool calls,
+// and a failure explanation — via the external id or the internal id.
+func TestSessionShow_OperationalSummary(t *testing.T) {
+	dir := sessionTestEnv(t)
+	sessStore, evStore := sessionTestStores(t, dir)
+	sess, err := sessStore.GetOrCreateExternal(context.Background(), "default", "support-bot", "ext-sess-1", talonsession.SourceClientAsserted)
+	require.NoError(t, err)
+	seedOperationalSession(t, evStore)
+
+	for _, id := range []string{"ext-sess-1", sess.ID} {
+		out, err := runSessionCmd(t, "session", "show", id)
+		require.NoError(t, err, "show %s", id)
+		assert.Contains(t, out, "Status:    active", "store row status must render")
+		assert.Contains(t, out, "Asserted:  client_asserted")
+		assert.Contains(t, out, "Requests:  3 LLM · 1 tool calls · 5 records")
+		assert.Contains(t, out, "failed attempts 1")
+		assert.Contains(t, out, "fallbacks 1")
+		assert.Contains(t, out, "Path:      anthropic/claude-sonnet-5 → openai/gpt-5")
+		assert.Contains(t, out, "mcp_tool_denied ×1")
+		assert.Contains(t, out, "session_budget_exceeded ×1")
+		assert.Contains(t, out, "PII redacted ×1 (EMAIL)")
+		assert.Contains(t, out, "tools filtered ×1 (delete_record)")
+		assert.Contains(t, out, "Tool calls: 1 intercepted (0 allowed, 1 denied) — delete_record")
+		assert.Contains(t, out, "Failure:   ", "failed session must carry a one-line explanation")
+		assert.Contains(t, out, "session_budget_exceeded: estimated cost exceeds remaining session budget")
+	}
+}
+
+// --json must be the same structure the dashboard drill-down serves: the
+// summary equals evidence.BuildSessionSummary over the session's records
+// (shared code path — the parity contract of #271).
+func TestSessionShow_JSONMatchesSharedProjection(t *testing.T) {
+	dir := sessionTestEnv(t)
+	sessStore, evStore := sessionTestStores(t, dir)
+	_, err := sessStore.GetOrCreateExternal(context.Background(), "default", "support-bot", "ext-sess-1", talonsession.SourceClientAsserted)
+	require.NoError(t, err)
+	seedOperationalSession(t, evStore)
+
+	out, err := runSessionCmd(t, "session", "show", "ext-sess-1", "--json")
+	require.NoError(t, err)
+	var got struct {
+		Session *talonsession.Session   `json:"session"`
+		Summary evidence.SessionSummary `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.NotNil(t, got.Session)
+	assert.Equal(t, "ext-sess-1", got.Session.ExternalSessionID)
+
+	records, err := evStore.ListBySessionID(context.Background(), "ext-sess-1")
+	require.NoError(t, err)
+	want := evidence.BuildSessionSummary("ext-sess-1", records)
+	assert.Equal(t, want.Requests, got.Summary.Requests)
+	assert.Equal(t, want.Fallbacks, got.Summary.Fallbacks)
+	assert.Equal(t, want.FailedAttempts, got.Summary.FailedAttempts)
+	assert.Equal(t, want.DeniedByReason, got.Summary.DeniedByReason)
+	assert.Equal(t, want.ProviderPath, got.Summary.ProviderPath)
+	assert.Equal(t, want.ToolCalls, got.Summary.ToolCalls)
+	assert.Equal(t, want.PIITypes, got.Summary.PIITypes)
+	assert.InDelta(t, want.TotalCost, got.Summary.TotalCost, 1e-9)
+	require.NotNil(t, got.Summary.LastFailure)
+	assert.Equal(t, want.LastFailure.Code, got.Summary.LastFailure.Code)
+}
+
+// A session asserted only on a path that creates no session row (e.g. MCP
+// proxy) still gets a summary, stated as evidence-only — never a fake row.
+func TestSessionShow_EvidenceOnlySession(t *testing.T) {
+	dir := sessionTestEnv(t)
+	_, evStore := sessionTestStores(t, dir)
+	require.NoError(t, evStore.Store(context.Background(), &evidence.Evidence{
+		ID: "e_only", CorrelationID: "corr_e_only", SessionID: "proxy-sess-9",
+		Timestamp: time.Now().UTC(), TenantID: "default", AgentID: "support-bot",
+		InvocationType: "proxy_tool_call",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+		Execution:      evidence.Execution{ToolsCalled: []string{"search_kb"}},
+	}))
+
+	out, err := runSessionCmd(t, "session", "show", "proxy-sess-9")
+	require.NoError(t, err)
+	assert.Contains(t, out, "(no session row — observed in evidence only)")
+	assert.Contains(t, out, "Tool calls: 1 intercepted (1 allowed) — search_kb")
+}
+
+func TestSessionShow_UnknownIDFails(t *testing.T) {
+	dir := sessionTestEnv(t)
+	sessionTestStores(t, dir)
+	_, err := runSessionCmd(t, "session", "show", "no-such-session")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// Two agents asserting the same external id are separate sessions (#198
+// tuple); showing that external id must surface the ambiguity, not silently
+// pick one.
+func TestSessionShow_AmbiguousExternalID(t *testing.T) {
+	dir := sessionTestEnv(t)
+	sessStore, _ := sessionTestStores(t, dir)
+	ctx := context.Background()
+	_, err := sessStore.GetOrCreateExternal(ctx, "default", "agent-a", "shared-ext", talonsession.SourceClientAsserted)
+	require.NoError(t, err)
+	_, err = sessStore.GetOrCreateExternal(ctx, "default", "agent-b", "shared-ext", talonsession.SourceClientAsserted)
+	require.NoError(t, err)
+
+	out, err := runSessionCmd(t, "session", "show", "shared-ext")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matches 2 sessions")
+	assert.Contains(t, out, "agent-a")
+	assert.Contains(t, out, "agent-b")
+}
+
+// `session list` shows the asserted external id and source, and synthetic
+// request-level ids never appear: they have no session rows by design (#271
+// boundary) — only evidence correlation.
+func TestSessionList_SourcesShownSyntheticExcluded(t *testing.T) {
+	dir := sessionTestEnv(t)
+	sessStore, evStore := sessionTestStores(t, dir)
+	ctx := context.Background()
+	_, err := sessStore.GetOrCreateExternal(ctx, "default", "support-bot", "ext-sess-1", talonsession.SourceClientAsserted)
+	require.NoError(t, err)
+	// Synthetic request-level id: evidence only, no session row.
+	require.NoError(t, evStore.Store(ctx, &evidence.Evidence{
+		ID: "e_syn", CorrelationID: "corr_e_syn", SessionID: "sess_gw_synthetic99",
+		Timestamp: time.Now().UTC(), TenantID: "default", AgentID: "support-bot",
+		InvocationType: "gateway",
+		PolicyDecision: evidence.PolicyDecision{Allowed: true, Action: "allow"},
+	}))
+
+	out, err := runSessionCmd(t, "session", "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "SOURCE")
+	assert.Contains(t, out, "ext-sess-1")
+	assert.Contains(t, out, "client_asserted")
+	assert.NotContains(t, out, "sess_gw_synthetic99", "synthetic ids must not be presented as sessions")
+
+	jsonOut, err := runSessionCmd(t, "session", "list", "--json")
+	require.NoError(t, err)
+	var rows []*talonsession.Session
+	require.NoError(t, json.Unmarshal([]byte(jsonOut), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "ext-sess-1", rows[0].ExternalSessionID)
+}

--- a/internal/evidence/record_class.go
+++ b/internal/evidence/record_class.go
@@ -71,6 +71,20 @@ var nonRequestClass = map[string]RecordClass{
 	CacheEventErasureUser:   ClassToolEvent,
 }
 
+// toolActionType is the closed registry of request-class invocation types that
+// are intercepted tool actions rather than LLM traffic units: MCP calls Talon
+// proxied or served, with their terminal outcome. Session summaries (#271)
+// split these out of the request count so "9 requests, 3 tool calls" reads
+// truthfully. Registered here, next to nonRequestClass, so a new tool-shaped
+// invocation type is classified in one place.
+var toolActionType = map[string]struct{}{
+	"proxy_tool_call":       {}, // proxied MCP tools/call, allowed and forwarded
+	"proxy_tool_blocked":    {}, // proxied MCP tools/call, denied by policy
+	"proxy_upstream_error":  {}, // proxied MCP tools/call, upstream failed (#357)
+	"proxy_method_rejected": {}, // ungoverned MCP method rejected fail-closed (#356)
+	"mcp":                   {}, // Talon MCP server tools/call
+}
+
 // RecordClassOf returns the class of an invocation type. Unknown/empty →
 // ClassRequest by design (see ClassRequest).
 func RecordClassOf(invocationType string) RecordClass {
@@ -78,6 +92,13 @@ func RecordClassOf(invocationType string) RecordClass {
 		return c
 	}
 	return ClassRequest
+}
+
+// IsToolActionType reports whether a request-class invocation type is an
+// intercepted tool action (MCP call) rather than an LLM request.
+func IsToolActionType(invocationType string) bool {
+	_, ok := toolActionType[invocationType]
+	return ok
 }
 
 // IsRequestClass reports whether an invocation type counts as request traffic.

--- a/internal/evidence/record_class_test.go
+++ b/internal/evidence/record_class_test.go
@@ -55,6 +55,26 @@ func TestRecordClassOf(t *testing.T) {
 	}
 }
 
+// TestIsToolActionType pins the tool-action registry (#271): intercepted MCP
+// calls stay request-class for traffic queries but are split out of the
+// session summary's LLM request count.
+func TestIsToolActionType(t *testing.T) {
+	toolActions := []string{"proxy_tool_call", "proxy_tool_blocked", "proxy_upstream_error", "proxy_method_rejected", "mcp"}
+	for _, it := range toolActions {
+		if !IsToolActionType(it) {
+			t.Errorf("IsToolActionType(%q) = false, want true", it)
+		}
+		if !IsRequestClass(it) {
+			t.Errorf("IsRequestClass(%q) = false — tool actions must stay request-class for traffic queries", it)
+		}
+	}
+	for _, it := range []string{"", "gateway", "manual", "gateway_failover_attempt", "proxy_shadow_violation"} {
+		if IsToolActionType(it) {
+			t.Errorf("IsToolActionType(%q) = true, want false", it)
+		}
+	}
+}
+
 // TestRequestClassSQLPredicate asserts the generated predicate is deterministic,
 // excludes every non-request type, and permits NULL/empty (request-class).
 func TestRequestClassSQLPredicate(t *testing.T) {

--- a/internal/evidence/session_summary.go
+++ b/internal/evidence/session_summary.go
@@ -2,6 +2,7 @@ package evidence
 
 import (
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -39,6 +40,61 @@ type SessionSummary struct {
 	FirstSeen        time.Time            `json:"first_seen"`
 	LastSeen         time.Time            `json:"last_seen"`
 	Subagents        []SessionAgentRollup `json:"subagents,omitempty"`
+
+	// Operational contract (#271). Everything below is derived from the same
+	// records as the totals above, so the CLI and dashboard cannot disagree.
+
+	// Requests counts request-class records that are LLM traffic units —
+	// provider sub-attempts (RecordClassOf) and intercepted tool actions
+	// (IsToolActionType) are split out. RecordCount keeps counting everything.
+	Requests int `json:"requests"`
+	// DurationMS is the observed traffic window (LastSeen − FirstSeen); zero
+	// for a single-record session.
+	DurationMS int64 `json:"duration_ms,omitempty"`
+
+	// Reliability facts. Retries counts records echoing a caller-asserted
+	// X-Talon-Retry-Attempt; the failover counts mirror the fleet definitions
+	// (FallbackCountsByAgent counts fallback_decision dispatches only).
+	Retries        int `json:"retries,omitempty"`
+	FailedAttempts int `json:"failed_attempts,omitempty"`
+	Fallbacks      int `json:"fallbacks,omitempty"`
+	FailClosed     int `json:"fail_closed,omitempty"`
+
+	// DeniedByReason buckets denials by machine reason code (DenyReasonCode),
+	// so budget denials are distinguishable from PII or egress blocks.
+	DeniedByReason map[string]int `json:"denied_by_reason,omitempty"`
+
+	// ProviderPath lists "provider/model" in order of first serving — the path
+	// that actually served the session, fallbacks included.
+	ProviderPath []string `json:"provider_path,omitempty"`
+
+	// Tool actions visible to Talon: intercepted MCP calls with their
+	// decisions. Local actions that bypass Talon are invisible and are not
+	// represented here — this is not a complete account of agent activity.
+	ToolCalls       int      `json:"tool_calls,omitempty"`
+	ToolCallsDenied int      `json:"tool_calls_denied,omitempty"`
+	ToolCallsFailed int      `json:"tool_calls_failed,omitempty"`
+	ToolNames       []string `json:"tool_names,omitempty"`
+
+	// Policy interventions on LLM requests.
+	ToolsFiltered    []string `json:"tools_filtered,omitempty"`
+	ToolFilterEvents int      `json:"tool_filter_events,omitempty"`
+	PIIRedactions    int      `json:"pii_redactions,omitempty"`
+	PIITypes         []string `json:"pii_types,omitempty"`
+	ShadowViolations int      `json:"shadow_violation_records,omitempty"`
+
+	// LastFailure is the newest deny or execution failure in the session — the
+	// one-line explanation for "why did this fail".
+	LastFailure *SessionFailure `json:"last_failure,omitempty"`
+}
+
+// SessionFailure is the newest failure observed in a session: a machine code
+// (structured failure_reason, deny reason code, or "error") plus a short
+// human-readable detail sourced from the record.
+type SessionFailure struct {
+	At     time.Time `json:"at"`
+	Code   string    `json:"code"`
+	Detail string    `json:"detail,omitempty"`
 }
 
 // SessionAgentRollup is the per-subagent slice of a session. AgentID is the
@@ -80,6 +136,18 @@ type sessionAgg struct {
 	// orchAt is the timestamp of the record whose orchestration block
 	// currently supplies SessionSource/Client (earliest wins).
 	orchAt time.Time
+	// pathHops collects (timestamp, provider/model) pairs for records that
+	// actually served; ordered into ProviderPath in finish() because input
+	// order is not guaranteed.
+	pathHops  []pathHop
+	toolNames map[string]struct{}
+	filtered  map[string]struct{}
+	piiTypes  map[string]struct{}
+}
+
+type pathHop struct {
+	at    time.Time
+	label string
 }
 
 func newSessionAgg(sessionID string) *sessionAgg {
@@ -89,6 +157,9 @@ func newSessionAgg(sessionID string) *sessionAgg {
 		providers: map[string]struct{}{},
 		models:    map[string]struct{}{},
 		subagents: map[string]*SessionAgentRollup{},
+		toolNames: map[string]struct{}{},
+		filtered:  map[string]struct{}{},
+		piiTypes:  map[string]struct{}{},
 	}
 }
 
@@ -98,6 +169,12 @@ func (a *sessionAgg) add(ev *Evidence) {
 	a.addOutcome(ev)
 	a.addTotals(ev)
 	a.addWindow(ev.Timestamp)
+	a.addClassCounts(ev)
+	a.addReliability(ev)
+	a.addToolAction(ev)
+	a.addInterventions(ev)
+	a.addPathHop(ev)
+	a.addFailure(ev)
 	accumulateAgent(a.subagents, ev)
 }
 
@@ -158,12 +235,207 @@ func (a *sessionAgg) addWindow(t time.Time) {
 	}
 }
 
+// addClassCounts splits the record stream into LLM requests vs everything
+// else: Requests counts only request-class records that are not intercepted
+// tool actions.
+func (a *sessionAgg) addClassCounts(ev *Evidence) {
+	if IsRequestClass(ev.InvocationType) && !IsToolActionType(ev.InvocationType) {
+		a.sum.Requests++
+	}
+	if !ev.PolicyDecision.Allowed {
+		if a.sum.DeniedByReason == nil {
+			a.sum.DeniedByReason = map[string]int{}
+		}
+		a.sum.DeniedByReason[DenyReasonCode(ev.PolicyDecision.Reasons)]++
+	}
+}
+
+func (a *sessionAgg) addReliability(ev *Evidence) {
+	if ev.RetryAttempt != "" {
+		a.sum.Retries++
+	}
+	if ev.Failover == nil {
+		return
+	}
+	switch ev.Failover.Role {
+	case FailoverRoleFailedAttempt:
+		a.sum.FailedAttempts++
+	case FailoverRoleFallbackDecision:
+		a.sum.Fallbacks++
+	case FailoverRoleFailClosed:
+		a.sum.FailClosed++
+	}
+}
+
+// addToolAction rolls up intercepted MCP calls: total, denied, failed
+// upstream, and the distinct tool names Talon saw.
+func (a *sessionAgg) addToolAction(ev *Evidence) {
+	if !IsToolActionType(ev.InvocationType) {
+		return
+	}
+	a.sum.ToolCalls++
+	if !ev.PolicyDecision.Allowed {
+		a.sum.ToolCallsDenied++
+	} else if ev.Execution.Error != "" {
+		a.sum.ToolCallsFailed++
+	}
+	for _, name := range ev.Execution.ToolsCalled {
+		if name != "" {
+			a.toolNames[name] = struct{}{}
+		}
+	}
+}
+
+func (a *sessionAgg) addInterventions(ev *Evidence) {
+	if ev.ToolGovernance != nil {
+		if len(ev.ToolGovernance.ToolsFiltered) > 0 {
+			a.sum.ToolFilterEvents++
+		}
+		for _, name := range ev.ToolGovernance.ToolsFiltered {
+			a.filtered[name] = struct{}{}
+		}
+	}
+	if ev.Classification.PIIRedacted || ev.Classification.InputPIIRedacted {
+		a.sum.PIIRedactions++
+	}
+	for _, t := range ev.Classification.PIIDetected {
+		a.piiTypes[t] = struct{}{}
+	}
+	for _, t := range ev.Classification.OutputPIITypes {
+		a.piiTypes[t] = struct{}{}
+	}
+	if len(ev.ShadowViolations) > 0 {
+		a.sum.ShadowViolations++
+	}
+}
+
+// addPathHop records what actually served the session: terminal request-class
+// records that completed with a model. Failed failover attempts also name a
+// model but did not serve — they are counted in FailedAttempts, not the path.
+// The provider comes from the routing decision when present, from the
+// failover context on fallback dispatches recorded without one.
+func (a *sessionAgg) addPathHop(ev *Evidence) {
+	if ev.Execution.ModelUsed == "" || ev.Execution.Error != "" {
+		return
+	}
+	if !IsRequestClass(ev.InvocationType) || IsToolActionType(ev.InvocationType) {
+		return
+	}
+	provider := ""
+	if ev.RoutingDecision != nil {
+		provider = ev.RoutingDecision.SelectedProvider
+	}
+	if provider == "" && ev.Failover != nil && ev.Failover.Role == FailoverRoleFallbackDecision {
+		provider = ev.Failover.Provider
+	}
+	label := ev.Execution.ModelUsed
+	if provider != "" {
+		label = provider + "/" + label
+	}
+	a.pathHops = append(a.pathHops, pathHop{at: ev.Timestamp, label: label})
+}
+
+// addFailure keeps the NEWEST deny or execution failure as the session's
+// one-line failure explanation.
+func (a *sessionAgg) addFailure(ev *Evidence) {
+	f := failureOf(ev)
+	if f == nil {
+		return
+	}
+	if a.sum.LastFailure == nil || f.At.After(a.sum.LastFailure.At) {
+		a.sum.LastFailure = f
+	}
+}
+
+// maxFailureDetail bounds the human detail line; evidence reasons can embed
+// long policy output.
+const maxFailureDetail = 200
+
+func failureOf(ev *Evidence) *SessionFailure {
+	switch {
+	case !ev.PolicyDecision.Allowed:
+		detail := ""
+		if len(ev.PolicyDecision.Reasons) > 0 {
+			detail = ev.PolicyDecision.Reasons[0]
+		}
+		return &SessionFailure{At: ev.Timestamp, Code: DenyReasonCode(ev.PolicyDecision.Reasons), Detail: truncateDetail(detail)}
+	case ev.Execution.Error != "":
+		code := ev.FailureReason
+		if code == "" {
+			code = "error"
+		}
+		return &SessionFailure{At: ev.Timestamp, Code: code, Detail: truncateDetail(ev.Execution.Error)}
+	default:
+		return nil
+	}
+}
+
+func truncateDetail(s string) string {
+	if len(s) <= maxFailureDetail {
+		return s
+	}
+	return s[:maxFailureDetail] + "…"
+}
+
 func (a *sessionAgg) finish() SessionSummary {
 	a.sum.AgentIDs = sortedKeys(a.agentIDs)
 	a.sum.Providers = sortedKeys(a.providers)
 	a.sum.Models = sortedKeys(a.models)
 	a.sum.Subagents = sortedAgents(a.subagents)
+	a.sum.ToolNames = sortedKeys(a.toolNames)
+	a.sum.ToolsFiltered = sortedKeys(a.filtered)
+	a.sum.PIITypes = sortedKeys(a.piiTypes)
+	a.sum.ProviderPath = orderedPath(a.pathHops)
+	if !a.sum.FirstSeen.IsZero() {
+		a.sum.DurationMS = a.sum.LastSeen.Sub(a.sum.FirstSeen).Milliseconds()
+	}
 	return a.sum
+}
+
+// orderedPath sorts hops by time and keeps the first occurrence of each label,
+// so a fallback session reads "anthropic/x → openai/y" regardless of input
+// order.
+func orderedPath(hops []pathHop) []string {
+	if len(hops) == 0 {
+		return nil
+	}
+	sort.SliceStable(hops, func(i, j int) bool { return hops[i].at.Before(hops[j].at) })
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(hops))
+	for _, h := range hops {
+		if _, ok := seen[h.label]; ok {
+			continue
+		}
+		seen[h.label] = struct{}{}
+		out = append(out, h.label)
+	}
+	return out
+}
+
+// DenyReasonCode classifies a deny by the machine-code prefix convention
+// ("session_budget_exceeded: ...", "budget_exceeded: ...", bare egress codes)
+// so denials bucket by cause instead of lumping under a generic policy_deny
+// (#199). Unrecognized shapes fall back to "policy_deny". Shared by the
+// session summary and the dashboard metrics projection — one classifier.
+func DenyReasonCode(reasons []string) string {
+	if len(reasons) == 0 {
+		return "policy_deny"
+	}
+	code := reasons[0]
+	if i := strings.IndexByte(code, ':'); i >= 0 {
+		code = code[:i]
+	}
+	code = strings.TrimSpace(code)
+	if code == "" || len(code) > 64 {
+		return "policy_deny"
+	}
+	for i := 0; i < len(code); i++ {
+		c := code[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '_' && c != '-' {
+			return "policy_deny"
+		}
+	}
+	return code
 }
 
 // accumulateAgent adds ev into the per-subagent rollup keyed by the

--- a/internal/evidence/session_summary_test.go
+++ b/internal/evidence/session_summary_test.go
@@ -180,6 +180,113 @@ func TestListRecentOrchestrationSessionIDs(t *testing.T) {
 	}
 }
 
+// The #271 operational contract: one session that saw a fallback, a denial, a
+// caller retry, intercepted MCP tool calls, tool filtering, and PII redaction
+// must surface every fact with counts and the serving provider path.
+func TestBuildSessionSummary_OperationalContract(t *testing.T) {
+	served := rec("s", "acme", "coder", true, 0.10, 1000, 200, 0, 0, "anthropic", "claude-sonnet-5", nil)
+	served.Timestamp = ts(1)
+	served.InvocationType = "gateway"
+	served.ToolGovernance = &ToolGovernance{
+		ToolsRequested: []string{"search", "delete_record", "summarize"},
+		ToolsFiltered:  []string{"delete_record"},
+		ToolsForwarded: []string{"search", "summarize"},
+	}
+	served.Classification.PIIRedacted = true
+	served.Classification.PIIDetected = []string{"EMAIL"}
+
+	failedAttempt := rec("s", "acme", "coder", true, 0, 0, 0, 0, 0, "", "claude-sonnet-5", nil)
+	failedAttempt.Timestamp = ts(10)
+	failedAttempt.InvocationType = "gateway_failover_attempt"
+	failedAttempt.Status = "failed"
+	failedAttempt.FailureReason = FailureReasonProviderTransient
+	failedAttempt.Execution.Error = "upstream status 529"
+	failedAttempt.Failover = &FailoverContext{Role: FailoverRoleFailedAttempt, Provider: "anthropic", Model: "claude-sonnet-5"}
+
+	fallbackServed := rec("s", "acme", "coder", true, 0.08, 800, 150, 0, 0, "", "gpt-5", nil)
+	fallbackServed.Timestamp = ts(11)
+	fallbackServed.InvocationType = "gateway"
+	fallbackServed.RetryAttempt = "1"
+	fallbackServed.Failover = &FailoverContext{Role: FailoverRoleFallbackDecision, Provider: "openai", Model: "gpt-5"}
+
+	denied := rec("s", "acme", "coder", false, 0, 0, 0, 0, 0, "", "", nil)
+	denied.Timestamp = ts(20)
+	denied.PolicyDecision.Reasons = []string{"session_budget_exceeded: estimated cost 0.09 exceeds remaining session budget 0.01"}
+
+	toolAllowed := rec("s", "acme", "coder", true, 0, 0, 0, 0, 0, "", "", nil)
+	toolAllowed.Timestamp = ts(5)
+	toolAllowed.InvocationType = "proxy_tool_call"
+	toolAllowed.Execution.ToolsCalled = []string{"search_kb"}
+
+	toolDenied := rec("s", "acme", "coder", false, 0, 0, 0, 0, 0, "", "", nil)
+	toolDenied.Timestamp = ts(6)
+	toolDenied.InvocationType = "proxy_tool_blocked"
+	toolDenied.Execution.ToolsCalled = []string{"delete_record"}
+	toolDenied.PolicyDecision.Reasons = []string{"mcp_tool_denied: delete_record"}
+	toolDenied.Execution.Error = "mcp_tool_denied: delete_record"
+
+	// Newest-first input, the ListBySessionID order.
+	sum := BuildSessionSummary("s", []*Evidence{denied, fallbackServed, failedAttempt, toolDenied, toolAllowed, served})
+
+	assert.Equal(t, 6, sum.RecordCount)
+	assert.Equal(t, 3, sum.Requests, "LLM requests: served, fallback-served, denied — attempt and tool calls split out")
+	assert.Equal(t, 2, sum.ToolCalls)
+	assert.Equal(t, 1, sum.ToolCallsDenied)
+	assert.Equal(t, 0, sum.ToolCallsFailed)
+	assert.Equal(t, []string{"delete_record", "search_kb"}, sum.ToolNames)
+	assert.Equal(t, 1, sum.Retries)
+	assert.Equal(t, 1, sum.FailedAttempts)
+	assert.Equal(t, 1, sum.Fallbacks)
+	assert.Equal(t, 0, sum.FailClosed)
+	assert.Equal(t, map[string]int{"session_budget_exceeded": 1, "mcp_tool_denied": 1}, sum.DeniedByReason)
+	assert.Equal(t, []string{"anthropic/claude-sonnet-5", "openai/gpt-5"}, sum.ProviderPath,
+		"path lists what served, in time order — the failed attempt is not a hop")
+	assert.Equal(t, []string{"delete_record"}, sum.ToolsFiltered)
+	assert.Equal(t, 1, sum.ToolFilterEvents)
+	assert.Equal(t, 1, sum.PIIRedactions)
+	assert.Equal(t, []string{"EMAIL"}, sum.PIITypes)
+	assert.Equal(t, ts(20).Sub(ts(1)).Milliseconds(), sum.DurationMS)
+	if assert.NotNil(t, sum.LastFailure, "denied session must explain its failure") {
+		assert.Equal(t, "session_budget_exceeded", sum.LastFailure.Code)
+		assert.True(t, sum.LastFailure.At.Equal(ts(20)))
+	}
+
+	// Order independence: oldest-first input gives the identical summary.
+	sum2 := BuildSessionSummary("s", []*Evidence{served, toolAllowed, toolDenied, failedAttempt, fallbackServed, denied})
+	assert.Equal(t, sum, sum2, "summary must be input-order independent")
+}
+
+// The failure explanation is the NEWEST deny or execution failure; structured
+// failure_reason wins over the generic "error" code.
+func TestBuildSessionSummary_LastFailureNewestWins(t *testing.T) {
+	older := rec("s", "acme", "c", false, 0, 0, 0, 0, 0, "", "", nil)
+	older.Timestamp = ts(3)
+	older.PolicyDecision.Reasons = []string{"pii_block: EMAIL in tier-2 payload"}
+	newer := rec("s", "acme", "c", true, 0, 0, 0, 0, 0, "", "m", nil)
+	newer.Timestamp = ts(9)
+	newer.Execution.Error = "provider timeout after 30s"
+	newer.FailureReason = "llm_error"
+
+	sum := BuildSessionSummary("s", []*Evidence{older, newer})
+	if assert.NotNil(t, sum.LastFailure) {
+		assert.Equal(t, "llm_error", sum.LastFailure.Code)
+		assert.Equal(t, "provider timeout after 30s", sum.LastFailure.Detail)
+	}
+
+	clean := rec("s", "acme", "c", true, 0.01, 1, 1, 0, 0, "anthropic", "m", nil)
+	assert.Nil(t, BuildSessionSummary("s", []*Evidence{clean}).LastFailure)
+}
+
+// Moved with the classifier from internal/metrics (#271): one deny-reason
+// vocabulary for the dashboard event projection and the session summary.
+func TestDenyReasonCode(t *testing.T) {
+	assert.Equal(t, "policy_deny", DenyReasonCode(nil))
+	assert.Equal(t, "policy_deny", DenyReasonCode([]string{"Data tier 2 exceeds caller restriction (max 1)"}))
+	assert.Equal(t, "session_budget_exceeded", DenyReasonCode([]string{"session_budget_exceeded: spend"}))
+	assert.Equal(t, "egress_tier_destination_disallowed", DenyReasonCode([]string{"egress_tier_destination_disallowed"}))
+	assert.Equal(t, "policy_deny", DenyReasonCode([]string{"<img onerror=alert(1)>: nope"}), "hostile prefix falls back")
+}
+
 // The session's client/source label comes from the EARLIEST orchestrated
 // record (the client that opened the session), regardless of input order —
 // ListBySessionID returns newest-first, which used to mislabel a

--- a/internal/metrics/projection.go
+++ b/internal/metrics/projection.go
@@ -121,34 +121,11 @@ func gatewayEventFromEvidence(e *evidence.Evidence) GatewayEvent {
 		ev.OrchClient = e.Orchestration.Client
 	}
 	if ev.Blocked {
-		ev.DenyReasonCode = denyReasonCode(e.PolicyDecision.Reasons)
+		// One classifier for deny reason codes across the dashboard event
+		// projection and the session summary (#271): evidence.DenyReasonCode.
+		ev.DenyReasonCode = evidence.DenyReasonCode(e.PolicyDecision.Reasons)
 	}
 	return ev
-}
-
-// denyReasonCode classifies a deny by the machine-code prefix convention
-// ("session_budget_exceeded: ...", "budget_exceeded: ...", bare egress codes)
-// so session denials don't lump under a generic policy_deny bucket (#199).
-// Unrecognized shapes fall back to "policy_deny".
-func denyReasonCode(reasons []string) string {
-	if len(reasons) == 0 {
-		return "policy_deny"
-	}
-	code := reasons[0]
-	if i := strings.IndexByte(code, ':'); i >= 0 {
-		code = code[:i]
-	}
-	code = strings.TrimSpace(code)
-	if code == "" || len(code) > 64 {
-		return "policy_deny"
-	}
-	for i := 0; i < len(code); i++ {
-		c := code[i]
-		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '_' && c != '-' {
-			return "policy_deny"
-		}
-	}
-	return code
 }
 
 // SnapshotFromEvidenceRecords aggregates a standalone snapshot from evidence rows.

--- a/internal/metrics/sessions_test.go
+++ b/internal/metrics/sessions_test.go
@@ -90,6 +90,25 @@ func TestFillSessions_EqualsAuditSummary(t *testing.T) {
 	now := time.Now().UTC()
 	require.NoError(t, store.Store(ctx, sessEvidence("ev1", "sess-eq", "coder", "anthropic", "claude-sonnet-5", "generator", 0.07, true, now.Add(-3*time.Minute))))
 	require.NoError(t, store.Store(ctx, sessEvidence("ev2", "sess-eq", "coder", "openai", "gpt-5.3-codex", "judge", 0.02, false, now.Add(-1*time.Minute))))
+	// Operational-contract records (#271): a failed failover attempt, a
+	// retried fallback dispatch, and a blocked MCP tool call — the full-struct
+	// equality below proves the dashboard carries every new field.
+	attempt := sessEvidence("ev3", "sess-eq", "coder", "anthropic", "claude-sonnet-5", "generator", 0, true, now.Add(-2*time.Minute))
+	attempt.InvocationType = "gateway_failover_attempt"
+	attempt.Execution.Error = "upstream status 529"
+	attempt.FailureReason = evidence.FailureReasonProviderTransient
+	attempt.Failover = &evidence.FailoverContext{Role: evidence.FailoverRoleFailedAttempt, Provider: "anthropic", Model: "claude-sonnet-5"}
+	require.NoError(t, store.Store(ctx, attempt))
+	fallback := sessEvidence("ev4", "sess-eq", "coder", "openai", "gpt-5.3-codex", "generator", 0.03, true, now.Add(-90*time.Second))
+	fallback.RetryAttempt = "1"
+	fallback.Failover = &evidence.FailoverContext{Role: evidence.FailoverRoleFallbackDecision, Provider: "openai", Model: "gpt-5.3-codex"}
+	require.NoError(t, store.Store(ctx, fallback))
+	tool := sessEvidence("ev5", "sess-eq", "coder", "", "", "generator", 0, false, now.Add(-80*time.Second))
+	tool.InvocationType = "proxy_tool_blocked"
+	tool.RoutingDecision = nil
+	tool.PolicyDecision.Reasons = []string{"mcp_tool_denied: delete_record"}
+	tool.Execution.ToolsCalled = []string{"delete_record"}
+	require.NoError(t, store.Store(ctx, tool))
 
 	c := NewCollector("enforce", nil, WithSessionQuerier(store))
 	defer c.Close()
@@ -101,6 +120,15 @@ func TestFillSessions_EqualsAuditSummary(t *testing.T) {
 	audit := evidence.BuildSessionSummary("sess-eq", records)
 
 	assert.Equal(t, audit, snap.Sessions[0], "dashboard and talon audit must be byte-identical for the same session")
+	// The fixture must actually exercise the operational fields, or the
+	// equality above proves nothing about them.
+	assert.Equal(t, 3, audit.Requests)
+	assert.Equal(t, 1, audit.Fallbacks)
+	assert.Equal(t, 1, audit.FailedAttempts)
+	assert.Equal(t, 1, audit.Retries)
+	assert.Equal(t, 1, audit.ToolCalls)
+	assert.NotEmpty(t, audit.ProviderPath)
+	assert.NotNil(t, audit.LastFailure)
 }
 
 // TestFillSessions_SurvivesReconcile: session stats are re-derived from the
@@ -204,12 +232,4 @@ func TestGatewayEventFromEvidence_ProjectsSessionFields(t *testing.T) {
 
 	den := sessEvidence("ev2", "sess-proj", "coder", "anthropic", "claude-sonnet-5", "generator", 0, false, time.Now().UTC())
 	assert.Equal(t, "session_budget_exceeded", GatewayEventFromEvidence(den).DenyReasonCode)
-}
-
-func TestDenyReasonCode(t *testing.T) {
-	assert.Equal(t, "policy_deny", denyReasonCode(nil))
-	assert.Equal(t, "policy_deny", denyReasonCode([]string{"Data tier 2 exceeds caller restriction (max 1)"}))
-	assert.Equal(t, "session_budget_exceeded", denyReasonCode([]string{"session_budget_exceeded: spend"}))
-	assert.Equal(t, "egress_tier_destination_disallowed", denyReasonCode([]string{"egress_tier_destination_disallowed"}))
-	assert.Equal(t, "policy_deny", denyReasonCode([]string{"<img onerror=alert(1)>: nope"}), "hostile prefix falls back")
 }

--- a/internal/server/dashboard_html_test.go
+++ b/internal/server/dashboard_html_test.go
@@ -73,6 +73,11 @@ func TestGatewayDashboardHTML_SessionsPanel(t *testing.T) {
 	assert.Contains(t, html, "Coding Sessions (orchestration)")
 	assert.Contains(t, html, `style="display:none"`, "sessions panel hidden by default")
 	assert.Contains(t, html, "renderSessions(d.sessions, d.denials_by_reason)")
+	// Session drill-down (#271): the expanded row renders the operational
+	// summary from the same evidence.SessionSummary fields the CLI prints.
+	assert.Contains(t, html, "function sessionFacts(sess)")
+	assert.Contains(t, html, "sessionFacts(sess)")
+	assert.Contains(t, html, "fmt(sess.requests)", "Requests column uses the LLM request count, not record_count")
 	// Naming collision resolved: the metrics feed card no longer claims the
 	// word "Session"; the new panel owns it.
 	assert.NotContains(t, html, "Session Timeline (Lifecycle)")

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -311,6 +311,40 @@ func (s *Store) GetByExternal(ctx context.Context, tenantID, agentID, externalID
 	return out, nil
 }
 
+// ListByExternalID returns every session row carrying the given external
+// (client/vendor-asserted) session id, newest activity first. Operator/CLI
+// use: evidence records key sessions by the EXTERNAL id while the store's
+// primary key is the internal opaque id, and `talon session show` must accept
+// either (#271). More than one row is possible when different agents assert
+// the same external id — callers must surface that instead of silently
+// picking one. A non-empty tenantID scopes the read (#215 semantics).
+func (s *Store) ListByExternalID(ctx context.Context, externalID, tenantID string) ([]*Session, error) {
+	query := `SELECT ` + sessionColumns + ` FROM sessions WHERE external_session_id = ?`
+	args := []any{externalID}
+	if tenantID != "" {
+		query += ` AND tenant_id = ?`
+		args = append(args, tenantID)
+	}
+	query += ` ORDER BY updated_at DESC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions by external id: %w", err)
+	}
+	defer rows.Close()
+	var out []*Session
+	for rows.Next() {
+		sess, err := scanSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning session row: %w", err)
+		}
+		out = append(out, sess)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating session rows: %w", err)
+	}
+	return out, nil
+}
+
 // GetOrCreateExternal returns the session for the caller-scoped tuple,
 // creating it (internal opaque id, status active) on first sight (#198,
 // create-if-absent). source must be client_asserted or vendor_asserted —

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -229,6 +229,39 @@ func TestGetByExternal_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, ErrSessionNotFound)
 }
 
+// ListByExternalID (#271): the operator lookup bridging the external-id
+// namespace evidence uses to the internal-id primary key — every matching row
+// is returned so a cross-agent collision is visible, and tenant scoping holds.
+func TestListByExternalID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	a, err := s.GetOrCreateExternal(ctx, "acme", "coder-a", "sess-shared", SourceClientAsserted)
+	require.NoError(t, err)
+	b, err := s.GetOrCreateExternal(ctx, "acme", "coder-b", "sess-shared", SourceClientAsserted)
+	require.NoError(t, err)
+	_, err = s.GetOrCreateExternal(ctx, "other", "coder-a", "sess-shared", SourceVendorAsserted)
+	require.NoError(t, err)
+
+	all, err := s.ListByExternalID(ctx, "sess-shared", "")
+	require.NoError(t, err)
+	require.Len(t, all, 3, "unscoped operator read sees every asserting tuple")
+
+	scoped, err := s.ListByExternalID(ctx, "sess-shared", "acme")
+	require.NoError(t, err)
+	require.Len(t, scoped, 2)
+	ids := []string{scoped[0].ID, scoped[1].ID}
+	require.ElementsMatch(t, []string{a.ID, b.ID}, ids)
+
+	none, err := s.ListByExternalID(ctx, "no-such-external", "")
+	require.NoError(t, err)
+	require.Empty(t, none)
+
+	internal, err := s.ListByExternalID(ctx, a.ID, "")
+	require.NoError(t, err)
+	require.Empty(t, internal, "internal ids live in a different namespace")
+}
+
 func TestGet_TenantScoped(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/web/gateway_dashboard.html
+++ b/web/gateway_dashboard.html
@@ -225,7 +225,7 @@
        client-asserted orchestration data exists. -->
   <div class="panel grid-full" id="panel-sessions" style="display:none">
     <div class="panel-title">Coding Sessions (orchestration)</div>
-    <div class="kpi-sub">Client-asserted coding sessions across providers &mdash; identical numbers to <code>talon audit list --session &lt;id&gt;</code>. Click a session for its per-agent breakdown.</div>
+    <div class="kpi-sub">Client-asserted coding sessions across providers &mdash; identical numbers to <code>talon session show &lt;id&gt;</code>. Click a session for its operational summary and per-agent breakdown.</div>
     <table>
       <thead><tr><th></th><th>Session</th><th>Client</th><th>Agent</th><th>Requests</th><th>Denied</th><th>Models</th><th>Providers</th><th>Tokens in/out</th><th data-cost-th="Cost">Cost (USD)</th><th>Last Active</th></tr></thead>
       <tbody id="sessions-table"></tbody>
@@ -536,6 +536,55 @@
     }).join('');
   }
 
+  // sessionFacts renders a session's operational summary line (#271): the
+  // same evidence-derived fields `talon session show` prints — reliability,
+  // provider path, denials by reason, interventions, tool calls, failure.
+  // All values are client-asserted/hostile; esc() everything.
+  function sessionFacts(sess) {
+    var parts = [];
+    var rel = [];
+    if (sess.retries) rel.push('retries ' + fmt(sess.retries));
+    if (sess.failed_attempts) rel.push('failed attempts ' + fmt(sess.failed_attempts));
+    if (sess.fallbacks) rel.push('fallbacks ' + fmt(sess.fallbacks));
+    if (sess.fail_closed) rel.push('fail-closed ' + fmt(sess.fail_closed));
+    if (rel.length) parts.push('Reliability: ' + rel.join(' &middot; '));
+    if (sess.provider_path && sess.provider_path.length) {
+      parts.push('Path: ' + sess.provider_path.map(esc).join(' &rarr; '));
+    }
+    if (sess.denied_by_reason) {
+      var dr = Object.keys(sess.denied_by_reason).sort().map(function(code) {
+        return esc(code) + ' &times; ' + fmt(sess.denied_by_reason[code]);
+      });
+      if (dr.length) parts.push('Denials: ' + dr.join(', '));
+    }
+    var iv = [];
+    if (sess.pii_redactions) {
+      iv.push('PII redacted &times; ' + fmt(sess.pii_redactions) +
+        (sess.pii_types && sess.pii_types.length ? ' (' + sess.pii_types.map(esc).join(', ') + ')' : ''));
+    }
+    if (sess.tool_filter_events) {
+      iv.push('tools filtered &times; ' + fmt(sess.tool_filter_events) +
+        (sess.tools_filtered && sess.tools_filtered.length ? ' (' + sess.tools_filtered.map(esc).join(', ') + ')' : ''));
+    }
+    if (sess.shadow_violation_records) iv.push('shadow violations &times; ' + fmt(sess.shadow_violation_records));
+    if (iv.length) parts.push('Interventions: ' + iv.join(' &middot; '));
+    if (sess.tool_calls) {
+      var tc = 'Tool calls: ' + fmt(sess.tool_calls) + ' intercepted';
+      var tcd = [];
+      if (sess.tool_calls_denied) tcd.push(fmt(sess.tool_calls_denied) + ' denied');
+      if (sess.tool_calls_failed) tcd.push(fmt(sess.tool_calls_failed) + ' failed upstream');
+      if (tcd.length) tc += ' (' + tcd.join(', ') + ')';
+      if (sess.tool_names && sess.tool_names.length) tc += ' &mdash; ' + sess.tool_names.map(esc).join(', ');
+      parts.push(tc);
+    }
+    if (sess.last_failure) {
+      parts.push('<span class="rate-bad">Failure: ' + esc(sess.last_failure.code) +
+        (sess.last_failure.detail ? ': ' + esc(sess.last_failure.detail) : '') + '</span>');
+    }
+    if (!parts.length) return 'No reliability events, denials, or interventions recorded.';
+    return parts.join(' &nbsp;&bull;&nbsp; ');
+  }
+
   // Sessions panel (#199). session_id / agent_id / client / models are
   // client-asserted strings — hostile input; esc() EVERYTHING interpolated.
   function renderSessions(sessions, denials) {
@@ -546,21 +595,22 @@
     panel.style.display = '';
     tb.innerHTML = sessions.map(function(sess, i) {
       var agents = sess.subagents || [];
-      var hasAgents = agents.length > 0;
-      var caret = hasAgents ? '<span class="sess-caret" id="sess-caret-' + i + '">&#9656;</span>' : '';
+      var caret = '<span class="sess-caret" id="sess-caret-' + i + '">&#9656;</span>';
       var deniedCell = (sess.denied || 0) > 0 ? '<span class="rate-bad">' + fmt(sess.denied) + '</span>' : fmt(sess.denied || 0);
-      var row = '<tr class="sess-row" data-idx="' + i + '" style="cursor:' + (hasAgents ? 'pointer' : 'default') + '">' +
+      var row = '<tr class="sess-row" data-idx="' + i + '" style="cursor:pointer">' +
         '<td>' + caret + '</td>' +
         '<td>' + esc(sess.session_id) + '</td>' +
         '<td>' + esc(sess.client || '-') + '</td>' +
         '<td>' + esc((sess.agents || []).join(', ')) + '</td>' +
-        '<td>' + fmt(sess.record_count) + '</td>' +
+        '<td>' + fmt(sess.requests) + '</td>' +
         '<td>' + deniedCell + '</td>' +
         '<td>' + esc((sess.models || []).join(', ')) + '</td>' +
         '<td>' + esc((sess.providers || []).join(', ')) + '</td>' +
         '<td>' + fmt(sess.input_tokens) + ' / ' + fmt(sess.output_tokens) + '</td>' +
         '<td>&euro;' + (sess.total_cost || 0).toFixed(4) + '</td>' +
         '<td>' + esc(new Date(sess.last_seen).toLocaleTimeString()) + '</td></tr>';
+      var detailRow = '<tr class="sess-agent-row sess-agents-' + i + '" style="display:none;color:var(--text-dim)">' +
+        '<td></td><td colspan="10" style="padding-left:18px">' + sessionFacts(sess) + '</td></tr>';
       var agentRows = agents.map(function(a) {
         var parent = a.parent_agent_id ? ' &larr; ' + esc(a.parent_agent_id) : '';
         return '<tr class="sess-agent-row sess-agents-' + i + '" style="display:none;color:var(--text-dim)">' +
@@ -569,7 +619,7 @@
           '<td>' + fmt(a.input_tokens) + ' / ' + fmt(a.output_tokens) + '</td>' +
           '<td>&euro;' + (a.total_cost || 0).toFixed(4) + '</td><td></td></tr>';
       }).join('');
-      return row + agentRows;
+      return row + detailRow + agentRows;
     }).join('');
     Array.prototype.forEach.call(tb.querySelectorAll('tr.sess-row'), function(row) {
       row.addEventListener('click', function() {


### PR DESCRIPTION
Closes #271. Control-plane MVP (#265), session-understanding pillar.

## What ships

**One shared projection.** `evidence.SessionSummary` (already backing `talon audit --session`, `talon costs --session`, and the dashboard sessions panel) is extended with the #271 operational contract — so the CLI and the dashboard drill-down are the same struct from the same pure function, and cannot drift:

- `requests` — LLM traffic units, split from provider sub-attempts (`RecordClassOf`) and intercepted tool actions (new closed `toolActionType` registry in `record_class.go`: `proxy_tool_call`, `proxy_tool_blocked`, `proxy_upstream_error`, `proxy_method_rejected`, `mcp`)
- `duration_ms`, `retries` (X-Talon-Retry-Attempt echoes), `failed_attempts` / `fallbacks` / `fail_closed` (same `failover.role` definitions as the fleet view)
- `denied_by_reason` — machine reason codes; `DenyReasonCode` moved from `internal/metrics` into `internal/evidence` so one classifier serves both
- `provider_path` — "provider/model" in first-served time order; failed attempts are counted, not pathed
- `tool_calls` / `tool_calls_denied` / `tool_calls_failed` / `tool_names` — intercepted MCP calls with decisions; the summary never implies coverage of actions that bypass Talon
- `tools_filtered` + `tool_filter_events`, `pii_redactions` + `pii_types`, `shadow_violation_records`
- `last_failure` — newest deny or execution failure: machine code + short detail

**`talon session show`** is rewritten from a raw-row JSON dump to the one-screen summary (`--json` for the same structure): store-row lifecycle facts (status, source, session cap/spend) + the shared rollup. It accepts the internal `sess_…` id **or** the external asserted id — `session.Store.ListByExternalID` bridges the two namespaces, and a cross-agent external-id collision is surfaced as an explicit ambiguity (non-zero exit), never silently resolved. Evidence-only sessions (e.g. MCP-proxy-asserted) render honestly as "no session row — observed in evidence only".

**`talon session list`** gains SESSION (external id) and SOURCE columns plus `--json`. Synthetic ids keep having no session rows by design; a test now pins that they never appear.

**Dashboard**: the sessions panel's Requests column now uses the LLM-request count, and every session expands to an operational-facts row (`sessionFacts`) rendering the same fields the CLI prints; all client-asserted strings escaped.

## Acceptance criteria → proof

- One screen with every mandatory field: `TestSessionShow_OperationalSummary` (internal and external id)
- Fallback + denial with counts and provider path: same test — `Path: anthropic/claude-sonnet-5 → openai/gpt-5`, `fallbacks 1`, `session_budget_exceeded ×1`
- Failure explanation sourced from evidence: `TestBuildSessionSummary_LastFailureNewestWins`, CLI assertion on the `Failure:` line
- Synthetic ids not presented as sessions: `TestSessionList_SourcesShownSyntheticExcluded`
- CLI/dashboard parity (shared code path + test): `TestFillSessions_EqualsAuditSummary` asserts full-struct equality over a fixture exercising every new field; `TestSessionShow_JSONMatchesSharedProjection` covers the CLI JSON path

## Known gap (filed, not hidden)

`StatusFailed`/`StatusTimedOut` are write-dead in the session store — row status can only ever read active/completed, and the fleet failed-session signal is unreachable. Filed as #401 with design options; the summary's `last_failure` is evidence-derived and truthful regardless.

## Test surface

`go test ./...` clean, `go test -tags integration ./tests/integration/` clean (73s), `golangci-lint run ./internal/...` 0 issues.