### PR TITLE
fix(mcp): JSON-RPC notifications get 202/no body on both endpoints (#363)

### DIFF
--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -234,11 +234,14 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// MCP lifecycle (#367): initialize is answered LOCALLY — tools capability
-	// only, never forwarded upstream (nothing ungoverned moves) — and
-	// notifications/initialized is accepted with 202/no body, so
-	// spec-conformant clients (Copilot CLI, Claude Code, MCP Inspector,
-	// SDKs) can complete the mandatory handshake against the proxy.
-	if req.Method == "notifications/initialized" {
+	// only, never forwarded upstream (nothing ungoverned moves). Generalized
+	// to every notification (#363): an id-less JSON-RPC message MUST NOT
+	// receive a response body (spec §4.1) — acknowledge with 202 and drop,
+	// instead of routing it into the method-allowlist rejection arm where it
+	// used to earn a -32601 body with "id": null. Nothing is forwarded
+	// upstream: the streamable-HTTP session handshake is unsupported here by
+	// design (#356 mapping), so there is no session to relay state into.
+	if isNotification(&req) {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}

--- a/internal/mcp/proxy_attribution_test.go
+++ b/internal/mcp/proxy_attribution_test.go
@@ -677,6 +677,43 @@ func TestNativeMCPHandshake(t *testing.T) {
 	assert.Empty(t, rec.Body.String())
 }
 
+// TestNotificationsGetNoResponse pins #363 on BOTH endpoints: any JSON-RPC
+// message without an id is a notification and MUST NOT receive a response
+// body — previously only notifications/initialized was handled, and e.g.
+// notifications/cancelled earned a -32601 body with "id": null, which a
+// spec-conformant SDK treats as a protocol error. A request WITH an id and
+// an unknown method keeps its -32601 response, id echoed.
+func TestNotificationsGetNoResponse(t *testing.T) {
+	hit := false
+	up := attribUpstream(t, &hit)
+	proxy, _ := attribHandler(t, policy.ProxyModeIntercept, up.URL, nil)
+	native := &Handler{}
+
+	for name, h := range map[string]http.Handler{"proxy": proxy, "native": native} {
+		for _, method := range []string{"notifications/cancelled", "notifications/progress", "totally/unknown"} {
+			body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "method": method})
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusAccepted, rec.Code, "%s: id-less %s must be accepted", name, method)
+			assert.Empty(t, rec.Body.String(), "%s: notifications get NO response body (%s)", name, method)
+		}
+		assert.False(t, hit, "%s: notifications are never forwarded upstream", name)
+
+		// The same unknown method WITH an id is a request — it keeps its
+		// -32601 response with the id echoed.
+		body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "id": 7, "method": "totally/unknown"})
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		var resp jsonrpcResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp), name)
+		require.NotNil(t, resp.Error, "%s: an id-carrying unknown method stays a proper JSON-RPC error", name)
+		assert.Equal(t, codeMethodNotFound, resp.Error.Code, name)
+		assert.Equal(t, float64(7), resp.ID, "%s: the request id is echoed", name)
+	}
+}
+
 // TestProxyDenialCodes pins #369 on the two most load-bearing denials:
 // integrators key on error.data.talon_code, never on prose.
 func TestProxyDenialCodes(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,6 +35,14 @@ type jsonrpcRequest struct {
 	ID      interface{}     `json:"id"`
 }
 
+// isNotification reports whether a decoded JSON-RPC message carries no id —
+// a notification, which per JSON-RPC 2.0 §4.1 (and the MCP streamable-HTTP
+// transport) MUST NOT receive a response. Shared by both `/mcp` and
+// `/mcp/proxy` ServeHTTPs (#363) so the two endpoints cannot drift. An
+// explicit `"id": null` is treated the same as an absent id — the spec
+// discourages null ids precisely because they are indistinguishable here.
+func isNotification(req *jsonrpcRequest) bool { return req.ID == nil }
+
 type jsonrpcResponse struct {
 	JSONRPC string      `json:"jsonrpc"`
 	Result  interface{} `json:"result,omitempty"`
@@ -105,10 +113,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// MCP lifecycle (#367): initialize is answered locally (tools capability
-	// only) and notifications/initialized is accepted with 202/no body —
-	// spec-conformant clients can now complete the mandatory handshake.
-	if req.Method == "notifications/initialized" {
+	// MCP lifecycle (#367) generalized to every notification (#363): a
+	// JSON-RPC message without an id MUST NOT receive a response body (spec
+	// §4.1; MCP streamable-HTTP transport) — acknowledge with 202 and drop.
+	// Previously only notifications/initialized was handled; any other
+	// notification got a -32601 body with "id": null, which a conformant SDK
+	// treats as a protocol error.
+	if isNotification(&req) {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}


### PR DESCRIPTION
Closes #363.

## The deviation

JSON-RPC 2.0 notifications (no `id`) must not receive a response. Only `notifications/initialized` was handled (#367's 202 arm); every other notification — `notifications/cancelled`, `notifications/progress`, anything an SDK emits — fell through to method dispatch and got a `-32601` body with `"id": null` (on the proxy via the #356 allowlist rejection arm). Spec-conformant MCP SDK clients treat that unexpected response as a protocol error.

## The fix

One shared `isNotification` check (id absent or explicitly null — indistinguishable after decode, which is exactly why the spec discourages null ids) generalizes the #367 special case: **202 Accepted, no body, message dropped**, on both `/mcp` and `/mcp/proxy`. Placed at the same position each handler's `notifications/initialized` arm occupied, so proxy attribution-header hygiene ordering is unchanged. Nothing is forwarded upstream — the streamable-HTTP session handshake remains unsupported by design (#356 mapping).

Requests **with** an id keep full JSON-RPC semantics: an unknown method still gets its `-32601` with the id echoed.

## Proof

`TestNotificationsGetNoResponse` — three notification methods × both endpoints → 202/empty, never forwarded; id-carrying unknown method → proper `-32601` with id echoed. Existing #367 handshake tests pass unchanged through the general path.

## Test surface

`go test ./...` clean · `go test -tags integration ./tests/integration/` clean, uncached (73s) · `golangci-lint run ./internal/...` 0 issues.