### PR TITLE
fix(gateway): truthful error types on request-side scanner/PII blocks (#209)

### DIFF
--- a/internal/gateway/egress_guard_test.go
+++ b/internal/gateway/egress_guard_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -73,4 +74,15 @@ func TestGatewayResidualPIIApprovalCannotBypass(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code, "residual PII must fail closed")
 	assert.Contains(t, rec.Body.String(), "recognized PII remains after redaction")
 	assert.Equal(t, 0, upstreamCalls, "approval headers must not bypass residual PII block")
+
+	// #209: a residual-PII block is a POLICY outcome — the error type must
+	// say so instead of the misleading invalid_request_error, so clients can
+	// distinguish "don't retry this content" from a retriable scanner outage.
+	var errBody struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errBody))
+	assert.Equal(t, "pii_policy_violation", errBody.Error.Type)
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -482,7 +482,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			durationMS := time.Since(start).Milliseconds()
 			RecordGatewayError(ctx, "scanner_unavailable")
-			WriteProviderError(w, wire, http.StatusBadGateway, "Request blocked: PII scanner unavailable (fail-closed)")
+			WriteProviderError(w, wire, http.StatusBadGateway, "scanner_unavailable: Request blocked: PII scanner unavailable (fail-closed)")
 			persisted, err := g.recordEvidence(ctx, correlationID, agent, route.Provider, extracted.Model, start, extracted.Text, nil, nil, 0, durationMS, "", false, []string{"scanner unavailable"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0, func(p *RecordGatewayEvidenceParams) {
 				if p.Scanner != nil {
 					p.Scanner.Failure = scannerFailureKind(scanErr)
@@ -573,7 +573,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Str("agent", agent.Name).Str("enforcement_mode", "shadow").Strs("pii", piiTypes).Msg("shadow_pii_block")
 		} else {
 			durationMS := time.Since(start).Milliseconds()
-			WriteProviderError(w, wire, http.StatusBadRequest, "Request contains PII that is not allowed")
+			WriteProviderError(w, wire, http.StatusBadRequest, "pii_policy_violation: Request contains PII that is not allowed")
 			persisted, err := g.recordEvidence(ctx, correlationID, agent, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, 0, "", false, []string{"PII block"}, false, nil, attSummary, nil, nil, false, "", 0, 0, false, 0, 0, 0)
 			if err != nil {
 				g.handleEvidenceWriteFailure(ctx, err)
@@ -779,7 +779,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if redactErr != nil {
 			durationMS := time.Since(start).Milliseconds()
 			RecordGatewayError(ctx, "scanner_unavailable")
-			WriteProviderError(w, wire, http.StatusBadGateway, "Request blocked: PII redaction failed (fail-closed)")
+			WriteProviderError(w, wire, http.StatusBadGateway, "scanner_unavailable: Request blocked: PII redaction failed (fail-closed)")
 			persisted, err := g.recordEvidence(ctx, correlationID, agent, route.Provider, extracted.Model, start, extracted.Text, classification, nil, 0, durationMS, "", false, []string{"request redaction failed"}, false, nil, attSummary, toolResult, nil, false, "", 0, 0, false, 0, 0, estimatedCost, func(p *RecordGatewayEvidenceParams) {
 				if p.Scanner != nil {
 					p.Scanner.Failure = scannerFailureKind(redactErr)
@@ -816,11 +816,16 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// and scanner failure kind must each say which one happened.
 			residual := errors.Is(verifyErr, classifier.ErrPIIDetected)
 			types := strings.Join(classifier.ResidualTypes(verifyErr), ", ")
-			msg := "Request blocked: recognized PII remains after redaction"
+			// The machine-code prefix travels into the provider-native
+			// error.type (#209): a residual block is a policy outcome (never
+			// retriable as-is), a failed verification is infrastructure
+			// (retriable once the engine is back) — SDK clients must be able
+			// to branch on that, consistent with the response path.
+			msg := "pii_policy_violation: Request blocked: recognized PII remains after redaction"
 			status := http.StatusBadRequest
 			reason := "request residual pii after redaction"
 			if !residual {
-				msg = "Request blocked: redaction could not be verified (fail-closed)"
+				msg = "scanner_unavailable: Request blocked: redaction could not be verified (fail-closed)"
 				status = http.StatusBadGateway
 				reason = "request redaction verification failed: scanner unavailable"
 				RecordGatewayError(ctx, "scanner_unavailable")

--- a/internal/gateway/gateway_scanner_test.go
+++ b/internal/gateway/gateway_scanner_test.go
@@ -83,6 +83,19 @@ func TestExternalScannerFailClosed_EnforceBlocksRequest(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "PII scanner unavailable")
 	assert.False(t, upstreamHit, "blocked request must never reach the provider")
 
+	// #209: the provider-native error TYPE must say infrastructure, not
+	// "your request is malformed" — a 502 scanner outage is retriable once
+	// the engine is back, and SDK clients branch on error.type.
+	var body struct {
+		Error struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "scanner_unavailable", body.Error.Type,
+		"request-side scanner outage must carry the same machine type as the response path")
+
 	ev := latestGatewayEvidence(t, evStore)
 	require.NotNil(t, ev.Classification.Scanner, "evidence must identify the scan engine")
 	assert.Equal(t, "failing-engine", ev.Classification.Scanner.Engine)


### PR DESCRIPTION
Closes #209. Parent contract: #142 (owns the full status × type × machine-code table; this is the concrete field-reported slice).

## The bug

Request-side fail-closed blocks returned `type: invalid_request_error` for everything — telling an OpenAI-SDK client that a **502 scanner outage** means its request is malformed and retrying is pointless (exactly the wrong signal), and leaving it unable to branch on error type the way the response path already allows.

## The fix

The four request-side block sites now carry machine-code prefixes, which the existing `normalizeGatewayError` prefix convention lifts into the provider-native `error.type` on both wire families (OpenAI-shape and Anthropic):

| Block | Status | Type |
|---|---|---|
| PII scanner unavailable (fail-closed) | 502 | `scanner_unavailable` |
| PII redaction failed (fail-closed) | 502 | `scanner_unavailable` |
| Redaction could not be verified (fail-closed) | 502 | `scanner_unavailable` |
| Request contains PII that is not allowed | 400 | `pii_policy_violation` |
| Recognized PII remains after redaction | 400 | `pii_policy_violation` |

Consistent with the response path's `scanner_unavailable`. Message text is byte-identical after the prefix (every existing `Contains` assertion passes unchanged); statuses and evidence reasons were already truthful and are untouched.

**Deliberately left**: the redacted-payload re-parse edge (400, "unable to verify redacted payload") keeps the generic fallback — it is neither a scanner outage nor a policy violation, and inventing a third code belongs to #142's contract table, not this fix.

## Proof

- `TestExternalScannerFailClosed_EnforceBlocksRequest` now asserts `error.type == "scanner_unavailable"` on the 502 block
- `TestGatewayResidualPIIApprovalCannotBypass` now asserts `error.type == "pii_policy_violation"` on the residual block

## Test surface

`go test ./...` clean · `go test -tags integration ./tests/integration/` clean (72s) · `golangci-lint run ./internal/...` 0 issues.