### PR TITLE
feat(cost): budget thresholds + hard stops as signed evidence, org webhook after commit (#144, PR-1)

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2841,21 +2840,10 @@ func emitBudgetAlertIfNeeded(ctx context.Context, tenantID string, dailyCost, mo
 }
 
 // allowedBudgetAlertURL returns true if the URL is safe for outbound webhook POST (HTTPS, or HTTP to loopback only).
-// Used to mitigate SSRF when the URL comes from policy config.
+// Used to mitigate SSRF when the URL comes from policy config. The rule lives
+// in policy.AllowedWebhookURL, shared with the org-wide cost webhook (#144).
 func allowedBudgetAlertURL(raw string) bool {
-	u, err := url.Parse(raw)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return false
-	}
-	switch u.Scheme {
-	case "https":
-		return true
-	case "http":
-		h := strings.ToLower(u.Hostname())
-		return h == "localhost" || h == "127.0.0.1" || strings.HasSuffix(h, ".localhost")
-	default:
-		return false
-	}
+	return policy.AllowedWebhookURL(raw)
 }
 
 func postBudgetAlert(ctx context.Context, webhookURL string, payload map[string]interface{}) {

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -305,10 +305,35 @@ func printBudgetUtilization(w io.Writer, currency string, dailyBudget, monthlyBu
 	// $0.001 cap as "42.1% ($0.000421 / $0.00)" — a non-zero percent of a
 	// zero-looking budget. Sub-cent caps are real at per-request LLM cost scale.
 	if dailyBudget != nil && dailyBudget.LimitEUR > 0 {
-		fmt.Fprintf(w, "  Daily budget:   %.1f%% (%s / %s) [%s]\n", dailyBudget.Percent, formatMoney(currency, dailyBudget.UsedEUR), formatMoney(currency, dailyBudget.LimitEUR), dailyBudget.Source)
+		fmt.Fprintf(w, "  Daily budget:   %.1f%% (%s / %s) [%s] — %s\n", dailyBudget.Percent, formatMoney(currency, dailyBudget.UsedEUR), formatMoney(currency, dailyBudget.LimitEUR), dailyBudget.Source, budgetStatusWord(dailyBudget.Percent))
 	}
 	if monthlyBudget != nil && monthlyBudget.LimitEUR > 0 {
-		fmt.Fprintf(w, "  Monthly budget: %.1f%% (%s / %s) [%s]\n", monthlyBudget.Percent, formatMoney(currency, monthlyBudget.UsedEUR), formatMoney(currency, monthlyBudget.LimitEUR), monthlyBudget.Source)
+		fmt.Fprintf(w, "  Monthly budget: %.1f%% (%s / %s) [%s] — %s\n", monthlyBudget.Percent, formatMoney(currency, monthlyBudget.UsedEUR), formatMoney(currency, monthlyBudget.LimitEUR), monthlyBudget.Source, budgetStatusWord(monthlyBudget.Percent))
+	}
+	if (dailyBudget != nil && dailyBudget.LimitEUR > 0) || (monthlyBudget != nil && monthlyBudget.LimitEUR > 0) {
+		warns := make([]string, 0, len(gateway.BudgetWarnThresholds))
+		for _, t := range gateway.BudgetWarnThresholds {
+			warns = append(warns, fmt.Sprintf("%.0f%%", t))
+		}
+		fmt.Fprintf(w, "  Thresholds:     warn at %s (signed evidence + org webhook), hard stop at 100%% (denied before the provider)\n", strings.Join(warns, " and "))
+	}
+}
+
+// budgetStatusWord maps utilization to the operator status vocabulary of the
+// cost-control contract (#144): the warning statuses correspond one-to-one to
+// the gateway's BudgetWarnThresholds evidence events; BLOCKED means new
+// requests whose estimate exceeds the remaining headroom are denied before
+// the provider is called.
+func budgetStatusWord(pct float64) string {
+	switch {
+	case pct >= 100:
+		return "BLOCKED"
+	case pct >= 95:
+		return "CRITICAL"
+	case pct >= 80:
+		return "WARNING"
+	default:
+		return "OK"
 	}
 }
 

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -185,6 +185,27 @@ func TestPrintBudgetUtilization_SubCentCapKeepsPrecision(t *testing.T) {
 	require.Contains(t, buf.String(), "Daily budget:   60.0% ($< 0.0001 / $< 0.0001) [policy_cost_limits]")
 }
 
+// The cost-control contract's operator status (#144): utilization maps to the
+// same vocabulary the gateway's threshold evidence fires on, and the output
+// names the thresholds and the hard stop so "clear status" needs no docs.
+func TestPrintBudgetUtilization_StatusAndThresholds(t *testing.T) {
+	var buf bytes.Buffer
+	printBudgetUtilization(&buf, "USD",
+		&budgetUsage{UsedEUR: 8.5, LimitEUR: 10, Percent: 85.0, Source: "server_effective_cap"},
+		&budgetUsage{UsedEUR: 210, LimitEUR: 200, Percent: 105.0, Source: "server_effective_cap"},
+	)
+	out := buf.String()
+	require.Contains(t, out, "Daily budget:   85.0% ($8.500000 / $10.000000) [server_effective_cap] — WARNING")
+	require.Contains(t, out, "Monthly budget: 105.0% ($210.000000 / $200.000000) [server_effective_cap] — BLOCKED")
+	require.Contains(t, out, "warn at 80% and 95% (signed evidence + org webhook), hard stop at 100%")
+
+	require.Equal(t, "OK", budgetStatusWord(0))
+	require.Equal(t, "OK", budgetStatusWord(79.9))
+	require.Equal(t, "WARNING", budgetStatusWord(80))
+	require.Equal(t, "CRITICAL", budgetStatusWord(95))
+	require.Equal(t, "BLOCKED", budgetStatusWord(100))
+}
+
 func TestRenderCostsExportCSV_IncludesProviderAndDeniedReason(t *testing.T) {
 	var buf bytes.Buffer
 	records := []evidence.ExportRecord{

--- a/internal/evidence/budget_events.go
+++ b/internal/evidence/budget_events.go
@@ -1,0 +1,35 @@
+package evidence
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// InvocationTypeBudgetThreshold is the invocation type of a warning-threshold
+// crossing record (#144): one signed fact per (agent, period, threshold) per
+// budget window, written when utilization first reaches the threshold.
+// Registered as operator_event in record_class.go.
+const InvocationTypeBudgetThreshold = "budget_threshold"
+
+// HasBudgetThresholdEvent reports whether a budget_threshold record already
+// exists for (tenant, agent, period, threshold) at or after windowStart. This
+// is the restart-safety half of the once-per-crossing contract (#144): the
+// gateway's in-memory fired-set is rebuilt lazily from this query, so a
+// process restart mid-window cannot duplicate the crossing fact.
+func (s *Store) HasBudgetThresholdEvent(ctx context.Context, tenantID, agentID, period string, thresholdPct float64, windowStart time.Time) (bool, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM evidence
+		WHERE invocation_type = ?
+		  AND tenant_id = ?
+		  AND agent_id = ?
+		  AND json_extract(evidence_json, '$.cost_budget.period') = ?
+		  AND json_extract(evidence_json, '$.cost_budget.threshold_pct') = ?
+		  AND timestamp >= ?`,
+		InvocationTypeBudgetThreshold, tenantID, agentID, period, thresholdPct, windowStart.UTC(),
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("querying budget threshold events: %w", err)
+	}
+	return n > 0, nil
+}

--- a/internal/evidence/budget_events_test.go
+++ b/internal/evidence/budget_events_test.go
@@ -1,0 +1,46 @@
+package evidence
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// HasBudgetThresholdEvent is the restart-safety half of the once-per-crossing
+// contract (#144): it must match only the same (tenant, agent, period,
+// threshold) within the window.
+func TestHasBudgetThresholdEvent(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "e.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	defer store.Close()
+	ctx := context.Background()
+
+	windowStart := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, store.Store(ctx, &Evidence{
+		ID: "bt1", CorrelationID: "corr-bt1", Timestamp: windowStart.Add(2 * time.Hour),
+		TenantID: "default", AgentID: "support-bot",
+		InvocationType: InvocationTypeBudgetThreshold,
+		PolicyDecision: PolicyDecision{Allowed: true, Action: "allow"},
+		CostBudget:     &CostBudget{Period: "daily", Limit: 10, Spent: 8.5, ThresholdPct: 80},
+	}))
+
+	got, err := store.HasBudgetThresholdEvent(ctx, "default", "support-bot", "daily", 80, windowStart)
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	for name, q := range map[string][5]any{
+		"different threshold": {"default", "support-bot", "daily", 95.0, windowStart},
+		"different period":    {"default", "support-bot", "monthly", 80.0, windowStart},
+		"different agent":     {"default", "other-bot", "daily", 80.0, windowStart},
+		"different tenant":    {"acme", "support-bot", "daily", 80.0, windowStart},
+		"next window":         {"default", "support-bot", "daily", 80.0, windowStart.Add(24 * time.Hour)},
+	} {
+		got, err := store.HasBudgetThresholdEvent(ctx, q[0].(string), q[1].(string), q[2].(string), q[3].(float64), q[4].(time.Time))
+		require.NoError(t, err, name)
+		assert.False(t, got, name)
+	}
+}

--- a/internal/evidence/record_class.go
+++ b/internal/evidence/record_class.go
@@ -61,6 +61,10 @@ var nonRequestClass = map[string]RecordClass{
 	"plan_dispatch":        ClassOperatorEvent,
 	"plan_dispatch_manual": ClassOperatorEvent,
 	"control_plane":        ClassOperatorEvent,
+	// Budget warning-threshold crossing (#144): a control-plane fact recorded
+	// once per crossing during some triggering request — counting it as a
+	// request would double that request in traffic queries.
+	"budget_threshold": ClassOperatorEvent,
 
 	// Configuration lifecycle.
 	"config_reload": ClassConfigEvent,

--- a/internal/evidence/record_class_test.go
+++ b/internal/evidence/record_class_test.go
@@ -36,6 +36,7 @@ func TestRecordClassOf(t *testing.T) {
 		"plan_dispatch":        ClassOperatorEvent,
 		"plan_dispatch_manual": ClassOperatorEvent,
 		"control_plane":        ClassOperatorEvent,
+		"budget_threshold":     ClassOperatorEvent, // #144 crossing fact
 
 		// Configuration lifecycle.
 		"config_reload": ClassConfigEvent,

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -115,6 +115,11 @@ type Evidence struct {
 	// session spend at evaluation time, and the pre-request estimate. Appended
 	// after orchestration per the spec §2 append rule.
 	SessionBudget *SessionBudget `json:"session_budget,omitempty"`
+	// CostBudget records the agent/org budget window a cost-control event was
+	// decided on (#144): the crossed warning threshold on a budget_threshold
+	// record, or the binding limit/spend/estimate a budget_exceeded deny saw.
+	// Appended after session_budget per the spec §2 append rule.
+	CostBudget *CostBudget `json:"cost_budget,omitempty"`
 }
 
 // SessionBudget is the structured detail of a session-budget deny (#198).
@@ -122,6 +127,19 @@ type SessionBudget struct {
 	Limit    float64 `json:"limit"`    // caller's max_session_cost at evaluation time
 	Spent    float64 `json:"spent"`    // accumulated session spend the rule saw
 	Estimate float64 `json:"estimate"` // pre-request estimate added to spend
+}
+
+// CostBudget is the structured budget-window context of a cost-control event
+// (#144): a warning-threshold crossing (invocation_type budget_threshold) or a
+// budget hard-stop deny. Limit is the BINDING cap — the tightest of the
+// per-agent resolved cap and the org ceiling, the same number enforcement and
+// utilization use (#216/#287).
+type CostBudget struct {
+	Period       string  `json:"period"`                  // daily | monthly
+	Limit        float64 `json:"limit"`                   // binding cap at evaluation time
+	Spent        float64 `json:"spent"`                   // window spend the decision saw
+	Estimate     float64 `json:"estimate,omitempty"`      // pre-request estimate (deny records)
+	ThresholdPct float64 `json:"threshold_pct,omitempty"` // crossed threshold (budget_threshold records)
 }
 
 // OrchestrationContext is the client-asserted orchestration identity for one

--- a/internal/gateway/budget_events.go
+++ b/internal/gateway/budget_events.go
@@ -1,0 +1,243 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/dativo-io/talon/internal/evidence"
+	"github.com/dativo-io/talon/internal/policy"
+)
+
+// BudgetWarnThresholds are the warning thresholds of the cost-control
+// contract (#144), in ascending order. Crossing each one yields exactly one
+// signed budget_threshold evidence record per budget window. Exported so
+// `talon costs` states the same thresholds enforcement fires on.
+var BudgetWarnThresholds = []float64{80, 95}
+
+// CostEvent is the payload POSTed to the organization cost webhook (#144),
+// strictly after the signed evidence record it references has committed.
+type CostEvent struct {
+	Event         string    `json:"event"` // budget_threshold | budget_denied
+	TenantID      string    `json:"tenant_id"`
+	Agent         string    `json:"agent"`
+	Period        string    `json:"period,omitempty"` // daily | monthly
+	ThresholdPct  float64   `json:"threshold_pct,omitempty"`
+	Limit         float64   `json:"limit,omitempty"`
+	Spent         float64   `json:"spent,omitempty"`
+	EstimatedCost float64   `json:"estimated_cost,omitempty"`
+	Currency      string    `json:"currency,omitempty"`
+	ReasonCode    string    `json:"reason_code,omitempty"` // budget_exceeded | session_budget_exceeded
+	EvidenceID    string    `json:"evidence_id"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+// budgetWindowStart returns the UTC start of the budget window a spend total
+// is accumulated over — the same UTC day/month windows enforcement uses
+// (agentCostTotals, #216).
+func budgetWindowStart(period string, now time.Time) time.Time {
+	now = now.UTC()
+	if period == "monthly" {
+		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	}
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func budgetEventKey(tenantID, agentName, period string, threshold float64, windowStart time.Time) string {
+	return tenantID + "|" + agentName + "|" + period + "|" +
+		strconv.FormatFloat(threshold, 'f', -1, 64) + "|" + windowStart.Format("2006-01-02")
+}
+
+// noteBudgetThresholds implements the once-per-crossing contract (#144) for
+// one budget period: for every warning threshold the window's spend has
+// reached, write ONE signed budget_threshold evidence record, then emit the
+// OTel alert metric and the organization cost webhook as projections of that
+// committed fact. Subsequent requests in the same window above the same
+// threshold write nothing. The in-memory fired-set is claimed under lock
+// before any I/O (concurrent requests race to one winner) and is rebuilt
+// lazily from the evidence store after a restart (HasBudgetThresholdEvent).
+// A failed evidence write releases the claim so a later request retries —
+// the metric and webhook never fire without a committed record.
+func (g *Gateway) noteBudgetThresholds(ctx context.Context, agent *ResolvedIdentity, provider, correlationID, period string, spent, cap float64) {
+	if cap <= 0 {
+		return
+	}
+	pct := (spent / cap) * 100
+	now := time.Now()
+	windowStart := budgetWindowStart(period, now)
+	for _, threshold := range BudgetWarnThresholds {
+		if pct < threshold {
+			break
+		}
+		key := budgetEventKey(agent.TenantID, agent.Name, period, threshold, windowStart)
+		if !g.claimBudgetEvent(key) {
+			continue
+		}
+		exists, err := g.evidenceStore.HasBudgetThresholdEvent(ctx, agent.TenantID, agent.Name, period, threshold, windowStart)
+		if err != nil {
+			// Store read failed: release so a later request re-checks. Firing
+			// blind could duplicate the crossing fact after a restart.
+			g.releaseBudgetEvent(key)
+			log.Warn().Err(err).Str("agent", agent.Name).Str("period", period).Msg("budget_threshold_lookup_failed")
+			continue
+		}
+		if exists {
+			continue // already recorded this window (pre-restart)
+		}
+		ev, err := RecordGatewayEvidence(ctx, g.evidenceStore, RecordGatewayEvidenceParams{
+			CorrelationID:  correlationID,
+			TenantID:       agent.TenantID,
+			AgentName:      agent.Name,
+			Team:           agent.Team,
+			Provider:       provider,
+			PolicyAllowed:  true,
+			PolicyVersion:  agent.PolicyDigest,
+			PolicyDigests:  g.policyDigests(agent, provider),
+			Currency:       g.pricingCurrency,
+			InvocationType: evidence.InvocationTypeBudgetThreshold,
+			CostBudget: &evidence.CostBudget{
+				Period:       period,
+				Limit:        cap,
+				Spent:        spent,
+				ThresholdPct: threshold,
+			},
+		})
+		if err != nil {
+			g.releaseBudgetEvent(key)
+			log.Warn().Err(err).Str("agent", agent.Name).Str("period", period).Msg("budget_threshold_evidence_failed")
+			continue
+		}
+		// Projections of the committed fact — strictly after the store write.
+		RecordBudgetAlert(ctx, agent.TenantID, threshold)
+		g.postCostEvent(CostEvent{
+			Event:        "budget_threshold",
+			TenantID:     agent.TenantID,
+			Agent:        agent.Name,
+			Period:       period,
+			ThresholdPct: threshold,
+			Limit:        cap,
+			Spent:        spent,
+			Currency:     g.pricingCurrency,
+			EvidenceID:   ev.ID,
+			Timestamp:    ev.Timestamp.UTC(),
+		})
+		log.Info().
+			Str("agent", agent.Name).
+			Str("period", period).
+			Float64("threshold_pct", threshold).
+			Str("evidence_id", ev.ID).
+			Msg("budget_threshold_crossed")
+	}
+}
+
+// claimBudgetEvent marks a (tenant, agent, period, threshold, window) key as
+// fired, returning false when it was already claimed. Claiming happens before
+// any I/O so concurrent requests race to exactly one winner.
+func (g *Gateway) claimBudgetEvent(key string) bool {
+	g.budgetEventMu.Lock()
+	defer g.budgetEventMu.Unlock()
+	if g.budgetEventFired == nil {
+		g.budgetEventFired = make(map[string]bool)
+	}
+	if g.budgetEventFired[key] {
+		return false
+	}
+	g.budgetEventFired[key] = true
+	return true
+}
+
+func (g *Gateway) releaseBudgetEvent(key string) {
+	g.budgetEventMu.Lock()
+	defer g.budgetEventMu.Unlock()
+	delete(g.budgetEventFired, key)
+}
+
+// costBudgetDetail extracts the structured budget-window context when an
+// agent/org budget deny fired, from the same numbers the policy decision saw.
+// Nil when no budget_exceeded reason is present. Limit is the BINDING cap for
+// the denied period — the tightest of agent and org, which is by construction
+// the cap the deny fired on.
+func costBudgetDetail(reasons []string, dailyCost, monthlyCost, dailyCap, monthlyCap, estimatedCost float64) *evidence.CostBudget {
+	for _, r := range reasons {
+		if !strings.HasPrefix(r, "budget_exceeded:") {
+			continue
+		}
+		period, spent, limit := "daily", dailyCost, dailyCap
+		if strings.Contains(r, "monthly") {
+			period, spent, limit = "monthly", monthlyCost, monthlyCap
+		}
+		return &evidence.CostBudget{
+			Period:   period,
+			Limit:    limit,
+			Spent:    spent,
+			Estimate: estimatedCost,
+		}
+	}
+	return nil
+}
+
+// costDenyReasonCode returns the machine code of the first cost-control deny
+// reason ("budget_exceeded" or "session_budget_exceeded"), or "" when the
+// denial was not cost-driven — only cost denials go to the cost webhook.
+func costDenyReasonCode(reasons []string) string {
+	for _, r := range reasons {
+		switch {
+		case strings.HasPrefix(r, "budget_exceeded:"):
+			return "budget_exceeded"
+		case strings.HasPrefix(r, "session_budget_exceeded:"):
+			return "session_budget_exceeded"
+		}
+	}
+	return ""
+}
+
+// postCostEvent delivers a cost event to the organization webhook, if one is
+// configured. Callers invoke it only AFTER the referenced evidence record
+// committed; delivery itself is asynchronous and best-effort — failure is
+// logged, evidence remains the truth (#144).
+func (g *Gateway) postCostEvent(ev CostEvent) {
+	url := g.config.OrganizationPolicy.CostWebhookURL
+	if url == "" {
+		return
+	}
+	go deliverCostEvent(url, ev)
+}
+
+// deliverCostEvent POSTs one event with a bounded timeout. The URL was
+// validated at config load (Validate) and is re-checked here as
+// defense-in-depth against a config object built without Validate.
+func deliverCostEvent(url string, ev CostEvent) {
+	if !policy.AllowedWebhookURL(url) {
+		log.Warn().Str("url", url).Msg("cost_webhook_url_rejected")
+		return
+	}
+	body, err := json.Marshal(ev)
+	if err != nil {
+		log.Warn().Err(err).Msg("cost_webhook_marshal_failed")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		log.Warn().Err(err).Str("url", url).Msg("cost_webhook_request_failed")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// URL validated by policy.AllowedWebhookURL (HTTPS or HTTP loopback only).
+	resp, err := (&http.Client{}).Do(req) // #nosec G704
+	if err != nil {
+		log.Warn().Err(err).Str("url", url).Str("event", ev.Event).Msg("cost_webhook_post_failed")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		log.Warn().Int("status", resp.StatusCode).Str("url", url).Str("event", ev.Event).Msg("cost_webhook_non_2xx")
+	}
+}

--- a/internal/gateway/budget_events_test.go
+++ b/internal/gateway/budget_events_test.go
@@ -1,0 +1,212 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dativo-io/talon/internal/evidence"
+)
+
+// Cost-control contract (#144): once-per-crossing threshold evidence, deny
+// context, and the org webhook delivered only after the evidence commit.
+
+func newBudgetEventsGateway(t *testing.T, store *evidence.Store, webhookURL string) *Gateway {
+	t.Helper()
+	return &Gateway{
+		config: &GatewayConfig{
+			OrganizationPolicy: OrganizationPolicy{CostWebhookURL: webhookURL},
+		},
+		evidenceStore:   store,
+		pricingCurrency: "EUR",
+	}
+}
+
+func newBudgetEventsStore(t *testing.T) *evidence.Store {
+	t.Helper()
+	store, err := evidence.NewStore(filepath.Join(t.TempDir(), "e.db"), "test-signing-key-1234567890123456")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func budgetTestAgent() *ResolvedIdentity {
+	return &ResolvedIdentity{Name: "support-bot", TenantID: "default", Enabled: true}
+}
+
+func thresholdRecords(t *testing.T, store *evidence.Store, correlationID string) []*evidence.Evidence {
+	t.Helper()
+	records, err := store.ListByCorrelationID(context.Background(), correlationID)
+	require.NoError(t, err)
+	out := make([]*evidence.Evidence, 0, len(records))
+	for _, ev := range records {
+		if ev.InvocationType == evidence.InvocationTypeBudgetThreshold {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// Crossing a warning threshold yields exactly ONE signed record; later
+// requests above the same threshold yield none; the next threshold yields its
+// own single record (#144 done-when 1).
+func TestNoteBudgetThresholds_OncePerCrossing(t *testing.T) {
+	store := newBudgetEventsStore(t)
+	g := newBudgetEventsGateway(t, store, "")
+	agent := budgetTestAgent()
+	ctx := context.Background()
+
+	g.noteBudgetThresholds(ctx, agent, "anthropic", "corr-a", "daily", 8.5, 10) // 85%
+	recs := thresholdRecords(t, store, "corr-a")
+	require.Len(t, recs, 1, "first crossing of 80%% → one signed record")
+	cb := recs[0].CostBudget
+	require.NotNil(t, cb)
+	assert.Equal(t, "daily", cb.Period)
+	assert.Equal(t, 10.0, cb.Limit)
+	assert.Equal(t, 8.5, cb.Spent)
+	assert.Equal(t, 80.0, cb.ThresholdPct)
+	assert.Equal(t, evidence.ClassOperatorEvent, evidence.RecordClassOf(recs[0].InvocationType),
+		"threshold facts must not count as request traffic")
+	assert.True(t, recs[0].PolicyDecision.Allowed)
+	assert.True(t, store.VerifyRecord(recs[0]), "threshold record must be signed")
+
+	g.noteBudgetThresholds(ctx, agent, "anthropic", "corr-b", "daily", 8.7, 10) // still ≥80
+	assert.Empty(t, thresholdRecords(t, store, "corr-b"), "later requests above the same threshold yield none")
+
+	g.noteBudgetThresholds(ctx, agent, "anthropic", "corr-c", "daily", 9.6, 10) // 96%
+	recs = thresholdRecords(t, store, "corr-c")
+	require.Len(t, recs, 1, "crossing 95%% fires its own single record")
+	assert.Equal(t, 95.0, recs[0].CostBudget.ThresholdPct)
+}
+
+// A restart must not duplicate the crossing fact: a fresh gateway (empty
+// in-memory fired-set) over the same store rebuilds from evidence.
+func TestNoteBudgetThresholds_RestartSafe(t *testing.T) {
+	store := newBudgetEventsStore(t)
+	ctx := context.Background()
+	agent := budgetTestAgent()
+
+	g1 := newBudgetEventsGateway(t, store, "")
+	g1.noteBudgetThresholds(ctx, agent, "anthropic", "corr-1", "monthly", 85, 100)
+	require.Len(t, thresholdRecords(t, store, "corr-1"), 1)
+
+	g2 := newBudgetEventsGateway(t, store, "") // simulated restart
+	g2.noteBudgetThresholds(ctx, agent, "anthropic", "corr-2", "monthly", 86, 100)
+	assert.Empty(t, thresholdRecords(t, store, "corr-2"), "restart must not re-record the same window's crossing")
+}
+
+// A jump straight past both thresholds records BOTH crossings — each is a
+// distinct fact, each exactly once.
+func TestNoteBudgetThresholds_DoubleCross(t *testing.T) {
+	store := newBudgetEventsStore(t)
+	g := newBudgetEventsGateway(t, store, "")
+	g.noteBudgetThresholds(context.Background(), budgetTestAgent(), "anthropic", "corr-x", "daily", 9.9, 10)
+	recs := thresholdRecords(t, store, "corr-x")
+	require.Len(t, recs, 2)
+	pcts := []float64{recs[0].CostBudget.ThresholdPct, recs[1].CostBudget.ThresholdPct}
+	assert.ElementsMatch(t, []float64{80, 95}, pcts)
+}
+
+// Distinct agents and periods track independently (#266 r4 precedent: one
+// agent's alert must not suppress another's).
+func TestNoteBudgetThresholds_PerAgentPerPeriod(t *testing.T) {
+	store := newBudgetEventsStore(t)
+	g := newBudgetEventsGateway(t, store, "")
+	ctx := context.Background()
+	a := &ResolvedIdentity{Name: "agent-a", TenantID: "default", Enabled: true}
+	b := &ResolvedIdentity{Name: "agent-b", TenantID: "default", Enabled: true}
+
+	g.noteBudgetThresholds(ctx, a, "anthropic", "corr-a", "daily", 85, 100)
+	g.noteBudgetThresholds(ctx, b, "anthropic", "corr-b", "daily", 85, 100)
+	g.noteBudgetThresholds(ctx, a, "anthropic", "corr-c", "monthly", 85, 100)
+
+	assert.Len(t, thresholdRecords(t, store, "corr-a"), 1)
+	assert.Len(t, thresholdRecords(t, store, "corr-b"), 1, "agent-b's crossing is its own fact")
+	assert.Len(t, thresholdRecords(t, store, "corr-c"), 1, "monthly window is independent of daily")
+}
+
+// The org webhook fires only AFTER the evidence record committed: the handler
+// itself verifies the referenced record is already readable in the store
+// (#144 done-when 3).
+func TestNoteBudgetThresholds_WebhookAfterEvidenceCommit(t *testing.T) {
+	store := newBudgetEventsStore(t)
+
+	var mu sync.Mutex
+	var got CostEvent
+	var evidenceExisted bool
+	var delivered bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var ev CostEvent
+		_ = json.Unmarshal(body, &ev)
+		records, err := store.ListByCorrelationID(r.Context(), "corr-wh")
+		exists := err == nil
+		found := false
+		for _, rec := range records {
+			if rec.ID == ev.EvidenceID {
+				found = true
+			}
+		}
+		mu.Lock()
+		got, evidenceExisted, delivered = ev, exists && found, true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	g := newBudgetEventsGateway(t, store, srv.URL) // http://127.0.0.1:… — loopback allowed
+	g.noteBudgetThresholds(context.Background(), budgetTestAgent(), "anthropic", "corr-wh", "daily", 8.5, 10)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return delivered
+	}, 5*time.Second, 10*time.Millisecond, "webhook must be delivered")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, evidenceExisted, "the webhook must reference an ALREADY-COMMITTED evidence record")
+	assert.Equal(t, "budget_threshold", got.Event)
+	assert.Equal(t, "support-bot", got.Agent)
+	assert.Equal(t, "daily", got.Period)
+	assert.Equal(t, 80.0, got.ThresholdPct)
+	assert.Equal(t, 10.0, got.Limit)
+	assert.Equal(t, "EUR", got.Currency)
+	assert.NotEmpty(t, got.EvidenceID)
+}
+
+func TestBudgetWindowStart(t *testing.T) {
+	at := time.Date(2026, 7, 28, 15, 4, 5, 0, time.FixedZone("CEST", 2*3600))
+	assert.Equal(t, time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC), budgetWindowStart("daily", at))
+	assert.Equal(t, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), budgetWindowStart("monthly", at))
+}
+
+func TestCostBudgetDetail(t *testing.T) {
+	daily := costBudgetDetail([]string{"budget_exceeded: request would exceed agent daily cost limit (10)"}, 9.8, 50, 10, 200, 0.5)
+	require.NotNil(t, daily)
+	assert.Equal(t, &evidence.CostBudget{Period: "daily", Limit: 10, Spent: 9.8, Estimate: 0.5}, daily)
+
+	monthly := costBudgetDetail([]string{"budget_exceeded: request would exceed organization monthly cost limit (200)"}, 9.8, 199.9, 10, 200, 0.5)
+	require.NotNil(t, monthly)
+	assert.Equal(t, "monthly", monthly.Period)
+	assert.Equal(t, 200.0, monthly.Limit)
+	assert.Equal(t, 199.9, monthly.Spent)
+
+	assert.Nil(t, costBudgetDetail([]string{"PII block"}, 1, 2, 3, 4, 5), "non-budget denials carry no cost context")
+	assert.Nil(t, costBudgetDetail(nil, 1, 2, 3, 4, 5))
+}
+
+func TestCostDenyReasonCode(t *testing.T) {
+	assert.Equal(t, "budget_exceeded", costDenyReasonCode([]string{"budget_exceeded: daily"}))
+	assert.Equal(t, "session_budget_exceeded", costDenyReasonCode([]string{"session_budget_exceeded: spend"}))
+	assert.Empty(t, costDenyReasonCode([]string{"PII block"}), "non-cost denials are not cost events")
+	assert.Empty(t, costDenyReasonCode(nil))
+}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/dativo-io/talon/internal/policy"
 )
 
 // Mode is the gateway operation mode.
@@ -196,6 +198,13 @@ type OrganizationPolicy struct {
 	// on tool content is deliberately not offered until per-block-type tool
 	// redaction exists (#212).
 	ScanToolContent string `yaml:"scan_tool_content,omitempty" json:"scan_tool_content,omitempty"` // evidence_only (default) | off
+	// CostWebhookURL is the ONE organization-wide endpoint for cost-control
+	// events (#144): budget warning-threshold crossings and budget hard-stop
+	// denials POST here strictly AFTER the signed evidence record commits.
+	// HTTPS required; HTTP is allowed to loopback only (the runner
+	// budget_alert_webhook SSRF rule, policy.AllowedWebhookURL). Delivery
+	// failure is logged — evidence remains the truth.
+	CostWebhookURL string `yaml:"cost_webhook_url,omitempty" json:"cost_webhook_url,omitempty"`
 }
 
 // OrgDefaults holds the organization baselines every agent inherits — the
@@ -672,6 +681,11 @@ func (c *GatewayConfig) Validate() error {
 	}
 	if err := validateToolPolicyAction("organization_policy.defaults.tool_policy_action", c.OrganizationPolicy.Defaults.ToolPolicyAction); err != nil {
 		return err
+	}
+	// A bad webhook URL must fail at load, not silently at first delivery —
+	// a misconfigured endpoint would otherwise drop every cost event (#144).
+	if u := c.OrganizationPolicy.CostWebhookURL; u != "" && !policy.AllowedWebhookURL(u) {
+		return fmt.Errorf("gateway organization_policy.cost_webhook_url must be https (or http to loopback), got %q", u)
 	}
 	if err := c.OrganizationPolicy.validateBudgetBounds(); err != nil {
 		return err

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -216,6 +216,51 @@ gateway:
 	})
 }
 
+// A misconfigured org cost webhook must fail at LOAD (#144): silently
+// dropping every cost event at delivery time would be an invisible outage of
+// the notification contract.
+func TestValidateCostWebhookURL(t *testing.T) {
+	base := `
+gateway:
+  enabled: true
+  mode: enforce
+  providers:
+    ollama:
+      enabled: true
+      base_url: "http://localhost:11434"
+  organization_policy:
+`
+	t.Run("https accepted", func(t *testing.T) {
+		path := writeConfig(t, base+"    cost_webhook_url: https://hooks.example.com/talon\n")
+		cfg, err := LoadGatewayConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.OrganizationPolicy.CostWebhookURL != "https://hooks.example.com/talon" {
+			t.Errorf("cost_webhook_url mis-parsed: %+v", cfg.OrganizationPolicy.CostWebhookURL)
+		}
+	})
+	t.Run("http loopback accepted", func(t *testing.T) {
+		path := writeConfig(t, base+"    cost_webhook_url: http://127.0.0.1:9000/hook\n")
+		if _, err := LoadGatewayConfig(path); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("http non-loopback rejected", func(t *testing.T) {
+		path := writeConfig(t, base+"    cost_webhook_url: http://internal.corp/hook\n")
+		_, err := LoadGatewayConfig(path)
+		if err == nil || !strings.Contains(err.Error(), "cost_webhook_url") {
+			t.Fatalf("want cost_webhook_url error, got: %v", err)
+		}
+	})
+	t.Run("unset accepted", func(t *testing.T) {
+		path := writeConfig(t, base+"    defaults:\n      daily_cost: 10\n")
+		if _, err := LoadGatewayConfig(path); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 // Org allowed_providers entries must name configured providers (#284):
 // matching is exact and case-sensitive, so a typo would silently deny every
 // request at runtime instead of failing at load.

--- a/internal/gateway/evidence.go
+++ b/internal/gateway/evidence.go
@@ -96,6 +96,9 @@ type RecordGatewayEvidenceParams struct {
 	// deny was decided on (#198). Nil unless a session_budget_exceeded
 	// deny fired.
 	SessionBudget *evidence.SessionBudget
+	// CostBudget carries the agent/org budget-window context of a
+	// cost-control event (#144): threshold crossings and budget denies.
+	CostBudget *evidence.CostBudget
 }
 
 // RecordGatewayEvidence creates and stores a signed evidence record for a gateway request.
@@ -186,6 +189,7 @@ func RecordGatewayEvidence(ctx context.Context, store *evidence.Store, params Re
 		Failover:       params.Failover,
 		Orchestration:  params.Orchestration,
 		SessionBudget:  params.SessionBudget,
+		CostBudget:     params.CostBudget,
 	}
 	if !params.PolicyAllowed {
 		ev.PolicyDecision.Action = "deny"

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -120,9 +120,12 @@ type Gateway struct {
 	// costEstimate; stamped into evidence so records stay self-describing
 	// if the operator later changes the table (#216).
 	pricingCurrency string
-	// budgetAlertLast tracks last time we emitted a budget alert per tenant+period+threshold to avoid spamming
-	budgetAlertMu   sync.Mutex
-	budgetAlertLast map[string]time.Time
+	// budgetEventFired is the in-memory half of the once-per-crossing budget
+	// contract (#144): keys (tenant|agent|period|threshold|window) whose signed
+	// budget_threshold record exists. Claimed before I/O, released on write
+	// failure, rebuilt lazily from the evidence store after a restart.
+	budgetEventMu    sync.Mutex
+	budgetEventFired map[string]bool
 }
 
 type gatewayCacheConfig struct {
@@ -601,16 +604,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// agent_budget_unavailable annotation instead.
 	dailyCap, monthlyCap := eff.BindingDailyCap(), eff.BindingMonthlyCap()
 	if dailyCap > 0 && !budgetUnavailable {
-		pct := (dailyCost / dailyCap) * 100
-		RecordBudgetUtilization(ctx, agent.TenantID, "daily", pct)
-		g.tryBudgetAlert(ctx, agent.Name, agent.TenantID, "daily", pct, 80)
-		g.tryBudgetAlert(ctx, agent.Name, agent.TenantID, "daily", pct, 95)
+		RecordBudgetUtilization(ctx, agent.TenantID, "daily", (dailyCost/dailyCap)*100)
+		g.noteBudgetThresholds(ctx, agent, route.Provider, correlationID, "daily", dailyCost, dailyCap)
 	}
 	if monthlyCap > 0 && !budgetUnavailable {
-		pct := (monthlyCost / monthlyCap) * 100
-		RecordBudgetUtilization(ctx, agent.TenantID, "monthly", pct)
-		g.tryBudgetAlert(ctx, agent.Name, agent.TenantID, "monthly", pct, 80)
-		g.tryBudgetAlert(ctx, agent.Name, agent.TenantID, "monthly", pct, 95)
+		RecordBudgetUtilization(ctx, agent.TenantID, "monthly", (monthlyCost/monthlyCap)*100)
+		g.noteBudgetThresholds(ctx, agent, route.Provider, correlationID, "monthly", monthlyCost, monthlyCap)
 	}
 	destinationRegion := g.providerRegion(route.Provider)
 	policyInput, sessionBudgetUnavailable := g.buildPolicyInputForRequest(ctx, agent, route.Provider, extracted.Model, tier, estimatedCost, dailyCost, monthlyCost, sessionID)
@@ -665,6 +664,9 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				WriteProviderError(w, wire, http.StatusForbidden, preferredDenyReason(reasons))
 				persisted, err := g.recordEvidence(ctx, correlationID, agent, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, reasons, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, estimatedCost, func(p *RecordGatewayEvidenceParams) {
 					p.SessionBudget = sessionBudgetDetail(reasons, policyInput, estimatedCost)
+					// Budget hard stop (#144): the deny record explicitly
+					// carries the window/limit/spend it was decided on.
+					p.CostBudget = costBudgetDetail(reasons, dailyCost, monthlyCost, dailyCap, monthlyCap, estimatedCost)
 					if sessionBudgetUnavailable {
 						p.GatewayAnnotations = append(p.GatewayAnnotations, "session_budget_unavailable")
 					}
@@ -672,6 +674,25 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					g.handleEvidenceWriteFailure(ctx, err)
 					return
+				}
+				// Cost hard stops notify the org webhook — strictly after the
+				// signed deny record committed (#144). Non-cost denials
+				// (PII, egress, tools) are not cost events.
+				if code := costDenyReasonCode(reasons); code != "" {
+					costEv := CostEvent{
+						Event:         "budget_denied",
+						TenantID:      agent.TenantID,
+						Agent:         agent.Name,
+						EstimatedCost: estimatedCost,
+						Currency:      g.pricingCurrency,
+						ReasonCode:    code,
+						EvidenceID:    persisted.ID,
+						Timestamp:     persisted.Timestamp.UTC(),
+					}
+					if cb := persisted.CostBudget; cb != nil {
+						costEv.Period, costEv.Limit, costEv.Spent = cb.Period, cb.Limit, cb.Spent
+					}
+					g.postCostEvent(costEv)
 				}
 				g.emitMetrics(ctx, agent, route.Provider, extracted.Model, classification, nil, nil, nil, 0, durationMS, false, true, piiAction, false, 0, 0, 0, persisted)
 				return
@@ -1920,31 +1941,6 @@ func hashJSONDigest(v any) string {
 	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
-}
-
-// tryBudgetAlert emits RecordBudgetAlert when utilization >= threshold, with a
-// 1-hour cooldown keyed per AGENT+tenant+period+threshold. Enforcement caps
-// and utilization are per-agent, so the cooldown must be too — a tenant-only
-// key let one agent's 80% alert suppress every other agent's for an hour
-// (#266 review round 4).
-func (g *Gateway) tryBudgetAlert(ctx context.Context, agentName, tenantID, period string, utilizationPct float64, threshold float64) {
-	if utilizationPct < threshold {
-		return
-	}
-	key := agentName + ":" + tenantID + ":" + period + ":" + fmt.Sprintf("%.0f", threshold)
-	g.budgetAlertMu.Lock()
-	if g.budgetAlertLast == nil {
-		g.budgetAlertLast = make(map[string]time.Time)
-	}
-	last := g.budgetAlertLast[key]
-	now := time.Now()
-	if now.Sub(last) < time.Hour {
-		g.budgetAlertMu.Unlock()
-		return
-	}
-	g.budgetAlertLast[key] = now
-	g.budgetAlertMu.Unlock()
-	RecordBudgetAlert(ctx, tenantID, threshold)
 }
 
 // agentCostTotals returns the agent's accumulated daily/monthly spend. The

--- a/internal/policy/webhook_url.go
+++ b/internal/policy/webhook_url.go
@@ -1,0 +1,27 @@
+package policy
+
+import (
+	"net/url"
+	"strings"
+)
+
+// AllowedWebhookURL reports whether a URL is safe for an outbound
+// operator-configured webhook POST: HTTPS anywhere, or HTTP to loopback only.
+// This is the SSRF rule the runner's budget_alert_webhook shipped with; the
+// org-wide cost webhook (#144) applies the identical rule so there is one
+// vocabulary for "where Talon will POST".
+func AllowedWebhookURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	switch u.Scheme {
+	case "https":
+		return true
+	case "http":
+		h := strings.ToLower(u.Hostname())
+		return h == "localhost" || h == "127.0.0.1" || strings.HasSuffix(h, ".localhost")
+	default:
+		return false
+	}
+}

--- a/internal/policy/webhook_url_test.go
+++ b/internal/policy/webhook_url_test.go
@@ -1,0 +1,35 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// One SSRF rule for every operator-configured webhook (#144): HTTPS anywhere,
+// HTTP to loopback only — the runner budget_alert_webhook contract.
+func TestAllowedWebhookURL(t *testing.T) {
+	allowed := []string{
+		"https://hooks.example.com/talon",
+		"https://hooks.example.com:8443/path?x=1",
+		"http://localhost:9000/hook",
+		"http://127.0.0.1/hook",
+		"http://dev.localhost/hook",
+	}
+	for _, u := range allowed {
+		assert.True(t, AllowedWebhookURL(u), "should allow %s", u)
+	}
+	rejected := []string{
+		"",
+		"http://internal.corp/hook",       // HTTP to non-loopback
+		"http://169.254.169.254/metadata", // cloud metadata endpoint
+		"http://10.0.0.5/hook",
+		"ftp://example.com/hook",
+		"file:///etc/passwd",
+		"hooks.example.com/no-scheme",
+		"://garbage",
+	}
+	for _, u := range rejected {
+		assert.False(t, AllowedWebhookURL(u), "should reject %s", u)
+	}
+}

--- a/schemas/talon.config.schema.json
+++ b/schemas/talon.config.schema.json
@@ -748,6 +748,10 @@
               ],
               "default": "evidence_only",
               "description": "Observation-only PII scan of tool-related request content (tool_use inputs, tool_result outputs, function-call arguments). evidence_only records findings in evidence without influencing enforcement; off disables the scan. Enforcement on tool content is not offered until per-block-type tool redaction exists (#212)."
+            },
+            "cost_webhook_url": {
+              "type": "string",
+              "description": "One organization-wide endpoint for cost-control events (#144): budget warning-threshold crossings and budget hard-stop denials POST here strictly after the signed evidence record commits. HTTPS required; HTTP is allowed to loopback only. Delivery failure is logged — evidence remains the truth."
             }
           },
           "description": "Organization policy in two explicit classes (#287): defaults — per-agent baselines an agent override may replace (PII and tool actions keep their monotonic floor merge) — and constraints — organization-wide hard bounds an override can only tighten within. Operational logging/scanning scalars stay at the top level. The pre-split flat keys (default_pii_action, max_daily_cost, allowed_models, ...) are rejected at load with a migration error naming the new location.",


### PR DESCRIPTION
Part 1 of #144 (cost-control contract) — control-plane MVP (#265), cost pillar. Covers the first three remaining-scope items and the CLI; **session-cap atomic reservation is PR-2** (LIMITATIONS.md stays truthful about the soft cap until then).

## Contract shipped

```
threshold crossed → signed evidence committed → OTel metric + organization webhook
hard limit reached → deny before provider → signed evidence committed → organization webhook
```

**Warning threshold as truth.** Crossing 80% or 95% of the binding daily/monthly cap writes ONE signed `budget_threshold` evidence record per crossing per UTC budget window (`gateway/budget_events.go`), replacing the 1-hour-cooldown OTel-only `tryBudgetAlert`. The OTel alert metric and the webhook fire strictly *after* the store commit, as projections of the committed fact — a failed evidence write releases the claim so nothing fires without a record. The in-memory fired-set is claimed under lock before any I/O (concurrent requests race to one winner) and is rebuilt lazily from the evidence store after a restart (`HasBudgetThresholdEvent`), so restarts can't duplicate crossings. Records carry `cost_budget {period, limit, spent, threshold_pct}` — `Limit` is the *binding* cap (tightest of agent and org, #216/#287), the same denominator enforcement uses. `budget_threshold` registers as `operator_event` in the record-class registry so crossing facts never inflate request traffic.

**Budget hard stop as evidence.** `budget_exceeded` denials now carry the same structured `cost_budget` context (window, binding limit, spend, pre-request estimate), appended after `session_budget` per the evidence-integrity append rule. Cost denials (`budget_exceeded` / `session_budget_exceeded`) notify the webhook after the deny record commits; PII/egress/tool denials are not cost events.

**One organization webhook.** `organization_policy.cost_webhook_url` — validated at *load* (a bad URL is a startup error, not a silent delivery outage) with the runner `budget_alert_webhook` SSRF rule, extracted to `policy.AllowedWebhookURL` (HTTPS anywhere, HTTP loopback only; runner now delegates to it). Delivery is async best-effort with a 10s timeout; failures are logged — evidence remains the truth. Payload includes the committed `evidence_id` for the proof path. Schema updated (`schemas/talon.config.schema.json`).

**CLI-first UX.** `talon costs` budget lines now end with the operator status — OK / WARNING (≥80) / CRITICAL (≥95) / BLOCKED (≥100) — computed from the same binding-cap denominators enforcement gates on, plus a legend naming the thresholds and the hard stop. Thresholds come from the exported `gateway.BudgetWarnThresholds` so CLI and enforcement can't drift.

## Done-when → proof

- Exactly one record + one webhook per crossing; later requests above the threshold yield none: `TestNoteBudgetThresholds_OncePerCrossing`, `_PerAgentPerPeriod`, `_DoubleCross` (jump past both thresholds → both facts, each once), `_RestartSafe`
- Webhook after evidence commit: `TestNoteBudgetThresholds_WebhookAfterEvidenceCommit` — the webhook *handler itself* verifies the referenced record is already readable in the store
- Hard-limit denial carries context and never reaches the provider: `TestCostBudgetDetail` + existing pre-forward deny path (unchanged ordering); `TestCostDenyReasonCode` pins that non-cost denials don't notify
- CLI status from the enforcement code path: `TestPrintBudgetUtilization_StatusAndThresholds`
- Config safety: `TestValidateCostWebhookURL` (load-time rejection), `TestAllowedWebhookURL` (SSRF table incl. cloud metadata endpoint)

## Test surface

`go test ./...` clean · `go test -tags integration ./tests/integration/` clean (69s) · `golangci-lint run ./internal/...` 0 issues.