### PR TITLE
chore(release): cut v1.10.0 — reliability-contract release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ For user-facing entries, include:
 - any upgrade/migration impact,
 - at least one share artifact reference (screenshot, GIF, or snippet) when applicable.
 
+## [1.10.0] - 2026-07-30
+
+Reliability-contract release: the reliability pillar's runtime contract is complete — same-provider retries with backoff before policy-valid fallback (#139), and a published, test-pinned gateway error contract giving every denial a stable machine code on both wire families (#142, #195; parent epic #113's runtime scope closes with this). Docs gain the verified Copilot CLI case study; carried fixes: #415 (session-show failure line) and #411 (drift-proof ollama smoke). Cross-pillar residuals stay tracked: read-only dashboard (#143), session terminal states (#401).
+
 ### Documentation
 
 - **Copilot CLI case study** (`docs/explanation/copilot-cli-case-study.md`): the full verified experiment behind the governance guide — one unmodified GitHub Copilot CLI session governed across both planes, what the one signed session record answers (use case, model, data handling, actions, cost, verifiability), the bounded-actions claims made honestly (preventive tool-surface scoping vs runtime denial, each with its own test), and the explicit non-interception boundary. Cost figures reflect the corrected #399 pricing.
@@ -816,7 +820,8 @@ Fleet Operations v1 (#265 milestone): discover, inspect, stop, and safely reconf
 - EU AI Act: risk management, transparency, human oversight (Art. 9, 13, 14).
 - Data residency: tier-based EU model routing.
 
-[Unreleased]: https://github.com/dativo-io/talon/compare/v1.9.4...HEAD
+[Unreleased]: https://github.com/dativo-io/talon/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/dativo-io/talon/compare/v1.9.4...v1.10.0
 [1.9.4]: https://github.com/dativo-io/talon/compare/v1.9.3...v1.9.4
 [1.9.3]: https://github.com/dativo-io/talon/compare/v1.9.2...v1.9.3
 [1.9.2]: https://github.com/dativo-io/talon/compare/v1.9.1...v1.9.2


### PR DESCRIPTION
Promotes the merged v1.10.0 work to the changelog. No code changes.

## Shipped (7 issues, 4 PRs)

| Area | Issues | PRs |
|---|---|---|
| Same-provider retries with backoff → policy-valid fallback (default off, evidence-visible) | #139 | #419 |
| Gateway error contract: stable machine codes for every denial + published table (`docs/reference/error-contract.md`) | #142, #195 | #421 |
| Copilot CLI case study in docs | — | #420 |
| Session-show failure-line dedup; drift-proof ollama smoke | #415, #411 | #418 |

MINOR bump per the repo's declared SemVer practice: #139 and #142 are features. The reliability pillar's **runtime contract** is complete with this cut (epic #113 retains only the cross-pillar dashboard #143).

## Live release-gate walkthrough (all passed, 2026-07-30)

Run against the release-branch binary: real `talon serve --gateway`, flaky mock upstream (odd calls 503), `organization_policy.defaults.retry {max_attempts: 2}`:

1. **Retry (#139):** request against the flaky upstream → **HTTP 200 on the same provider** (503 first attempt retried); the failed attempt is a signed `gateway_failover_attempt` record with role `failed_attempt` (ordinal 0 correctly omitted per spec — 0/absent = first attempt). Session summary shows `Reliability: failed attempts 2` across the run's two flaky calls.
2. **`model_not_allowed` (#142):** `gpt-4o` against a `gpt-4o-mini`-only provider → 403 `{"type":"model_not_allowed","code":"model_not_allowed"}`.
3. **`invalid_agent_key` (#142):** wrong bearer → 401 `{"type":"invalid_agent_key","code":"invalid_agent_key"}`.
4. **#415:** session-cap deny → `talon session show` Failure line prints the machine code once: `session_budget_exceeded: session spend 0.0018 + estimate 0.0004 exceeds limit 0.002`.
5. **Signatures:** `talon audit verify --session` → 5 records, 5 valid, 0 invalid.

Not exercised live: #411 (needs the nightly's live Ollama — the assertion change is test-only and compiles/skips locally).

## Release-blocker status

- Security/govulncheck: green (zero reachable since #413; deps unchanged since)
- main CI green on the base commit; evidence spec current (1.9 covers `cost_budget` and `failover.retry`)

After merge: tag `v1.10.0` → goreleaser (linux+docker) + darwin jobs publish.