### PR TITLE
fix(lint): SA5011 flow clarity in cache nullable-fields test

### DIFF
--- a/internal/cache/store_test.go
+++ b/internal/cache/store_test.go
@@ -58,16 +58,16 @@ func TestLookupAndGetByIDWithNullableColumns(t *testing.T) {
 	}
 
 	got, err := store.GetByID(ctx, entry.ID)
-	if err != nil {
+	// Ordered switch: each case's deref is guarded by the nil case before it —
+	// keeps the flow obvious to SA5011 across staticcheck versions.
+	switch {
+	case err != nil:
 		t.Fatalf("GetByID() error = %v", err)
-	}
-	if got == nil {
+	case got == nil:
 		t.Fatalf("GetByID() returned nil entry")
-	}
-	if got.UserID != "" {
+	case got.UserID != "":
 		t.Fatalf("GetByID() user_id mismatch: got %q want empty", got.UserID)
-	}
-	if got.LastAccessed != nil {
+	case got.LastAccessed != nil:
 		t.Fatalf("GetByID() last_accessed mismatch: got non-nil, want nil")
 	}
 }


### PR DESCRIPTION
Unblocks the v1.9.4 release PR (#416): a fresh golangci-lint release (CI pins `version=latest`, per the known trap) began flagging `internal/cache/store_test.go`'s GetByID nil-check-then-deref sequence as SA5011 on the otherwise-green tree — the Lint job failed on a changelog-only PR.

Restructured into one ordered `switch` where every dereferencing case is guarded by the nil case before it — explicit to any staticcheck version, test behavior unchanged. Cache suite green locally.