### PR TITLE
fix: session-show failure line dedup + drift-proof ollama smoke (#415, #411)

### DIFF
--- a/internal/classifier/adapter/llm/smoke_ollama_test.go
+++ b/internal/classifier/adapter/llm/smoke_ollama_test.go
@@ -46,15 +46,21 @@ func TestOllamaSmoke(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, cls.HasPII, "a real model should find the email address")
 
-	foundEmail := false
+	// Assert the ADAPTER contract, not the tiny model's taxonomy (#411):
+	// llama3.2:1b has drifted between labeling this fixture "email" and
+	// "national_id", and the label is the model's judgment call. What this
+	// lane must prove is pipeline behavior — an entity COVERS the address
+	// with byte-exact relocated offsets, redaction removes it, and the
+	// verify re-scan passes.
+	foundAddress := false
 	for _, e := range cls.Entities {
 		assert.Equal(t, e.Value, text[e.Position:e.Position+len(e.Value)],
 			"relocated offsets must be byte-exact regardless of model behavior")
-		if e.Type == "email" && strings.Contains(e.Value, "kai.nova@example.com") {
-			foundEmail = true
+		if strings.Contains(e.Value, "kai.nova@example.com") {
+			foundAddress = true
 		}
 	}
-	assert.True(t, foundEmail, "expected an email entity, got %+v", cls.Entities)
+	assert.True(t, foundAddress, "expected an entity covering the email address (any type), got %+v", cls.Entities)
 
 	redacted, err := a.RedactText(ctx, text)
 	require.NoError(t, err)

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -510,8 +510,13 @@ func renderSessionSummaryBody(w io.Writer, sum evidence.SessionSummary) {
 	renderSessionToolCalls(w, sum)
 	if sum.LastFailure != nil {
 		fmt.Fprintf(w, "  Failure:   [%s] %s", sum.LastFailure.At.Format(time.RFC3339), sum.LastFailure.Code)
-		if sum.LastFailure.Detail != "" && sum.LastFailure.Detail != sum.LastFailure.Code {
-			fmt.Fprintf(w, ": %s", sum.LastFailure.Detail)
+		// Gateway deny reasons carry the machine-code prefix by convention;
+		// the code is already printed, so strip it from the detail rather
+		// than printing "code: code: detail" (#415). Renderer-side only —
+		// --json keeps the raw reason, and the shared summary is not mutated.
+		detail := strings.TrimSpace(strings.TrimPrefix(sum.LastFailure.Detail, sum.LastFailure.Code+":"))
+		if detail != "" && detail != sum.LastFailure.Code {
+			fmt.Fprintf(w, ": %s", detail)
 		}
 		fmt.Fprintln(w)
 	}

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -147,6 +147,27 @@ func TestSessionShow_OperationalSummary(t *testing.T) {
 	}
 }
 
+// #415: gateway deny reasons carry the machine-code prefix, and the Failure
+// line already prints the code — the renderer must not print it twice.
+func TestRenderSessionSummary_FailureLineNoDoubledCode(t *testing.T) {
+	var buf bytes.Buffer
+	renderSessionSummary(&buf, evidence.SessionSummary{
+		SessionID:   "s",
+		RecordCount: 1,
+		Requests:    1,
+		Denied:      1,
+		LastFailure: &evidence.SessionFailure{
+			At:     time.Date(2026, 7, 29, 13, 56, 50, 0, time.UTC),
+			Code:   "session_budget_exceeded",
+			Detail: "session_budget_exceeded: session spend 0.0018 + estimate 0.0004 exceeds limit 0.002",
+		},
+	})
+	out := buf.String()
+	assert.Contains(t, out, "session_budget_exceeded: session spend 0.0018")
+	assert.NotContains(t, out, "session_budget_exceeded: session_budget_exceeded",
+		"the machine code must not print twice (#415)")
+}
+
 // --json must be the same structure the dashboard drill-down serves: the
 // summary equals evidence.BuildSessionSummary over the session's records
 // (shared code path — the parity contract of #271).


### PR DESCRIPTION
Two release-walkthrough follow-ups. Closes #415, closes #411.

**#415** — `talon session show`'s Failure line printed `session_budget_exceeded: session_budget_exceeded: …` because gateway deny reasons carry the machine-code prefix by convention and the renderer printed the code and the raw reason. The renderer now strips a leading `code:` from the detail — renderer-side only (`--json` keeps the raw reason; the shared summary struct is not mutated). Regression: `TestRenderSessionSummary_FailureLineNoDoubledCode`.

**#411** — the nightly scanner-ollama lane went red because `TestOllamaSmoke` asserted the tiny model's *taxonomy* (`email`), and llama3.2:1b drifted to labeling the fixture `national_id` — with the pipeline actually healthy (offsets, redaction, verify all passing). The test now asserts the adapter contract: an entity **covering the address** with byte-exact relocated offsets, redaction removing it, and the verify re-scan passing — immune to model-label drift. Validates on tonight's nightly (the lane needs a live Ollama; local run compiles + skips).

`go test ./...` clean · lint 0 issues.