### PR TITLE
feat(agents): AI use-case operating record — agent.use_case → agents show + fleet API (#382)

### DIFF
--- a/docs/explanation/control-plane.md
+++ b/docs/explanation/control-plane.md
@@ -45,6 +45,7 @@ Cost warning thresholds as signed evidence + org webhook (#144)
 
 - **AI use case** — the public product term: one operated unit of AI usage (a bot, an agent, a copilot integration).
 - **Agent** — the CLI/config object that represents one AI use case. One `agent.talon.yaml` describes one use case; `agent.name` is its operational identity in one Talon installation. Shipped model (#266): one active vault-bound Talon key per agent — the presented key IS the traffic identity, and `tenant_id` derives from it.
+- **Operating record** (`agent.use_case`, #382) — the optional block in `agent.talon.yaml` naming what the use case is for, which department operates it, how critical it is, and who is accountable (business / technical / budget / risk owners as contact strings), plus pointers to external approval records. `talon agents show` and the fleet API project it as declared. Two identities, never conflated: the **Talon key authenticates the presenter of traffic**; the **owner metadata is attribution for humans** — it authenticates nobody and is never a policy input. Criticality is context; it maps to no enforcement unless an explicit policy does so.
 - **Evidence** — the signed record of a decision; the proof layer, not the front door.
 
 ## Operator model: CLI primary, dashboard secondary

--- a/examples/product-demo/agents/coding-assistant/agent.talon.yaml
+++ b/examples/product-demo/agents/coding-assistant/agent.talon.yaml
@@ -13,6 +13,19 @@ agent:
   description: "Coding assistant — may search/read; the admin_* boundary is company-wide"
   version: "1.0.0"
   tenant_id: acme
+  # Different accountabilities than customer-support: engineering runs and
+  # budgets its own use case; the risk owner is shared company-wide.
+  use_case:
+    purpose: "Assist engineers with code review, refactoring and internal API usage"
+    department: "Engineering"
+    criticality: standard
+    owners:
+      business: "Priya Nair <p.nair@acme.example>"
+      technical: "dev-productivity@acme.example"
+      budget: "eng-budget@acme.example"
+      risk: "privacy-office@acme.example"
+    references:
+      - "AIGOV-102"
   key:
     secret_name: coding-assistant-talon-key
 

--- a/examples/product-demo/agents/customer-support/agent.talon.yaml
+++ b/examples/product-demo/agents/customer-support/agent.talon.yaml
@@ -18,6 +18,20 @@ agent:
   description: "Customer support assistant — prefers the local model; PII in scope"
   version: "1.0.0"
   tenant_id: acme
+  # Operating record (#382): who this use case is for and who is accountable.
+  # Attribution for humans reading the fleet — the Talon key authenticates
+  # traffic; nothing here authenticates the named owners.
+  use_case:
+    purpose: "Answer tier-1 customer questions from the support knowledge base"
+    department: "Customer Support"
+    criticality: important
+    owners:
+      business: "Sofia Marino <s.marino@acme.example>"
+      technical: "support-platform@acme.example"
+      budget: "cs-finops@acme.example"
+      risk: "privacy-office@acme.example"
+    references:
+      - "AIGOV-101"
   key:
     secret_name: customer-support-talon-key
 

--- a/examples/product-demo/agents/document-summary/agent.talon.yaml
+++ b/examples/product-demo/agents/document-summary/agent.talon.yaml
@@ -23,6 +23,20 @@ agent:
   description: "Batch document summarizer on Anthropic — session + daily budgets"
   version: "1.0.0"
   tenant_id: acme
+  # A third accountability shape: operations owns the outcome AND the budget;
+  # still experimental, so it says so instead of borrowing importance.
+  use_case:
+    purpose: "Summarize inbound contracts and reports for the operations team"
+    department: "Operations"
+    criticality: experimental
+    owners:
+      business: "ops-leads@acme.example"
+      technical: "support-platform@acme.example"
+      budget: "ops-leads@acme.example"
+      risk: "privacy-office@acme.example"
+    references:
+      - "AIGOV-103"
+      - "https://wiki.acme.example/ai/document-summary"
   key:
     secret_name: document-summary-talon-key
 

--- a/internal/agentbridge/usecase.go
+++ b/internal/agentbridge/usecase.go
@@ -1,0 +1,32 @@
+package agentbridge
+
+import (
+	"github.com/dativo-io/talon/internal/fleet"
+	"github.com/dativo-io/talon/internal/policy"
+)
+
+// FleetUseCase maps the agent config's operating record onto the fleet
+// projection (#382). It lives here — next to the policy → gateway identity
+// adapter — so the server fleet endpoint and the CLI offline path project the
+// IDENTICAL representation instead of each re-reading YAML shapes; fleet
+// itself stays a leaf read model with no policy import. Nil in, nil out: an
+// agent without a use_case block projects no record.
+func FleetUseCase(pol *policy.Policy) *fleet.UseCase {
+	if pol == nil || pol.Agent.UseCase == nil {
+		return nil
+	}
+	uc := pol.Agent.UseCase
+	out := &fleet.UseCase{
+		Purpose:     uc.Purpose,
+		Department:  uc.Department,
+		Criticality: uc.Criticality,
+		References:  append([]string(nil), uc.References...),
+	}
+	if uc.Owners != nil {
+		out.OwnerBusiness = uc.Owners.Business
+		out.OwnerTechnical = uc.Owners.Technical
+		out.OwnerBudget = uc.Owners.Budget
+		out.OwnerRisk = uc.Owners.Risk
+	}
+	return out
+}

--- a/internal/agentbridge/usecase_test.go
+++ b/internal/agentbridge/usecase_test.go
@@ -1,0 +1,53 @@
+package agentbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dativo-io/talon/internal/fleet"
+	"github.com/dativo-io/talon/internal/policy"
+)
+
+// FleetUseCase is the ONE policy → fleet mapping (#382): the server fleet
+// endpoint and the CLI offline path both call it, so the projections cannot
+// drift — this test pins the field-by-field contract.
+func TestFleetUseCase(t *testing.T) {
+	pol := &policy.Policy{Agent: policy.AgentConfig{
+		Name: "support-bot",
+		UseCase: &policy.UseCaseConfig{
+			Purpose:     "Answer tier-1 customer questions",
+			Department:  "Customer Support",
+			Criticality: "important",
+			Owners: &policy.UseCaseOwners{
+				Business:  "Sofia Marino <s.marino@acme.example>",
+				Technical: "support-platform@acme.example",
+				Budget:    "cs-finops@acme.example",
+				Risk:      "privacy-office@acme.example",
+			},
+			References: []string{"AIGOV-101"},
+		},
+	}}
+
+	got := FleetUseCase(pol)
+	assert.Equal(t, &fleet.UseCase{
+		Purpose:        "Answer tier-1 customer questions",
+		Department:     "Customer Support",
+		Criticality:    "important",
+		OwnerBusiness:  "Sofia Marino <s.marino@acme.example>",
+		OwnerTechnical: "support-platform@acme.example",
+		OwnerBudget:    "cs-finops@acme.example",
+		OwnerRisk:      "privacy-office@acme.example",
+		References:     []string{"AIGOV-101"},
+	}, got)
+
+	// Owners block absent: the flat fields stay empty, record still projects.
+	pol.Agent.UseCase.Owners = nil
+	partial := FleetUseCase(pol)
+	assert.Empty(t, partial.OwnerBusiness)
+	assert.Equal(t, "Customer Support", partial.Department)
+
+	// Nil-safety at both levels: no policy, no record.
+	assert.Nil(t, FleetUseCase(nil))
+	assert.Nil(t, FleetUseCase(&policy.Policy{}), "agent without use_case projects no record")
+}

--- a/internal/cmd/agents_queue.go
+++ b/internal/cmd/agents_queue.go
@@ -236,6 +236,7 @@ func offlineFleet(ctx context.Context, cfg *config.Config, tenant string) ([]fle
 			// uses. Offline has the gateway providers when a gateway config is
 			// present; without one, only a categorical model block is detectable.
 			PolicyDenyAll: !gateway.AgentCanAcceptWork(org, override, providers),
+			UseCase:       agentbridge.FleetUseCase(a.Policy),
 		})
 	}
 
@@ -343,6 +344,7 @@ func renderAgentShow(w io.Writer, r fleet.AgentRow, label string) {
 		fmt.Fprintf(w, "  - %s: %s\n", c.Kind, c.Detail)
 	}
 	fmt.Fprintln(w)
+	renderAgentUseCase(w, r.UseCase)
 	fmt.Fprintf(w, "Cost (month-to-date): %s\n", monthCostLine(r))
 	fmt.Fprintf(w, "Cost (today):         %s\n", dayCostLine(r))
 	fmt.Fprintln(w)
@@ -362,6 +364,41 @@ func renderAgentShow(w io.Writer, r fleet.AgentRow, label string) {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Detail: `talon costs --agent`, `talon session`, `talon agents score` (layered effective policy + recent sessions/denials/fallbacks: #305).")
+}
+
+// renderAgentUseCase prints the operating record declared in the agent's
+// config (#382). Purely declared metadata — no health/budget/policy
+// computation happens here; owners are attribution for the reader, never
+// authentication of the named people.
+func renderAgentUseCase(w io.Writer, uc *fleet.UseCase) {
+	if uc == nil {
+		return
+	}
+	fmt.Fprintln(w, "Use case (declared in config):")
+	if uc.Purpose != "" {
+		fmt.Fprintf(w, "  Purpose:     %s\n", uc.Purpose)
+	}
+	if uc.Department != "" {
+		fmt.Fprintf(w, "  Department:  %s\n", uc.Department)
+	}
+	if uc.Criticality != "" {
+		fmt.Fprintf(w, "  Criticality: %s\n", uc.Criticality)
+	}
+	owners := [][2]string{
+		{"business", uc.OwnerBusiness},
+		{"technical", uc.OwnerTechnical},
+		{"budget", uc.OwnerBudget},
+		{"risk", uc.OwnerRisk},
+	}
+	for _, o := range owners {
+		if o[1] != "" {
+			fmt.Fprintf(w, "  Owner (%s): %s\n", o[0], o[1])
+		}
+	}
+	for _, ref := range uc.References {
+		fmt.Fprintf(w, "  Reference:   %s\n", ref)
+	}
+	fmt.Fprintln(w)
 }
 
 func monthCostLine(r fleet.AgentRow) string {

--- a/internal/cmd/agents_queue_test.go
+++ b/internal/cmd/agents_queue_test.go
@@ -66,6 +66,61 @@ func TestOfflineFleet_ProjectsLocalConfig(t *testing.T) {
 	assert.Equal(t, fleet.HealthHealthy, rows[1].Health)
 }
 
+// The operating record (#382) flows from agent.talon.yaml through the catalog
+// and the fleet projection into the row `agents show` renders — no separate
+// YAML re-parse anywhere on the path.
+func TestOfflineFleet_ProjectsUseCaseRecord(t *testing.T) {
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	d := filepath.Join(agentsDir, "support")
+	require.NoError(t, os.MkdirAll(d, 0o755))
+	y := `agent:
+  name: support
+  version: "1.0.0"
+  use_case:
+    purpose: "Answer tier-1 customer questions"
+    department: "Customer Support"
+    criticality: important
+    owners:
+      business: "Sofia Marino <s.marino@acme.example>"
+      budget: "cs-finops@acme.example"
+    references:
+      - "AIGOV-101"
+policies:
+  cost_limits:
+    daily: 10
+`
+	require.NoError(t, os.WriteFile(filepath.Join(d, "agent.talon.yaml"), []byte(y), 0o600))
+	writeQueueAgent(t, agentsDir, "plain", true) // no use_case block
+
+	rows, _, err := offlineFleet(context.Background(), offlineTestConfig(t, agentsDir), "")
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	byName := map[string]fleet.AgentRow{rows[0].Name: rows[0], rows[1].Name: rows[1]}
+
+	uc := byName["support"].UseCase
+	require.NotNil(t, uc)
+	assert.Equal(t, "Customer Support", uc.Department)
+	assert.Equal(t, "important", uc.Criticality)
+	assert.Equal(t, "Sofia Marino <s.marino@acme.example>", uc.OwnerBusiness)
+	assert.Nil(t, byName["plain"].UseCase, "no block → no record, not an empty one")
+
+	// The show rendering carries the record; a row without one stays clean.
+	var buf bytes.Buffer
+	renderAgentShow(&buf, byName["support"], "")
+	out := buf.String()
+	assert.Contains(t, out, "Use case (declared in config):")
+	assert.Contains(t, out, "Purpose:     Answer tier-1 customer questions")
+	assert.Contains(t, out, "Criticality: important")
+	assert.Contains(t, out, "Owner (business): Sofia Marino <s.marino@acme.example>")
+	assert.Contains(t, out, "Owner (budget): cs-finops@acme.example")
+	assert.Contains(t, out, "Reference:   AIGOV-101")
+
+	buf.Reset()
+	renderAgentShow(&buf, byName["plain"], "")
+	assert.NotContains(t, buf.String(), "Use case", "absent record renders nothing")
+}
+
 // TestOfflineFleet_DenyAllPolicyIsBlocked covers #270 review round 1, P1: an
 // agent whose effective policy denies all new work (blocked_models: ["*"])
 // renders BLOCKED offline, while a normal agent does not.

--- a/internal/fleet/assemble.go
+++ b/internal/fleet/assemble.go
@@ -18,6 +18,8 @@ type Membership struct {
 	ConfigError    string
 	// PolicyDenyAll — the ACTIVE policy denies all new work agent-wide (BLOCKED).
 	PolicyDenyAll bool
+	// UseCase is the config-declared operating record (#382); nil when absent.
+	UseCase *UseCase
 }
 
 // CapLookup returns an agent's effective daily/monthly cost caps (0 = uncapped),
@@ -53,6 +55,7 @@ func AssembleStatuses(members []Membership, caps CapLookup, currency string) []A
 			DailyCap:       daily,
 			MonthlyCap:     monthly,
 			Currency:       currency,
+			UseCase:        m.UseCase,
 		})
 	}
 	return out

--- a/internal/fleet/projection.go
+++ b/internal/fleet/projection.go
@@ -127,6 +127,7 @@ func Project(ctx context.Context, ev EvidenceSource, ss SessionSource, agents []
 			ConfigPath:     a.ConfigPath,
 			PolicyDigest:   a.PolicyDigest,
 			ConfigError:    a.ConfigError,
+			UseCase:        a.UseCase,
 		})
 	}
 	sortRows(rows)

--- a/internal/fleet/types.go
+++ b/internal/fleet/types.go
@@ -186,6 +186,8 @@ type AgentStatus struct {
 	MonthlyCap float64
 	// Currency the caps and evidence spend are denominated in (ISO-4217).
 	Currency string
+	// UseCase is the config-declared operating record (#382); nil when absent.
+	UseCase *UseCase
 }
 
 // AgentRow is one projected attention-queue row: the STATE/HEALTH/COST/WHY the
@@ -214,6 +216,27 @@ type AgentRow struct {
 	ConfigPath     string    `json:"config_path"`
 	PolicyDigest   string    `json:"policy_digest"`
 	ConfigError    string    `json:"config_error,omitempty"`
+	// UseCase is the operating record declared in the agent's config (#382):
+	// purpose, organizational context and accountable owners. Nil when the
+	// config declares none — the record is optional by design.
+	UseCase *UseCase `json:"use_case,omitempty"`
+}
+
+// UseCase is the AI use-case operating record (#382) as projected to the CLI
+// and dashboard: flat strings mirroring policy.UseCaseConfig so internal/fleet
+// stays a leaf read model (no policy import). Owner values are attribution
+// for humans reading the fleet — the Talon key authenticates the presenter of
+// traffic; nothing here authenticates the named owners, and none of it is a
+// policy input.
+type UseCase struct {
+	Purpose        string   `json:"purpose,omitempty"`
+	Department     string   `json:"department,omitempty"`
+	Criticality    string   `json:"criticality,omitempty"`
+	OwnerBusiness  string   `json:"owner_business,omitempty"`
+	OwnerTechnical string   `json:"owner_technical,omitempty"`
+	OwnerBudget    string   `json:"owner_budget,omitempty"`
+	OwnerRisk      string   `json:"owner_risk,omitempty"`
+	References     []string `json:"references,omitempty"`
 }
 
 // CostString renders the COST column: month-to-date spend, and "/ cap" when a

--- a/internal/policy/agent.talon.schema.json
+++ b/internal/policy/agent.talon.schema.json
@@ -25,7 +25,34 @@
             "secret_name": {"type": "string", "minLength": 1}
           }
         },
-        "accept_client_metadata": {"type": "boolean", "description": "Record client-asserted orchestration identity (session/subagent headers) in evidence for this agent's gateway traffic. Default true; recording only, never a policy input."}
+        "accept_client_metadata": {"type": "boolean", "description": "Record client-asserted orchestration identity (session/subagent headers) in evidence for this agent's gateway traffic. Default true; recording only, never a policy input."},
+        "use_case": {
+          "type": "object",
+          "description": "Optional AI use-case operating record (#382): purpose, organizational context and accountable owners. Attribution for humans reading the fleet — the Talon key authenticates the presenter of traffic; nothing here authenticates the named owners, and none of it is a policy input.",
+          "additionalProperties": false,
+          "properties": {
+            "purpose": {"type": "string", "maxLength": 500, "description": "Short human description of what the use case does."},
+            "department": {"type": "string", "maxLength": 200, "description": "Operating area that owns the use case day-to-day."},
+            "criticality": {"type": "string", "enum": ["experimental", "standard", "important", "critical"], "description": "Closed vocabulary — context for operators; maps to NO enforcement unless an explicit separate policy does so."},
+            "owners": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Accountable contacts by role — stable identifiers or contact strings, never an embedded organization directory.",
+              "properties": {
+                "business": {"type": "string", "maxLength": 200, "description": "Accountable for the business outcome."},
+                "technical": {"type": "string", "maxLength": 200, "description": "Operates the integration."},
+                "budget": {"type": "string", "maxLength": 200, "description": "Owns the spend allocation the cost caps draw from."},
+                "risk": {"type": "string", "maxLength": 200, "description": "Owns control/risk decisions and explicit policy exceptions."}
+              }
+            },
+            "references": {
+              "type": "array",
+              "maxItems": 8,
+              "items": {"type": "string", "maxLength": 300},
+              "description": "External lifecycle/approval pointers (ticket ids, wiki URLs). Talon stores pointers; the workflows stay external."
+            }
+          }
+        }
       }
     },
     "capabilities": {

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -102,6 +102,12 @@ func LoadPolicy(ctx context.Context, path string, strict bool, baseDir string) (
 		return nil, fmt.Errorf("computing policy identity: %w", err)
 	}
 
+	// Operating-record rules (#382): closed criticality vocabulary + length
+	// bounds. A config without a use_case block is untouched.
+	if err := ValidateUseCase(pol.Agent.UseCase); err != nil {
+		return nil, fmt.Errorf("use_case validation: %w", err)
+	}
+
 	// Validate routing configuration for sovereignty misconfigurations
 	if pol.Policies.ModelRouting != nil {
 		warnings, err := ValidateRouting(pol.Policies.ModelRouting)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -58,6 +58,12 @@ type AgentConfig struct {
 	// agent loaded into the gateway identity registry (a missing binding fails
 	// startup); optional for native-only, non-traffic-bound runs.
 	Key *AgentKeyBinding `yaml:"key,omitempty" json:"key,omitempty"`
+	// UseCase is the optional AI use-case operating record (#382): purpose,
+	// organizational context and accountable owners. Attribution for humans
+	// reading the fleet — the Talon key authenticates the presenter of
+	// traffic; nothing here authenticates the named owners, and none of it is
+	// a policy input. Fully optional: existing configs stay valid unchanged.
+	UseCase *UseCaseConfig `yaml:"use_case,omitempty" json:"use_case,omitempty"`
 	// AcceptClientMetadata controls whether client-asserted orchestration
 	// identity (x-claude-code-* / Codex / generic X-Talon-* headers) is
 	// recorded in evidence for this agent's gateway traffic. nil = true
@@ -77,6 +83,93 @@ func (a *AgentConfig) IsEnabled() bool {
 // per agent, structurally.
 type AgentKeyBinding struct {
 	SecretName string `yaml:"secret_name" json:"secret_name"`
+}
+
+// UseCaseConfig is the AI use-case operating record (#382): what the use case
+// is for, which part of the organization operates it, how critical it is, and
+// who is accountable. Every field is optional (a use case must route traffic
+// before its paperwork is complete); owners are stable identifiers or contact
+// strings, never an embedded organization directory. Criticality is context
+// for operators and stakeholders — it maps to NO enforcement unless an
+// explicit separate policy does so.
+type UseCaseConfig struct {
+	// Purpose is a short human description of what the use case does.
+	Purpose string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	// Department is the operating area that owns the use case day-to-day.
+	Department string `yaml:"department,omitempty" json:"department,omitempty"`
+	// Criticality is one of: experimental, standard, important, critical.
+	// A closed vocabulary so fleet views stay comparable — free-form values
+	// are rejected at load rather than silently becoming a risk taxonomy.
+	Criticality string `yaml:"criticality,omitempty" json:"criticality,omitempty"`
+	// Owners names who is accountable, by role.
+	Owners *UseCaseOwners `yaml:"owners,omitempty" json:"owners,omitempty"`
+	// References link to external lifecycle/approval records (ticket ids,
+	// wiki URLs). Talon stores the pointers; the workflows stay external.
+	References []string `yaml:"references,omitempty" json:"references,omitempty"`
+}
+
+// UseCaseOwners are the accountable contacts for a use case, by role. Free
+// strings ("Jane Vos <j.vos@acme.example>", "finops@acme.example") —
+// attribution for humans, never authentication of the named owners.
+type UseCaseOwners struct {
+	// Business is accountable for the business outcome.
+	Business string `yaml:"business,omitempty" json:"business,omitempty"`
+	// Technical operates the integration.
+	Technical string `yaml:"technical,omitempty" json:"technical,omitempty"`
+	// Budget owns the spend allocation the cost caps draw from.
+	Budget string `yaml:"budget,omitempty" json:"budget,omitempty"`
+	// Risk owns control/risk decisions and explicit policy exceptions.
+	Risk string `yaml:"risk,omitempty" json:"risk,omitempty"`
+}
+
+// Use-case validation bounds: generous for humans, tight enough that the
+// record stays a record (not embedded documentation).
+const (
+	useCasePurposeMaxLen   = 500
+	useCaseFieldMaxLen     = 200
+	useCaseMaxReferences   = 8
+	useCaseReferenceMaxLen = 300
+)
+
+var useCaseCriticalities = map[string]bool{
+	"experimental": true, "standard": true, "important": true, "critical": true,
+}
+
+// ValidateUseCase enforces the operating-record rules (#382): closed
+// criticality vocabulary and length bounds. A nil record is valid — the block
+// is optional by design.
+func ValidateUseCase(uc *UseCaseConfig) error {
+	if uc == nil {
+		return nil
+	}
+	if uc.Criticality != "" && !useCaseCriticalities[uc.Criticality] {
+		return fmt.Errorf("use_case.criticality must be one of experimental|standard|important|critical, got %q", uc.Criticality)
+	}
+	if len(uc.Purpose) > useCasePurposeMaxLen {
+		return fmt.Errorf("use_case.purpose exceeds %d characters", useCasePurposeMaxLen)
+	}
+	if len(uc.Department) > useCaseFieldMaxLen {
+		return fmt.Errorf("use_case.department exceeds %d characters", useCaseFieldMaxLen)
+	}
+	if uc.Owners != nil {
+		for field, v := range map[string]string{
+			"business": uc.Owners.Business, "technical": uc.Owners.Technical,
+			"budget": uc.Owners.Budget, "risk": uc.Owners.Risk,
+		} {
+			if len(v) > useCaseFieldMaxLen {
+				return fmt.Errorf("use_case.owners.%s exceeds %d characters", field, useCaseFieldMaxLen)
+			}
+		}
+	}
+	if len(uc.References) > useCaseMaxReferences {
+		return fmt.Errorf("use_case.references allows at most %d entries", useCaseMaxReferences)
+	}
+	for i, r := range uc.References {
+		if len(r) > useCaseReferenceMaxLen {
+			return fmt.Errorf("use_case.references[%d] exceeds %d characters", i, useCaseReferenceMaxLen)
+		}
+	}
+	return nil
 }
 
 // CapabilitiesConfig defines what the agent is allowed to do.

--- a/internal/policy/usecase_test.go
+++ b/internal/policy/usecase_test.go
@@ -1,0 +1,97 @@
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Operating-record contract (#382): optional use_case block — parsing,
+// validation rules, and backward compatibility.
+
+const useCaseAgentYAML = `
+agent:
+  name: support-bot
+  version: "1.0.0"
+  use_case:
+    purpose: "Answer tier-1 customer questions"
+    department: "Customer Support"
+    criticality: important
+    owners:
+      business: "Sofia Marino <s.marino@acme.example>"
+      technical: "support-platform@acme.example"
+      budget: "cs-finops@acme.example"
+      risk: "privacy-office@acme.example"
+    references:
+      - "AIGOV-101"
+policies:
+  cost_limits:
+    daily: 10.0
+`
+
+func writeUseCasePolicy(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.talon.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestLoadPolicy_UseCaseParsed(t *testing.T) {
+	path := writeUseCasePolicy(t, useCaseAgentYAML)
+	pol, err := LoadPolicy(context.Background(), path, false, filepath.Dir(path))
+	require.NoError(t, err)
+	uc := pol.Agent.UseCase
+	require.NotNil(t, uc)
+	assert.Equal(t, "Answer tier-1 customer questions", uc.Purpose)
+	assert.Equal(t, "Customer Support", uc.Department)
+	assert.Equal(t, "important", uc.Criticality)
+	require.NotNil(t, uc.Owners)
+	assert.Equal(t, "Sofia Marino <s.marino@acme.example>", uc.Owners.Business)
+	assert.Equal(t, "privacy-office@acme.example", uc.Owners.Risk)
+	assert.Equal(t, []string{"AIGOV-101"}, uc.References)
+}
+
+// Existing configs without the block stay valid, parse to nil, and keep their
+// canonical digest unchanged — the record is purely additive.
+func TestLoadPolicy_UseCaseAbsentBackCompat(t *testing.T) {
+	without := "agent:\n  name: support-bot\n  version: \"1.0.0\"\npolicies:\n  cost_limits:\n    daily: 10.0\n"
+	path := writeUseCasePolicy(t, without)
+	pol, err := LoadPolicy(context.Background(), path, false, filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Nil(t, pol.Agent.UseCase)
+	require.NotEmpty(t, pol.Hash)
+
+	// Adding the block changes the digest (it is part of the config's
+	// identity); removing it restores the original — no hidden state.
+	withPath := writeUseCasePolicy(t, useCaseAgentYAML)
+	withPol, err := LoadPolicy(context.Background(), withPath, false, filepath.Dir(withPath))
+	require.NoError(t, err)
+	assert.NotEqual(t, pol.Hash, withPol.Hash)
+}
+
+func TestLoadPolicy_UseCaseCriticalityClosedVocabulary(t *testing.T) {
+	bad := strings.Replace(useCaseAgentYAML, "criticality: important", "criticality: sev1", 1)
+	path := writeUseCasePolicy(t, bad)
+	_, err := LoadPolicy(context.Background(), path, false, filepath.Dir(path))
+	require.Error(t, err, "free-form criticality must be rejected, not become a private risk taxonomy")
+	assert.Contains(t, err.Error(), "criticality")
+}
+
+func TestValidateUseCase_Bounds(t *testing.T) {
+	assert.NoError(t, ValidateUseCase(nil), "record is optional")
+	assert.NoError(t, ValidateUseCase(&UseCaseConfig{}), "empty record is valid")
+	assert.NoError(t, ValidateUseCase(&UseCaseConfig{Criticality: "critical"}))
+
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{Criticality: "high"}))
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{Purpose: strings.Repeat("x", useCasePurposeMaxLen+1)}))
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{Department: strings.Repeat("x", useCaseFieldMaxLen+1)}))
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{Owners: &UseCaseOwners{Budget: strings.Repeat("x", useCaseFieldMaxLen+1)}}))
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{References: make([]string, useCaseMaxReferences+1)}))
+	assert.Error(t, ValidateUseCase(&UseCaseConfig{References: []string{strings.Repeat("x", useCaseReferenceMaxLen+1)}}))
+}

--- a/internal/server/handlers_fleet.go
+++ b/internal/server/handlers_fleet.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/dativo-io/talon/internal/agentbridge"
 	"github.com/dativo-io/talon/internal/agentcatalog"
 	"github.com/dativo-io/talon/internal/fleet"
 	"github.com/dativo-io/talon/internal/gateway"
@@ -174,6 +175,7 @@ func membershipFromView(view agentcatalog.FleetView, denyAll func(tenantID, agen
 			ConfigRejected: rejected,
 			ConfigError:    reason,
 			PolicyDenyAll:  denyAll != nil && denyAll(tenant, ra.Name),
+			UseCase:        agentbridge.FleetUseCase(ra.Policy),
 		})
 	}
 	return members

--- a/schemas/agent.talon.schema.json
+++ b/schemas/agent.talon.schema.json
@@ -25,7 +25,34 @@
             "secret_name": {"type": "string", "minLength": 1}
           }
         },
-        "accept_client_metadata": {"type": "boolean", "description": "Record client-asserted orchestration identity (session/subagent headers) in evidence for this agent's gateway traffic. Default true; recording only, never a policy input."}
+        "accept_client_metadata": {"type": "boolean", "description": "Record client-asserted orchestration identity (session/subagent headers) in evidence for this agent's gateway traffic. Default true; recording only, never a policy input."},
+        "use_case": {
+          "type": "object",
+          "description": "Optional AI use-case operating record (#382): purpose, organizational context and accountable owners. Attribution for humans reading the fleet — the Talon key authenticates the presenter of traffic; nothing here authenticates the named owners, and none of it is a policy input.",
+          "additionalProperties": false,
+          "properties": {
+            "purpose": {"type": "string", "maxLength": 500, "description": "Short human description of what the use case does."},
+            "department": {"type": "string", "maxLength": 200, "description": "Operating area that owns the use case day-to-day."},
+            "criticality": {"type": "string", "enum": ["experimental", "standard", "important", "critical"], "description": "Closed vocabulary — context for operators; maps to NO enforcement unless an explicit separate policy does so."},
+            "owners": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Accountable contacts by role — stable identifiers or contact strings, never an embedded organization directory.",
+              "properties": {
+                "business": {"type": "string", "maxLength": 200, "description": "Accountable for the business outcome."},
+                "technical": {"type": "string", "maxLength": 200, "description": "Operates the integration."},
+                "budget": {"type": "string", "maxLength": 200, "description": "Owns the spend allocation the cost caps draw from."},
+                "risk": {"type": "string", "maxLength": 200, "description": "Owns control/risk decisions and explicit policy exceptions."}
+              }
+            },
+            "references": {
+              "type": "array",
+              "maxItems": 8,
+              "items": {"type": "string", "maxLength": 300},
+              "description": "External lifecycle/approval pointers (ticket ids, wiki URLs). Talon stores pointers; the workflows stay external."
+            }
+          }
+        }
       }
     },
     "capabilities": {


### PR DESCRIPTION
Closes #382. Control-plane strategy addendum (2026-07-21, #265) — the operating record that connects ownership and organizational context to the fleet view.

## What ships

**The `use_case` block** (optional, under `agent:` in `agent.talon.yaml`): purpose (≤500), department (≤200), closed criticality vocabulary (`experimental|standard|important|critical` — free-form rejected at load so it can't silently become a risk taxonomy), owners by role (business/technical/budget/risk — contact strings ≤200, never a directory model), and ≤8 external lifecycle/approval references. Validated in `LoadPolicy` (`ValidateUseCase`); JSON schema updated in both copies with `additionalProperties: false` on the new objects.

**One shared representation.** `policy.UseCaseConfig` → flat `fleet.UseCase` through exactly one mapping (`agentbridge.FleetUseCase`), called by both membership builders — the server's `/v1/agents/fleet` and the CLI offline path. The dashboard/API and `talon agents show` therefore consume the same projection by construction; `internal/fleet` remains a leaf read model with no policy import.

**`talon agents show`** renders the declared record (purpose, department, criticality, owners, references) as its own section — declared metadata only, zero health/budget/policy computation. `--json` and the fleet endpoint carry `use_case` on `AgentRow`.

**The boundary, written down three times** (schema, code comments, `docs/explanation/control-plane.md` vocabulary): the Talon key authenticates the *presenter of traffic*; owner metadata is *attribution for humans* — authenticates nobody, never a policy input.

**Worked example:** the product-demo fleet's three use cases (customer-support / coding-assistant / document-summary) now declare distinct business, technical and budget accountabilities across Customer Support, Engineering and Operations.

## Acceptance criteria → proof

- Documented schema decision + validation rules: posted on #382; enforced by `ValidateUseCase` + JSON schema
- Existing configs valid without migration: `TestLoadPolicy_UseCaseAbsentBackCompat` (nil record, digest unchanged)
- `agents show` displays purpose/context/owners without duplicating computation: `TestOfflineFleet_ProjectsUseCaseRecord` (config → catalog → fleet row → rendered output, one path)
- Dashboard/API same shared representation: structural (one `FleetUseCase` call in both builders) + `TestFleetUseCase` field contract
- Key-vs-owner documentation: control-plane.md vocabulary entry
- Departmental fleet example with 3 distinct accountabilities: `examples/product-demo/agents/*`
- Parsing/validation/back-compat/projection tests: `internal/policy/usecase_test.go`, `internal/agentbridge/usecase_test.go`, `internal/cmd/agents_queue_test.go`

## Deliberately not in this slice

Evidence/export attachment of the record — mixing declared metadata into signed records needs its own provenance decision (noted on the issue). #383 (thin lifecycle) builds on this shape next.

## Test surface

`go test ./...` clean · `go test -tags integration ./tests/integration/` clean (72s) · `golangci-lint run ./internal/...` 0 issues.